### PR TITLE
Add SSE transport support for init --from-mcp

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -49,6 +49,7 @@ export interface InitFromMcpOptions {
   authEnv?: string
   grouping?: string
   hooks?: string
+  transport?: string
   jsonOutput: boolean
 }
 
@@ -335,6 +336,7 @@ export function parseInitFromMcpOptions(rawArgs: string[], initialName?: string,
     authEnv: read('--auth-env'),
     grouping: read('--grouping'),
     hooks: read('--hooks'),
+    transport: read('--transport'),
     jsonOutput: rawArgs.includes('--json'),
   }
 }
@@ -529,7 +531,7 @@ async function runInitFromMcp(initialName?: string, initialSource?: string) {
       throw new Error('Provide an MCP server URL or local command. Example: pluxx init --from-mcp https://example.com/mcp')
     }
 
-    let source = parseMcpSourceInput(rawSource)
+    let source = parseMcpSourceInput(rawSource, options.transport)
 
     let introspection
     try {
@@ -779,6 +781,7 @@ Examples:
   pluxx init --from-mcp https://example.com/mcp  Scaffold from a remote MCP server
   pluxx init --from-mcp "npx -y @acme/mcp"       Scaffold from a local MCP command
   pluxx init --from-mcp https://example.com/mcp --yes --name acme --display-name "Acme" --author "Acme" --targets claude-code,codex --grouping workflow --hooks safe --json
+  pluxx init --from-mcp https://example.com/sse --transport sse   Scaffold from an SSE-transport MCP server
   pluxx sync                              Refresh a scaffold using .pluxx/mcp.json metadata
   pluxx sync --from-mcp https://example.com/mcp  Refresh using an explicit MCP source override
   pluxx install                           Install to all configured targets

--- a/src/cli/init-from-mcp.ts
+++ b/src/cli/init-from-mcp.ts
@@ -141,10 +141,15 @@ export function parseMcpSourceInput(input: string, transportOverride?: string): 
     throw new Error('Expected an MCP server URL or a local command.')
   }
 
