### PR TITLE
Auto-generate mutation confirmation hooks for MCP tools

### DIFF
--- a/src/cli/init-from-mcp.ts
+++ b/src/cli/init-from-mcp.ts
@@ -571,13 +571,13 @@ const MUTATING_PREFIXES = [
   'bulk', 'send', 'post', 'publish',
 ] as const
 
-export function detectMutatingTools(tools: IntrospectedMcpTool[]): string[] {
-  const prefixPattern = new RegExp(`^(${MUTATING_PREFIXES.join('|')})\\b`, 'i')
+const MUTATING_PREFIX_PATTERN = new RegExp(`^(${MUTATING_PREFIXES.join('|')})\\b`, 'i')
 
+export function detectMutatingTools(tools: IntrospectedMcpTool[]): string[] {
   return tools
     .filter((tool) => {
       const normalized = normalizeIdentifier(tool.name).trim().toLowerCase()
-      return prefixPattern.test(normalized)
+      return MUTATING_PREFIX_PATTERN.test(normalized)
     })
     .map((tool) => tool.name)
 }
@@ -609,11 +609,11 @@ function planGeneratedHooks(source: McpServer, tools: IntrospectedMcpTool[], ser
   }
 
   if (mutatingTools.length > 0) {
-    hookEntries.preToolUse = [{
+    hookEntries.preToolUse = mutatingTools.map((toolName) => ({
       type: 'command',
       command: 'bash "${PLUGIN_ROOT}/scripts/confirm-mutation.sh"',
-      matcher: `mcp__${serverName}`,
-    }]
+      matcher: buildMcpToolMatcher(serverName, toolName),
+    }))
     files.push({
       relativePath: 'scripts/confirm-mutation.sh',
       content: buildMutationConfirmationScript(mutatingTools),
@@ -629,7 +629,7 @@ function planGeneratedHooks(source: McpServer, tools: IntrospectedMcpTool[], ser
 }
 
 export function buildMutationConfirmationScript(mutatingTools: string[]): string {
-  const toolList = mutatingTools.join(', ')
+  const toolList = JSON.stringify(mutatingTools.map(sanitizeShellCommentText))
   return `#!/usr/bin/env bash
 set -euo pipefail
 # This hook runs before mutating MCP tools.
@@ -643,12 +643,16 @@ function collectRequiredEnvVars(source: McpServer): string[] {
   const envVars = new Set<string>()
 
   if (source.auth?.type && source.auth.type !== 'none') {
-    envVars.add(source.auth.envVar)
+    if (isValidShellEnvVarName(source.auth.envVar)) {
+      envVars.add(source.auth.envVar)
+    }
   }
 
   if (source.transport === 'stdio') {
     for (const key of Object.keys(source.env ?? {})) {
-      envVars.add(key)
+      if (isValidShellEnvVarName(key)) {
+        envVars.add(key)
+      }
     }
   }
 
@@ -668,6 +672,18 @@ set -euo pipefail
 
 ${checks}
 `
+}
+
+function buildMcpToolMatcher(serverName: string, toolName: string): string {
+  return `mcp__${serverName}__${toolName}`
+}
+
+function sanitizeShellCommentText(value: string): string {
+  return value.replace(/[\u0000-\u001f\u007f\u2028\u2029]/g, ' ').trim()
+}
+
+function isValidShellEnvVarName(value: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(value)
 }
 
 function buildMcpScaffoldMetadata(input: {

--- a/src/cli/init-from-mcp.ts
+++ b/src/cli/init-from-mcp.ts
@@ -182,7 +182,7 @@ export async function writeMcpScaffold(options: McpScaffoldOptions): Promise<Mcp
   const plannedSkills = planSkillScaffolds(options.introspection.tools, options.skillGrouping)
   const skillDirectories: string[] = []
   const generatedFiles = ['pluxx.config.ts', './INSTRUCTIONS.md']
-  const generatedHooks = planGeneratedHooks(options.source, options.hookMode)
+  const generatedHooks = planGeneratedHooks(options.source, options.introspection.tools, serverName, options.hookMode)
   const metadataPath = MCP_SCAFFOLD_METADATA_PATH
 
   await Bun.write(
@@ -564,30 +564,79 @@ function serializeHooks(hooks: Record<string, HookEntry[]>): string {
   return `{\n${entries}\n  }`
 }
 
-function planGeneratedHooks(source: McpServer, hookMode: McpHookMode = 'none'): GeneratedHookScaffold {
+const MUTATING_PREFIXES = [
+  'create', 'add', 'insert',
+  'update', 'edit', 'modify', 'patch',
+  'delete', 'remove', 'destroy', 'drop', 'purge',
+  'bulk', 'send', 'post', 'publish',
+] as const
+
+export function detectMutatingTools(tools: IntrospectedMcpTool[]): string[] {
+  const prefixPattern = new RegExp(`^(${MUTATING_PREFIXES.join('|')})\\b`, 'i')
+
+  return tools
+    .filter((tool) => {
+      const normalized = normalizeIdentifier(tool.name).trim().toLowerCase()
+      return prefixPattern.test(normalized)
+    })
+    .map((tool) => tool.name)
+}
+
+function planGeneratedHooks(source: McpServer, tools: IntrospectedMcpTool[], serverName: string, hookMode: McpHookMode = 'none'): GeneratedHookScaffold {
   if (hookMode !== 'safe') {
     return { mode: 'none', files: [] }
   }
 
   const envVars = collectRequiredEnvVars(source)
-  if (envVars.length === 0) {
+  const mutatingTools = detectMutatingTools(tools)
+
+  if (envVars.length === 0 && mutatingTools.length === 0) {
     return { mode: 'none', files: [] }
+  }
+
+  const hookEntries: Record<string, HookEntry[]> = {}
+  const files: Array<{ relativePath: string; content: string }> = []
+
+  if (envVars.length > 0) {
+    hookEntries.sessionStart = [{
+      type: 'command',
+      command: 'bash "${PLUGIN_ROOT}/scripts/check-env.sh"',
+    }]
+    files.push({
+      relativePath: 'scripts/check-env.sh',
+      content: buildEnvValidationScript(envVars),
+    })
+  }
+
+  if (mutatingTools.length > 0) {
+    hookEntries.preToolUse = [{
+      type: 'command',
+      command: 'bash "${PLUGIN_ROOT}/scripts/confirm-mutation.sh"',
+      matcher: `mcp__${serverName}`,
+    }]
+    files.push({
+      relativePath: 'scripts/confirm-mutation.sh',
+      content: buildMutationConfirmationScript(mutatingTools),
+    })
   }
 
   return {
     mode: 'safe',
     scriptsPath: './scripts/',
-    hookEntries: {
-      sessionStart: [{
-        type: 'command',
-        command: 'bash "${PLUGIN_ROOT}/scripts/check-env.sh"',
-      }],
-    },
-    files: [{
-      relativePath: 'scripts/check-env.sh',
-      content: buildEnvValidationScript(envVars),
-    }],
+    hookEntries,
+    files,
   }
+}
+
+export function buildMutationConfirmationScript(mutatingTools: string[]): string {
+  const toolList = mutatingTools.join(', ')
+  return `#!/usr/bin/env bash
+set -euo pipefail
+# This hook runs before mutating MCP tools.
+# The platform will prompt the user for confirmation.
+# Mutating tools: ${toolList}
+echo "pluxx: This tool modifies data. The agent should confirm before proceeding." >&2
+`
 }
 
 function collectRequiredEnvVars(source: McpServer): string[] {

--- a/tests/init-from-mcp.test.ts
+++ b/tests/init-from-mcp.test.ts
@@ -220,15 +220,76 @@ describe('init-from-mcp scaffold', () => {
     expect(result.generatedHookEvents).toContain('preToolUse')
 
     const confirmScript = readFileSync(resolve(TEST_DIR, 'scripts/confirm-mutation.sh'), 'utf-8')
-    expect(confirmScript).toContain('createIssue')
-    expect(confirmScript).toContain('delete_record')
-    expect(confirmScript).toContain('update-contact')
+    expect(confirmScript).toContain(JSON.stringify([
+      'createIssue',
+      'delete_record',
+      'update-contact',
+    ]))
     expect(confirmScript).toContain('pluxx: This tool modifies data')
 
     const config = readFileSync(resolve(TEST_DIR, 'pluxx.config.ts'), 'utf-8')
     expect(config).toContain('preToolUse')
     expect(config).toContain('confirm-mutation.sh')
-    expect(config).toContain('mcp__sumble')
+    expect(config).toContain('matcher: "mcp__sumble__createIssue"')
+    expect(config).toContain('matcher: "mcp__sumble__delete_record"')
+    expect(config).toContain('matcher: "mcp__sumble__update-contact"')
+    expect(config).not.toContain('matcher: "mcp__sumble"')
+  })
+
+  it('filters invalid shell env names from generated safe hook scripts', async () => {
+    const result = await writeMcpScaffold({
+      rootDir: TEST_DIR,
+      pluginName: 'test-mcp',
+      authorName: 'Test Author',
+      targets: ['claude-code'],
+      source: {
+        transport: 'stdio',
+        command: 'npx',
+        args: ['-y', '@sumble/mcp'],
+        env: {
+          SAFE_KEY: '1',
+          'BAD-NAME\nrm -rf /': '2',
+        },
+        auth: {
+          type: 'bearer',
+          envVar: 'ALSO BAD\nNAME',
+        },
+      },
+      introspection,
+      hookMode: 'safe',
+    })
+
+    expect(result.generatedFiles).toContain('scripts/check-env.sh')
+
+    const envScript = readFileSync(resolve(TEST_DIR, 'scripts/check-env.sh'), 'utf-8')
+    expect(envScript).toContain('SAFE_KEY')
+    expect(envScript).not.toContain('BAD-NAME')
+    expect(envScript).not.toContain('ALSO BAD')
+  })
+
+  it('sanitizes dangerous tool names in generated confirmation scripts', async () => {
+    const dangerousTool = 'createIssue\nrm -rf /'
+    const mutatingIntrospection: IntrospectedMcpServer = {
+      ...introspection,
+      tools: [
+        ...introspection.tools,
+        { name: dangerousTool, description: 'Create an issue.' },
+      ],
+    }
+
+    await writeMcpScaffold({
+      rootDir: TEST_DIR,
+      pluginName: 'test-mcp',
+      authorName: 'Test Author',
+      targets: ['claude-code'],
+      source: { transport: 'http', url: 'https://mcp.example.com/' },
+      introspection: mutatingIntrospection,
+      hookMode: 'safe',
+    })
+
+    const confirmScript = readFileSync(resolve(TEST_DIR, 'scripts/confirm-mutation.sh'), 'utf-8')
+    expect(confirmScript).toContain(JSON.stringify(['createIssue rm -rf /']))
+    expect(confirmScript).not.toContain(dangerousTool)
   })
 })
 

--- a/tests/init-from-mcp.test.ts
+++ b/tests/init-from-mcp.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, beforeEach, afterEach } from 'bun:test'
 import { existsSync, readFileSync, rmSync } from 'fs'
 import { resolve } from 'path'
 import { loadConfig } from '../src/config/load'
-import { derivePluginName, parseMcpSourceInput, planSkillScaffolds, writeMcpScaffold } from '../src/cli/init-from-mcp'
+import { derivePluginName, detectMutatingTools, parseMcpSourceInput, planSkillScaffolds, writeMcpScaffold } from '../src/cli/init-from-mcp'
 import type { IntrospectedMcpServer } from '../src/mcp/introspect'
 
 const TEST_DIR = resolve(import.meta.dir, '.init-from-mcp')
@@ -193,5 +193,95 @@ describe('init-from-mcp scaffold', () => {
     const loadedConfig = await loadConfig(TEST_DIR)
     expect(loadedConfig.name).toBe('sumble')
     expect(loadedConfig.brand?.displayName).toBe('Sumble MCP')
+  })
+
+  it('generates mutation confirmation hooks when safe mode detects mutating tools', async () => {
+    const mutatingIntrospection: IntrospectedMcpServer = {
+      ...introspection,
+      tools: [
+        ...introspection.tools,
+        { name: 'createIssue', description: 'Create a new issue.' },
+        { name: 'delete_record', description: 'Delete a record by ID.' },
+        { name: 'update-contact', description: 'Update an existing contact.' },
+      ],
+    }
+
+    const result = await writeMcpScaffold({
+      rootDir: TEST_DIR,
+      pluginName: 'test-mcp',
+      authorName: 'Test Author',
+      targets: ['claude-code'],
+      source: { transport: 'http', url: 'https://mcp.example.com/' },
+      introspection: mutatingIntrospection,
+      hookMode: 'safe',
+    })
+
+    expect(result.generatedFiles).toContain('scripts/confirm-mutation.sh')
+    expect(result.generatedHookEvents).toContain('preToolUse')
+
+    const confirmScript = readFileSync(resolve(TEST_DIR, 'scripts/confirm-mutation.sh'), 'utf-8')
+    expect(confirmScript).toContain('createIssue')
+    expect(confirmScript).toContain('delete_record')
+    expect(confirmScript).toContain('update-contact')
+    expect(confirmScript).toContain('pluxx: This tool modifies data')
+
+    const config = readFileSync(resolve(TEST_DIR, 'pluxx.config.ts'), 'utf-8')
+    expect(config).toContain('preToolUse')
+    expect(config).toContain('confirm-mutation.sh')
+    expect(config).toContain('mcp__sumble')
+  })
+})
+
+describe('detectMutatingTools', () => {
+  it('detects camelCase mutating tool names', () => {
+    const tools = [
+      { name: 'createIssue', description: 'Create an issue.' },
+      { name: 'getIssue', description: 'Get an issue.' },
+      { name: 'updateRecord', description: 'Update a record.' },
+      { name: 'deleteUser', description: 'Delete a user.' },
+    ]
+    expect(detectMutatingTools(tools)).toEqual(['createIssue', 'updateRecord', 'deleteUser'])
+  })
+
+  it('detects snake_case mutating tool names', () => {
+    const tools = [
+      { name: 'add_contact', description: 'Add a contact.' },
+      { name: 'list_contacts', description: 'List all contacts.' },
+      { name: 'remove_contact', description: 'Remove a contact.' },
+      { name: 'insert_row', description: 'Insert a row.' },
+    ]
+    expect(detectMutatingTools(tools)).toEqual(['add_contact', 'remove_contact', 'insert_row'])
+  })
+
+  it('detects kebab-case mutating tool names', () => {
+    const tools = [
+      { name: 'publish-post', description: 'Publish a post.' },
+      { name: 'read-post', description: 'Read a post.' },
+      { name: 'send-email', description: 'Send an email.' },
+    ]
+    expect(detectMutatingTools(tools)).toEqual(['publish-post', 'send-email'])
+  })
+
+  it('detects bulk and destroy prefixes', () => {
+    const tools = [
+      { name: 'bulk_import', description: 'Bulk import records.' },
+      { name: 'destroy_session', description: 'Destroy a session.' },
+      { name: 'drop_table', description: 'Drop a table.' },
+      { name: 'purge_cache', description: 'Purge cache.' },
+    ]
+    expect(detectMutatingTools(tools)).toEqual(['bulk_import', 'destroy_session', 'drop_table', 'purge_cache'])
+  })
+
+  it('returns empty array when no tools match', () => {
+    const tools = [
+      { name: 'getUser', description: 'Get user.' },
+      { name: 'list_items', description: 'List items.' },
+      { name: 'search-docs', description: 'Search docs.' },
+    ]
+    expect(detectMutatingTools(tools)).toEqual([])
+  })
+
+  it('returns empty array for empty input', () => {
+    expect(detectMutatingTools([])).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary
- Adds `detectMutatingTools()` that identifies create/update/delete-style MCP tools via 16 high-confidence name prefixes
- Extends `planGeneratedHooks` to generate `preToolUse` hooks with MCP server matcher for mutating tools
- Generates `scripts/confirm-mutation.sh` listing the detected mutating tool names
- 7 new tests covering detection across camelCase, snake_case, kebab-case, and full scaffold integration

## Linear
Addresses PLUXX-26 — mutation confirmation defaults beyond env validation.

## Test plan
- [ ] `bun test` passes (7 new tests)
- [ ] `bun run typecheck` clean
- [ ] Scaffold with `--hooks safe` against an MCP server with create/delete tools generates `confirm-mutation.sh`
- [ ] Generated config includes `preToolUse` with correct `matcher` pattern
- [ ] Tools without mutating prefixes are not included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Automatic detection of data-mutating tools with built-in safety confirmation workflow
  - Conditional hook generation that creates environment checks and mutation confirmations only when needed
  - Optimized MCP scaffold generation to reduce unnecessary files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->