+  if (transportOverride && transportOverride !== 'http' && transportOverride !== 'sse') {
+    throw new Error('Transport must be one of: http, sse')
+  }
+
   try {
     const url = new URL(value)
     if (url.protocol === 'http:' || url.protocol === 'https:') {
-      const transport = transportOverride === 'sse' || (!transportOverride && url.pathname.endsWith('/sse'))
+      const normalizedPath = url.pathname.replace(/\/+$/, '')
+      const transport = transportOverride === 'sse' || (!transportOverride && normalizedPath.endsWith('/sse'))
         ? 'sse' as const
         : 'http' as const
       return {

--- a/src/cli/init-from-mcp.ts
+++ b/src/cli/init-from-mcp.ts
@@ -135,7 +135,7 @@ const WORKFLOW_SKILL_DEFINITIONS = [
   },
 ] as const
 
-export function parseMcpSourceInput(input: string): McpServer {
+export function parseMcpSourceInput(input: string, transportOverride?: string): McpServer {
   const value = input.trim()
   if (!value) {
     throw new Error('Expected an MCP server URL or a local command.')
@@ -144,8 +144,11 @@ export function parseMcpSourceInput(input: string): McpServer {
   try {
     const url = new URL(value)
     if (url.protocol === 'http:' || url.protocol === 'https:') {
+      const transport = transportOverride === 'sse' || (!transportOverride && url.pathname.endsWith('/sse'))
+        ? 'sse' as const
+        : 'http' as const
       return {
-        transport: 'http',
+        transport,
         url: url.toString(),
       }
     }

--- a/src/mcp/introspect.ts
+++ b/src/mcp/introspect.ts
@@ -86,10 +86,35 @@ interface McpClient {
 }
 
 export async function introspectMcpServer(server: McpServer): Promise<IntrospectedMcpServer> {
-  const client = server.transport === 'stdio'
-    ? await createStdioClient(server)
-    : createHttpClient(server)
+  if (server.transport === 'stdio') {
+    const client = await createStdioClient(server)
+    return await introspectWithClient(client)
+  }
 
+  if (server.transport === 'sse') {
+    const client = await createSseClient(server)
+    return await introspectWithClient(client)
+  }
+
+  try {
+    return await introspectWithClient(createHttpClient(server))
+  } catch (error) {
+    if (
+      error instanceof McpIntrospectionError
+      && (error.status === 400 || error.status === 404 || error.status === 405)
+    ) {
+      const sseClient = await createSseClient({
+        ...server,
+        transport: 'sse',
+      })
+      return await introspectWithClient(sseClient)
+    }
+
+    throw error
+  }
+}
+
+async function introspectWithClient(client: McpClient): Promise<IntrospectedMcpServer> {
   try {
     const initialize = await client.request<InitializeResult>('initialize', {
       protocolVersion: MCP_PROTOCOL_VERSION,
@@ -198,6 +223,287 @@ function createHttpClient(server: Exclude<McpServer, { transport: 'stdio' }>): M
       } catch {
         // Session cleanup is best effort only.
       }
+    },
+  }
+}
+
+async function createSseClient(server: Extract<McpServer, { transport: 'sse' }>): Promise<McpClient> {
+  let sessionId: string | null = null
+  let endpointUrl: string | null = null
+  let isClosed = false
+  const pending = new Map<number, {
+    resolve: (value: unknown) => void
+    reject: (error: Error) => void
+    timeout: ReturnType<typeof setTimeout>
+  }>()
+  const abortController = new AbortController()
+  let resolveEndpoint!: (value: string) => void
+  let rejectEndpoint!: (error: Error) => void
+  let endpointSettled = false
+
+  const endpointReady = new Promise<string>((resolve, reject) => {
+    resolveEndpoint = (value) => {
+      endpointSettled = true
+      resolve(value)
+    }
+    rejectEndpoint = (error) => {
+      endpointSettled = true
+      reject(error)
+    }
+  })
+
+  const streamPromise = (async () => {
+    const response = await fetch(server.url, {
+      method: 'GET',
+      headers: buildSseStreamHeaders(server.auth, sessionId),
+      signal: abortController.signal,
+    })
+
+    if (!response.ok) {
+      throw new McpIntrospectionError(
+        `MCP SSE stream failed with ${response.status} ${response.statusText}.`,
+        response.status,
+      )
+    }
+
+    const contentType = response.headers.get('content-type') ?? ''
+    if (!contentType.includes('text/event-stream')) {
+      throw new McpIntrospectionError(`Unsupported MCP SSE response content type: ${contentType || 'unknown'}.`)
+    }
+
+    sessionId = response.headers.get('Mcp-Session-Id') ?? sessionId
+
+    if (!response.body) {
+      throw new McpIntrospectionError('MCP SSE stream opened without a readable response body.')
+    }
+
+    const reader = response.body.getReader()
+    const decoder = new TextDecoder()
+    let buffer = ''
+    let eventName = 'message'
+    let dataLines: string[] = []
+
+    const flushEvent = () => {
+      if (dataLines.length === 0) {
+        eventName = 'message'
+        return
+      }
+
+      const data = dataLines.join('\n').trim()
+      dataLines = []
+      const currentEvent = eventName || 'message'
+      eventName = 'message'
+
+      if (!data) {
+        return
+      }
+
+      if (currentEvent === 'endpoint') {
+        endpointUrl = new URL(data, server.url).toString()
+        if (!endpointSettled) {
+          resolveEndpoint(endpointUrl)
+        }
+        return
+      }
+
+      if (currentEvent !== 'message') {
+        return
+      }
+
+      const envelope = JSON.parse(data) as JsonRpcEnvelope<unknown>
+      if (typeof envelope !== 'object' || envelope === null || !('id' in envelope)) {
+        return
+      }
+
+      const requestId = typeof envelope.id === 'number' ? envelope.id : Number.NaN
+      if (!Number.isFinite(requestId)) return
+
+      const entry = pending.get(requestId)
+      if (!entry) return
+
+      pending.delete(requestId)
+      clearTimeout(entry.timeout)
+
+      try {
+        entry.resolve(unwrapEnvelope(envelope))
+      } catch (error) {
+        entry.reject(error instanceof Error ? error : new Error(String(error)))
+      }
+    }
+
+    while (true) {
+      const { value, done } = await reader.read()
+      if (done) break
+
+      buffer += decoder.decode(value, { stream: true })
+      const lines = buffer.split(/\r?\n/)
+      buffer = lines.pop() ?? ''
+
+      for (const line of lines) {
+        if (line === '') {
+          flushEvent()
+          continue
+        }
+
+        if (line.startsWith(':')) {
+          continue
+        }
+
+        const separatorIndex = line.indexOf(':')
+        const field = separatorIndex === -1 ? line : line.slice(0, separatorIndex)
+        const rawValue = separatorIndex === -1 ? '' : line.slice(separatorIndex + 1).trimStart()
+
+        if (field === 'event') {
+          eventName = rawValue || 'message'
+        } else if (field === 'data') {
+          dataLines.push(rawValue)
+        }
+      }
+    }
+
+    if (buffer) {
+      const tailLines = buffer.split(/\r?\n/)
+      for (const line of tailLines) {
+        if (line.startsWith('data:')) {
+          dataLines.push(line.slice(5).trimStart())
+        }
+      }
+    }
+    flushEvent()
+
+    if (!endpointSettled) {
+      rejectEndpoint(new McpIntrospectionError('MCP SSE stream did not provide the required endpoint event.'))
+      return
+    }
+
+    if (!isClosed && pending.size > 0) {
+      const error = new McpIntrospectionError('MCP SSE stream ended before pluxx finished introspecting it.')
+      for (const entry of pending.values()) {
+        clearTimeout(entry.timeout)
+        entry.reject(error)
+      }
+      pending.clear()
+    }
+  })().catch((error) => {
+    if (isClosed && error instanceof DOMException && error.name === 'AbortError') {
+      return
+    }
+
+    const wrapped = error instanceof Error
+      ? error
+      : new McpIntrospectionError(String(error))
+
+    if (!endpointSettled) {
+      rejectEndpoint(wrapped)
+    }
+
+    for (const entry of pending.values()) {
+      clearTimeout(entry.timeout)
+      entry.reject(wrapped)
+    }
+    pending.clear()
+  })
+
+  await endpointReady
+
+  return {
+    async request<T>(method: string, params?: Record<string, unknown>): Promise<T> {
+      const requestId = nextRequestId()
+      const endpoint = endpointUrl ?? await endpointReady
+
+      const resultPromise = new Promise<T>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          pending.delete(requestId)
+          reject(new McpIntrospectionError(`Timed out waiting for MCP SSE response to ${method}.`))
+        }, DEFAULT_TIMEOUT_MS)
+
+        pending.set(requestId, {
+          resolve: (value) => {
+            clearTimeout(timeout)
+            resolve(value as T)
+          },
+          reject: (error) => {
+            clearTimeout(timeout)
+            reject(error)
+          },
+          timeout,
+        })
+      })
+
+      let response: Response
+      try {
+        response = await fetch(endpoint, {
+          method: 'POST',
+          headers: buildHttpHeaders(server.auth, sessionId),
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: requestId,
+            method,
+            ...(params ? { params } : {}),
+          }),
+        })
+      } catch (error) {
+        const entry = pending.get(requestId)
+        if (entry) {
+          pending.delete(requestId)
+          clearTimeout(entry.timeout)
+        }
+        throw new McpIntrospectionError(`MCP SSE request failed: ${error instanceof Error ? error.message : String(error)}`)
+      }
+
+      if (!response.ok && response.status !== 202) {
+        const entry = pending.get(requestId)
+        if (entry) {
+          pending.delete(requestId)
+          clearTimeout(entry.timeout)
+        }
+        throw new McpIntrospectionError(
+          `MCP SSE request failed with ${response.status} ${response.statusText}.`,
+          response.status,
+        )
+      }
+
+      sessionId = response.headers.get('Mcp-Session-Id') ?? sessionId
+      const contentType = response.headers.get('content-type') ?? ''
+      if (contentType.includes('application/json') || contentType.includes('text/event-stream')) {
+        const entry = pending.get(requestId)
+        if (entry) {
+          pending.delete(requestId)
+          clearTimeout(entry.timeout)
+        }
+        const envelope = await parseHttpEnvelope<T>(response, requestId)
+        return unwrapEnvelope(envelope)
+      }
+
+      return await resultPromise
+    },
+
+    async notify(method: string, params?: Record<string, unknown>): Promise<void> {
+      const endpoint = endpointUrl ?? await endpointReady
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: buildHttpHeaders(server.auth, sessionId),
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          method,
+          ...(params ? { params } : {}),
+        }),
+      })
+
+      if (!response.ok && response.status !== 202) {
+        throw new McpIntrospectionError(
+          `MCP SSE notification failed with ${response.status} ${response.statusText}.`,
+          response.status,
+        )
+      }
+
+      sessionId = response.headers.get('Mcp-Session-Id') ?? sessionId
+    },
+
+    async close(): Promise<void> {
+      isClosed = true
+      abortController.abort()
+      await streamPromise
     },
   }
 }
@@ -316,6 +622,24 @@ function buildHttpHeaders(auth: McpAuth | undefined, sessionId: string | null): 
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
     Accept: 'application/json, text/event-stream',
+    'Mcp-Protocol-Version': MCP_PROTOCOL_VERSION,
+  }
+
+  if (sessionId) {
+    headers['Mcp-Session-Id'] = sessionId
+  }
+
+  const authHeader = resolveAuthHeader(auth)
+  if (authHeader) {
+    headers[authHeader.name] = authHeader.value
+  }
+
+  return headers
+}
+
+function buildSseStreamHeaders(auth: McpAuth | undefined, sessionId: string | null): HeadersInit {
+  const headers: Record<string, string> = {
+    Accept: 'text/event-stream',
     'Mcp-Protocol-Version': MCP_PROTOCOL_VERSION,
   }
 

--- a/tests/cli-init.test.ts
+++ b/tests/cli-init.test.ts
@@ -43,6 +43,35 @@ describe('CLI init option parsing', () => {
     })
   })
 
+  it('parses --transport flag for SSE transport override', () => {
+    const options = parseInitFromMcpOptions(
+      [
+        'init',
+        '--from-mcp',
+        'https://example.com/mcp',
+        '--transport',
+        'sse',
+        '--yes',
+      ],
+      undefined,
+      'https://example.com/mcp',
+    )
+
+    expect(options.transport).toBe('sse')
+    expect(options.source).toBe('https://example.com/mcp')
+    expect(options.assumeDefaults).toBe(true)
+  })
+
+  it('leaves transport undefined when --transport is not provided', () => {
+    const options = parseInitFromMcpOptions(
+      ['init', '--from-mcp', 'https://example.com/mcp'],
+      undefined,
+      'https://example.com/mcp',
+    )
+
+    expect(options.transport).toBeUndefined()
+  })
+
   it('lets the positional name seed the MCP scaffold flow', () => {
     const options = parseInitFromMcpOptions(
       ['init', 'sumble', '--from-mcp', 'npx -y @sumble/mcp'],

--- a/tests/init-from-mcp.test.ts
+++ b/tests/init-from-mcp.test.ts
@@ -88,6 +88,35 @@ describe('init-from-mcp scaffold', () => {
     })
   })
 
+  it('parses URL with explicit SSE transport override', () => {
+    expect(parseMcpSourceInput('https://mcp.example.com/v1', 'sse')).toEqual({
+      transport: 'sse',
+      url: 'https://mcp.example.com/v1',
+    })
+  })
+
+  it('auto-detects SSE transport when URL path ends with /sse', () => {
+    expect(parseMcpSourceInput('https://mcp.example.com/sse')).toEqual({
+      transport: 'sse',
+      url: 'https://mcp.example.com/sse',
+    })
+  })
+
+  it('defaults to http transport when URL path does not end with /sse', () => {
+    expect(parseMcpSourceInput('https://mcp.example.com/mcp')).toEqual({
+      transport: 'http',
+      url: 'https://mcp.example.com/mcp',
+    })
+  })
+
+  it('ignores transport override for stdio commands', () => {
+    expect(parseMcpSourceInput('npx -y @acme/mcp', 'sse')).toEqual({
+      transport: 'stdio',
+      command: 'npx',
+      args: ['-y', '@acme/mcp'],
+    })
+  })
+
   it('derives a stable plugin name from MCP metadata', () => {
     expect(derivePluginName(introspection, { transport: 'http', url: 'https://mcp.sumble.com/' })).toBe('sumble')
   })

--- a/tests/init-from-mcp.test.ts
+++ b/tests/init-from-mcp.test.ts
@@ -102,11 +102,29 @@ describe('init-from-mcp scaffold', () => {
     })
   })
 
+  it('auto-detects SSE transport for trailing-slash SSE paths', () => {
+    expect(parseMcpSourceInput('https://mcp.example.com/sse/')).toEqual({
+      transport: 'sse',
+      url: 'https://mcp.example.com/sse/',
+    })
+
+    expect(parseMcpSourceInput('https://mcp.example.com/v1/sse/')).toEqual({
+      transport: 'sse',
+      url: 'https://mcp.example.com/v1/sse/',
+    })
+  })
+
   it('defaults to http transport when URL path does not end with /sse', () => {
     expect(parseMcpSourceInput('https://mcp.example.com/mcp')).toEqual({
       transport: 'http',
       url: 'https://mcp.example.com/mcp',
     })
+  })
+
+  it('rejects invalid transport overrides', () => {
+    expect(() => parseMcpSourceInput('https://mcp.example.com/v1', 'websocket')).toThrow(
+      'Transport must be one of: http, sse',
+    )
   })
 
   it('ignores transport override for stdio commands', () => {

--- a/tests/mcp-introspect.test.ts
+++ b/tests/mcp-introspect.test.ts
@@ -184,4 +184,190 @@ describe('MCP introspection', () => {
       globalThis.fetch = originalFetch
     }
   })
+
+  it('introspects legacy SSE MCP servers via the advertised endpoint event', async () => {
+    let sawStreamAuthHeader = false
+    let sawPostAuthHeader = false
+    let sawSessionHeader = false
+    const originalFetch = globalThis.fetch
+    const encoder = new TextEncoder()
+    let controller: ReadableStreamDefaultController<Uint8Array> | null = null
+
+    const stream = new ReadableStream<Uint8Array>({
+      start(streamController) {
+        controller = streamController
+        streamController.enqueue(encoder.encode('event: endpoint\ndata: /messages\n\n'))
+      },
+    })
+
+    globalThis.fetch = (async (input, init) => {
+      const request = new Request(input, init)
+
+      if (request.method === 'GET') {
+        sawStreamAuthHeader = request.headers.get('Authorization') === 'Bearer legacy-token'
+        return new Response(stream, {
+          status: 200,
+          headers: {
+            'Content-Type': 'text/event-stream',
+          },
+        })
+      }
+
+      const message = await request.json() as Record<string, unknown>
+
+      if (request.url === 'https://example.com/messages' && message.method === 'initialize') {
+        sawPostAuthHeader = request.headers.get('Authorization') === 'Bearer legacy-token'
+        controller?.enqueue(encoder.encode(`event: message\ndata: ${JSON.stringify({
+          jsonrpc: '2.0',
+          id: message.id,
+          result: {
+            protocolVersion: '2025-03-26',
+            capabilities: { tools: { listChanged: false } },
+            serverInfo: {
+              name: 'legacy-sse',
+              title: 'Legacy SSE',
+            },
+          },
+        })}\n\n`))
+
+        return new Response(null, {
+          status: 202,
+          headers: {
+            'Mcp-Session-Id': 'legacy-session',
+          },
+        })
+      }
+
+      if (request.url === 'https://example.com/messages' && message.method === 'notifications/initialized') {
+        sawSessionHeader = request.headers.get('Mcp-Session-Id') === 'legacy-session'
+        return new Response(null, { status: 202 })
+      }
+
+      if (request.url === 'https://example.com/messages' && message.method === 'tools/list') {
+        sawSessionHeader = sawSessionHeader && request.headers.get('Mcp-Session-Id') === 'legacy-session'
+        controller?.enqueue(encoder.encode(`event: message\ndata: ${JSON.stringify({
+          jsonrpc: '2.0',
+          id: message.id,
+          result: {
+            tools: [{
+              name: 'search_legacy_companies',
+              description: 'Search companies via legacy SSE.',
+            }],
+          },
+        })}\n\n`))
+        controller?.close()
+        return new Response(null, { status: 202 })
+      }
+
+      return new Response('Unhandled', { status: 500 })
+    }) as typeof fetch
+
+    process.env.TEST_LEGACY_SSE_TOKEN = 'legacy-token'
+
+    try {
+      const result = await introspectMcpServer({
+        transport: 'sse',
+        url: 'https://example.com/sse',
+        auth: {
+          type: 'bearer',
+          envVar: 'TEST_LEGACY_SSE_TOKEN',
+        },
+      })
+
+      expect(result.serverInfo.name).toBe('legacy-sse')
+      expect(result.tools.map((tool) => tool.name)).toEqual(['search_legacy_companies'])
+      expect(sawStreamAuthHeader).toBe(true)
+      expect(sawPostAuthHeader).toBe(true)
+      expect(sawSessionHeader).toBe(true)
+    } finally {
+      delete process.env.TEST_LEGACY_SSE_TOKEN
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  it('falls back from HTTP initialize failures to legacy SSE transport', async () => {
+    let attemptedHttpInitialize = false
+    const originalFetch = globalThis.fetch
+    const encoder = new TextEncoder()
+    let controller: ReadableStreamDefaultController<Uint8Array> | null = null
+
+    const stream = new ReadableStream<Uint8Array>({
+      start(streamController) {
+        controller = streamController
+        streamController.enqueue(encoder.encode('event: endpoint\ndata: /messages\n\n'))
+      },
+    })
+
+    globalThis.fetch = (async (input, init) => {
+      const request = new Request(input, init)
+
+      if (request.url === 'https://example.com/legacy' && request.method === 'POST') {
+        const message = await request.json() as Record<string, unknown>
+        if (message.method === 'initialize') {
+          attemptedHttpInitialize = true
+          return new Response('Method Not Allowed', { status: 405, statusText: 'Method Not Allowed' })
+        }
+      }
+
+      if (request.url === 'https://example.com/legacy' && request.method === 'GET') {
+        return new Response(stream, {
+          status: 200,
+          headers: {
+            'Content-Type': 'text/event-stream',
+          },
+        })
+      }
+
+      const message = await request.json() as Record<string, unknown>
+      if (request.url === 'https://example.com/messages' && message.method === 'initialize') {
+        controller?.enqueue(encoder.encode(`event: message\ndata: ${JSON.stringify({
+          jsonrpc: '2.0',
+          id: message.id,
+          result: {
+            protocolVersion: '2025-03-26',
+            capabilities: { tools: { listChanged: false } },
+            serverInfo: {
+              name: 'fallback-legacy',
+              title: 'Fallback Legacy',
+            },
+          },
+        })}\n\n`))
+        return new Response(null, { status: 202 })
+      }
+
+      if (request.url === 'https://example.com/messages' && message.method === 'notifications/initialized') {
+        return new Response(null, { status: 202 })
+      }
+
+      if (request.url === 'https://example.com/messages' && message.method === 'tools/list') {
+        controller?.enqueue(encoder.encode(`event: message\ndata: ${JSON.stringify({
+          jsonrpc: '2.0',
+          id: message.id,
+          result: {
+            tools: [{
+              name: 'search_fallback_companies',
+              description: 'Search companies after HTTP fallback.',
+            }],
+          },
+        })}\n\n`))
+        controller?.close()
+        return new Response(null, { status: 202 })
+      }
+
+      return new Response('Unhandled', { status: 500 })
+    }) as typeof fetch
+
+    try {
+      const result = await introspectMcpServer({
+        transport: 'http',
+        url: 'https://example.com/legacy',
+      })
+
+      expect(attemptedHttpInitialize).toBe(true)
+      expect(result.serverInfo.name).toBe('fallback-legacy')
+      expect(result.tools.map((tool) => tool.name)).toEqual(['search_fallback_companies'])
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
 })


### PR DESCRIPTION
## Summary
- Adds `--transport sse` flag to `pluxx init --from-mcp` for explicit SSE transport selection
- Auto-detects SSE when URL path ends with `/sse`
- Generated config correctly tags `transport: 'sse'` for downstream plugin consumers
- 6 new tests covering SSE override, auto-detect, and flag parsing

## Linear
Closes remaining SSE gap in PLUXX-23.

## Test plan
- [ ] `bun test` passes (6 new tests)
- [ ] `bun run typecheck` clean
- [ ] `pluxx init --from-mcp https://example.com/sse` auto-detects SSE
- [ ] `pluxx init --from-mcp https://example.com/mcp --transport sse` explicitly sets SSE
- [ ] Generated `pluxx.config.ts` has `transport: 'sse'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--transport` CLI option for the `pluxx init` command, allowing users to explicitly specify MCP server transport type (e.g., `--transport sse`).
  * Enhanced transport auto-detection to intelligently select SSE transport based on URL patterns.

* **Tests**
  * Added test coverage for transport option parsing and selection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->