### PR TITLE
Polish init wizard with @clack/prompts UX

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,10 +1,10 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "plugahh",
       "dependencies": {
+        "@clack/prompts": "^1.2.0",
         "zod": "^3.24.0",
       },
       "devDependencies": {
@@ -14,11 +14,23 @@
     },
   },
   "packages": {
+    "@clack/core": ["@clack/core@1.2.0", "", { "dependencies": { "fast-wrap-ansi": "^0.1.3", "sisteransi": "^1.0.5" } }, "sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg=="],
+
+    "@clack/prompts": ["@clack/prompts@1.2.0", "", { "dependencies": { "@clack/core": "1.2.0", "fast-string-width": "^1.1.0", "fast-wrap-ansi": "^0.1.3", "sisteransi": "^1.0.5" } }, "sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w=="],
+
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
     "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
+    "fast-string-truncated-width": ["fast-string-truncated-width@1.2.1", "", {}, "sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow=="],
+
+    "fast-string-width": ["fast-string-width@1.1.0", "", { "dependencies": { "fast-string-truncated-width": "^1.2.0" } }, "sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ=="],
+
+    "fast-wrap-ansi": ["fast-wrap-ansi@0.1.6", "", { "dependencies": { "fast-string-width": "^1.1.0" } }, "sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w=="],
+
+    "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "typescript": "^5.7.0"
   },
   "dependencies": {
+    "@clack/prompts": "^1.2.0",
     "zod": "^3.24.0"
   }
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -17,7 +17,7 @@ import {
 import { migrate } from './migrate'
 import { lintProject, printLintResult, runLint } from './lint'
 import { introspectMcpServer, McpIntrospectionError } from '../mcp/introspect'
-import { promptText, promptYesNo, closePrompts } from './prompt'
+import { promptText, promptYesNo, PromptCancelledError } from './prompt'
 import * as clack from '@clack/prompts'
 import type { TargetPlatform } from '../schema'
 import { basename } from 'path'
@@ -403,8 +403,6 @@ async function runInit() {
       brandColor = await promptText('Brand color (hex)', '#000000')
     }
 
-    closePrompts()
-
     const pluginName = toKebabCase(name) || dirName
     const skillName = pluginName
 
@@ -503,8 +501,12 @@ Example prompt or command here
     console.log('    3. Run: pluxx install')
     console.log('')
   } catch (error) {
-    closePrompts()
-    throw error instanceof Error ? error : new Error('Init cancelled')
+    if (error instanceof PromptCancelledError) {
+      console.log('Init cancelled')
+      return
+    }
+
+    throw error instanceof Error ? error : new Error(String(error))
   }
 }
 
@@ -641,8 +643,6 @@ async function runInitFromMcp(initialName?: string, initialSource?: string) {
           ], defaultHookModeValue)
         : defaultHookModeValue
 
-    closePrompts()
-
     // ── Step 4/4 · Generating scaffold ───────────────────────────────
 
     const g = !options.jsonOutput ? clack.spinner() : undefined
@@ -683,14 +683,25 @@ async function runInitFromMcp(initialName?: string, initialSource?: string) {
     }
 
     g?.stop(`Created ${summary.files.length} files`)
-    clack.log.success(`Lint: ${lintResult.errors} errors, ${lintResult.warnings} warnings`)
+    if (lintResult.errors > 0) {
+      clack.log.error(`Lint: ${lintResult.errors} errors, ${lintResult.warnings} warnings`)
+    } else if (lintResult.warnings > 0) {
+      clack.log.warn(`Lint: ${lintResult.errors} errors, ${lintResult.warnings} warnings`)
+    } else {
+      clack.log.success('Lint: 0 errors, 0 warnings')
+    }
 
     if (lintResult.issues.length > 0) {
       for (const issue of lintResult.issues) {
         const levelLabel = issue.level === 'error' ? 'ERROR' : 'WARN '
         const platformLabel = issue.platform ? `[${issue.platform}] ` : ''
         const loc = issue.file ? `${issue.file}: ` : ''
-        clack.log.warn(`${levelLabel} ${issue.code} ${platformLabel}${loc}${issue.message}`)
+        const message = `${levelLabel} ${issue.code} ${platformLabel}${loc}${issue.message}`
+        if (issue.level === 'error') {
+          clack.log.error(message)
+        } else {
+          clack.log.warn(message)
+        }
       }
     }
 
@@ -723,11 +734,14 @@ async function runInitFromMcp(initialName?: string, initialSource?: string) {
 
     clack.outro('Scaffold complete')
   } catch (error) {
-    closePrompts()
-    if (!options.jsonOutput) {
-      clack.cancel('Init cancelled')
+    if (error instanceof PromptCancelledError) {
+      if (!options.jsonOutput) {
+        clack.cancel(error.message)
+      }
+      return
     }
-    throw error instanceof Error ? error : new Error('Init cancelled')
+
+    throw error instanceof Error ? error : new Error(String(error))
   }
 }
 
@@ -739,8 +753,7 @@ async function clackText(message: string, defaultValue?: string): Promise<string
     placeholder: defaultValue,
   })
   if (clack.isCancel(result)) {
-    clack.cancel('Init cancelled')
-    process.exit(0)
+    throw new PromptCancelledError()
   }
   return result
 }
@@ -757,8 +770,7 @@ async function clackSelect<T extends string>(
     initialValue: initialValue as string,
   })
   if (clack.isCancel(result)) {
-    clack.cancel('Init cancelled')
-    process.exit(0)
+    throw new PromptCancelledError()
   }
   return result as T
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,6 +5,7 @@ import { build } from '../generators'
 import { ensureHookTrust, installPlugin, uninstallPlugin } from './install'
 import { runDev } from './dev'
 import {
+  buildToolExampleRequest,
   derivePluginName,
   MCP_HOOK_MODES,
   MCP_SKILL_GROUPINGS,
@@ -17,6 +18,7 @@ import { migrate } from './migrate'
 import { lintProject, printLintResult, runLint } from './lint'
 import { introspectMcpServer, McpIntrospectionError } from '../mcp/introspect'
 import { promptText, promptYesNo, closePrompts } from './prompt'
+import * as clack from '@clack/prompts'
 import type { TargetPlatform } from '../schema'
 import { basename } from 'path'
 import { mkdir } from 'fs/promises'
@@ -509,27 +511,26 @@ Example prompt or command here
 async function runInitFromMcp(initialName?: string, initialSource?: string) {
   const options = parseInitFromMcpOptions(args, initialName, initialSource)
   const defaultTargets = DEFAULT_INIT_TARGETS.join(',')
-  const log = (...values: Array<string | number>) => {
-    if (!options.jsonOutput) {
-      console.log(...values)
-    }
+  const interactive = !options.jsonOutput && !options.assumeDefaults
+
+  if (!options.jsonOutput) {
+    clack.intro('pluxx init --from-mcp')
   }
 
-  log('')
-  log('  pluxx init --from-mcp — Scaffold from an MCP server')
-  log('  ─────────────────────────────────────────────────────')
-  log('')
-
   try {
-    const rawSource = options.source ?? await resolveTextOption({
-      label: 'MCP server URL or local command',
-      assumeDefaults: options.assumeDefaults,
-    })
+    // ── Step 1/4 · Connecting to MCP server ──────────────────────────
+
+    const rawSource = options.source ?? (interactive
+      ? await clackText('MCP server URL or local command')
+      : '')
     if (!rawSource) {
       throw new Error('Provide an MCP server URL or local command. Example: pluxx init --from-mcp https://example.com/mcp')
     }
 
     let source = parseMcpSourceInput(rawSource)
+
+    const s = !options.jsonOutput ? clack.spinner() : undefined
+    s?.start('Step 1/4 \u00b7 Connecting to MCP server...')
 
     let introspection
     try {
@@ -540,11 +541,10 @@ async function runInitFromMcp(initialName?: string, initialSource?: string) {
         && source.transport !== 'stdio'
         && (error.status === 401 || error.status === 403)
       ) {
-        const envVar = await resolveTextOption({
-          label: 'Bearer auth env var for this MCP server',
-          providedValue: options.authEnv,
-          assumeDefaults: options.assumeDefaults,
-        })
+        s?.stop('Server requires authentication')
+        const envVar = options.authEnv ?? (interactive
+          ? await clackText('Bearer auth env var for this MCP server')
+          : '')
         if (!envVar) {
           throw new Error(
             'This MCP server requires auth. Re-run init with --auth-env YOUR_ENV_VAR or provide an auth env var name interactively.',
@@ -560,69 +560,93 @@ async function runInitFromMcp(initialName?: string, initialSource?: string) {
             headerTemplate: 'Bearer ${value}',
           },
         }
+        s?.start('Step 1/4 \u00b7 Reconnecting with auth...')
         introspection = await introspectMcpServer(source)
       } else {
+        s?.stop('Connection failed')
         throw error
       }
     }
 
-    log(`  Detected MCP server: ${introspection.serverInfo.title ?? introspection.serverInfo.name}`)
-    log(`  Discovered tools: ${introspection.tools.length}`)
-    log('')
+    const serverLabel = introspection.serverInfo.title ?? introspection.serverInfo.name
+    s?.stop(`Connected: ${serverLabel} (${introspection.tools.length} tools discovered)`)
 
-    const generatedAuthEnv = source.transport === 'stdio'
-      ? await resolveTextOption({
-          label: 'Auth env var for generated plugin (optional)',
-          providedValue: options.authEnv,
-          assumeDefaults: options.assumeDefaults,
-        })
-      : options.authEnv
+    // Only ask for stdio auth env when the source has no env vars and no auth already
+    const stdioHasEnv = source.transport === 'stdio'
+      && source.env
+      && Object.keys(source.env).length > 0
+    const stdioNeedsAuthPrompt = source.transport === 'stdio'
+      && !stdioHasEnv
+      && !source.auth
+      && !options.authEnv
+
+    const generatedAuthEnv = stdioNeedsAuthPrompt && interactive
+      ? await clackText('Auth env var for generated plugin (optional)', '')
+      : source.transport === 'stdio'
+        ? (options.authEnv ?? undefined)
+        : options.authEnv
 
     source = applyGeneratedAuthEnv(source, generatedAuthEnv)
 
+    // ── Step 2/4 · Plugin identity ───────────────────────────────────
+
+    if (!options.jsonOutput) {
+      clack.log.step('Step 2/4 \u00b7 Plugin identity')
+    }
+
+    const defaultPluginName = options.name ? toKebabCase(options.name) : derivePluginName(introspection, source)
     const pluginName = toKebabCase(
-      await resolveTextOption({
-        label: 'Plugin name',
-        defaultValue: options.name ? toKebabCase(options.name) : derivePluginName(introspection, source),
-        providedValue: options.name,
-        assumeDefaults: options.assumeDefaults,
-      }),
+      options.name ?? (interactive
+        ? await clackText('Plugin name', defaultPluginName)
+        : defaultPluginName),
     )
-    const authorName = await resolveTextOption({
-      label: 'Author name',
-      defaultValue: process.env.USER ?? '',
-      providedValue: options.author,
-      assumeDefaults: options.assumeDefaults,
-    })
-    const displayName = await resolveTextOption({
-      label: 'Display name',
-      defaultValue: options.displayName ?? introspection.serverInfo.title ?? pluginName,
-      providedValue: options.displayName,
-      assumeDefaults: options.assumeDefaults,
-    })
-    const targetsRaw = await resolveTextOption({
-      label: 'Which platforms? (comma-separated)',
-      defaultValue: options.targets ?? defaultTargets,
-      providedValue: options.targets,
-      assumeDefaults: options.assumeDefaults,
-    })
+    const defaultDisplayName = options.displayName ?? introspection.serverInfo.title ?? pluginName
+    const displayName = options.displayName ?? (interactive
+      ? await clackText('Display name', defaultDisplayName)
+      : defaultDisplayName)
+    const defaultAuthor = process.env.USER ?? ''
+    const authorName = options.author ?? (interactive
+      ? await clackText('Author name', defaultAuthor)
+      : defaultAuthor)
+
+    // ── Step 3/4 · Build settings ────────────────────────────────────
+
+    if (!options.jsonOutput) {
+      clack.log.step('Step 3/4 \u00b7 Build settings')
+    }
+
+    const defaultTargetsValue = options.targets ?? defaultTargets
+    const targetsRaw = options.targets ?? (interactive
+      ? await clackText('Platforms (comma-separated)', defaultTargetsValue)
+      : defaultTargetsValue)
     const targets = parseTargetPlatforms(targetsRaw)
-    const grouping = await resolveChoiceOption<McpSkillGrouping>({
-      label: 'Skill grouping strategy',
-      values: MCP_SKILL_GROUPINGS,
-      defaultValue: 'workflow',
-      providedValue: options.grouping,
-      assumeDefaults: options.assumeDefaults,
-    })
-    const hookMode = await resolveChoiceOption<McpHookMode>({
-      label: 'Install-ready hooks',
-      values: MCP_HOOK_MODES,
-      defaultValue: defaultHookMode(source),
-      providedValue: options.hooks,
-      assumeDefaults: options.assumeDefaults,
-    })
+
+    const defaultGrouping: McpSkillGrouping = 'workflow'
+    const grouping: McpSkillGrouping = options.grouping
+      ? parseChoiceOption(options.grouping, MCP_SKILL_GROUPINGS, 'Skill grouping')
+      : interactive
+        ? await clackSelect<McpSkillGrouping>('Skill grouping', [
+            { value: 'workflow', label: 'workflow', hint: 'Group related tools into workflow skills' },
+            { value: 'tool', label: 'tool', hint: 'One skill per tool' },
+          ], defaultGrouping)
+        : defaultGrouping
+
+    const defaultHookModeValue = defaultHookMode(source)
+    const hookMode: McpHookMode = options.hooks
+      ? parseChoiceOption(options.hooks, MCP_HOOK_MODES, 'Install-ready hooks')
+      : interactive
+        ? await clackSelect<McpHookMode>('Install-ready hooks', [
+            { value: 'none', label: 'none', hint: 'No install hooks' },
+            { value: 'safe', label: 'safe', hint: 'Auto-generate safe install hooks' },
+          ], defaultHookModeValue)
+        : defaultHookModeValue
 
     closePrompts()
+
+    // ── Step 4/4 · Generating scaffold ───────────────────────────────
+
+    const g = !options.jsonOutput ? clack.spinner() : undefined
+    g?.start('Step 4/4 \u00b7 Generating scaffold...')
 
     const result = await writeMcpScaffold({
       rootDir: process.cwd(),
@@ -658,30 +682,85 @@ async function runInitFromMcp(initialName?: string, initialSource?: string) {
       return
     }
 
-    console.log('')
-    console.log('  Created:')
-    for (const file of summary.files) {
-      console.log(`    ${file}`)
+    g?.stop(`Created ${summary.files.length} files`)
+    clack.log.success(`Lint: ${lintResult.errors} errors, ${lintResult.warnings} warnings`)
+
+    if (lintResult.issues.length > 0) {
+      for (const issue of lintResult.issues) {
+        const levelLabel = issue.level === 'error' ? 'ERROR' : 'WARN '
+        const platformLabel = issue.platform ? `[${issue.platform}] ` : ''
+        const loc = issue.file ? `${issue.file}: ` : ''
+        clack.log.warn(`${levelLabel} ${issue.code} ${platformLabel}${loc}${issue.message}`)
+      }
     }
-    console.log('')
-    printLintResult(lintResult, process.cwd())
+
     if (summary.notes.length > 0) {
-      console.log('')
-      console.log('  Notes:')
-      summary.notes.forEach((note) => {
-        console.log(`    - ${note}`)
-      })
+      for (const n of summary.notes) {
+        clack.log.info(n)
+      }
     }
-    console.log('')
-    console.log('  Next steps:')
-    summary.nextSteps.forEach((step, index) => {
-      console.log(`    ${index + 1}. ${step}`)
-    })
-    console.log('')
+
+    // Build a concrete test prompt from the first tool's example request
+    const firstTool = introspection.tools[0]
+    const testPrompt = firstTool ? buildToolExampleRequest(firstTool) : undefined
+    const installTarget = targets[0]
+    const installCommand = summary.hookMode === 'safe'
+      ? `pluxx install --trust --target ${installTarget}`
+      : `pluxx install --target ${installTarget}`
+
+    const nextStepLines = [
+      '1. Review INSTRUCTIONS.md and skills/',
+      '2. pluxx build',
+      `3. ${installCommand}`,
+    ]
+    if (testPrompt) {
+      nextStepLines.push(`4. Test in ${installTarget}: "${testPrompt}"`)
+    }
+    nextStepLines.push('')
+    nextStepLines.push(`To refresh later: pluxx sync --from-mcp`)
+
+    clack.note(nextStepLines.join('\n'), 'Next steps')
+
+    clack.outro('Scaffold complete')
   } catch (error) {
     closePrompts()
+    if (!options.jsonOutput) {
+      clack.cancel('Init cancelled')
+    }
     throw error instanceof Error ? error : new Error('Init cancelled')
   }
+}
+
+/** Wrapper for clack.text that handles cancellation. */
+async function clackText(message: string, defaultValue?: string): Promise<string> {
+  const result = await clack.text({
+    message,
+    defaultValue,
+    placeholder: defaultValue,
+  })
+  if (clack.isCancel(result)) {
+    clack.cancel('Init cancelled')
+    process.exit(0)
+  }
+  return result
+}
+
+/** Wrapper for clack.select that handles cancellation. */
+async function clackSelect<T extends string>(
+  message: string,
+  options: Array<{ value: T; label: string; hint?: string }>,
+  initialValue: T,
+): Promise<T> {
+  const result = await clack.select({
+    message,
+    options: options as Array<{ value: string; label: string; hint?: string }>,
+    initialValue: initialValue as string,
+  })
+  if (clack.isCancel(result)) {
+    clack.cancel('Init cancelled')
+    process.exit(0)
+  }
+  return result as T
 }
 
 async function runSync() {

--- a/src/cli/init-from-mcp.ts
+++ b/src/cli/init-from-mcp.ts
@@ -790,7 +790,7 @@ function getTopLevelSchemaFields(inputSchema?: Record<string, unknown>): SchemaF
   })
 }
 
-function buildToolExampleRequest(tool: IntrospectedMcpTool): string {
+export function buildToolExampleRequest(tool: IntrospectedMcpTool): string {
   const action = inferToolAction(tool)
   const objectLabel = inferToolObject(tool)
   const context = buildToolRequestContext(tool)

--- a/src/cli/prompt.ts
+++ b/src/cli/prompt.ts
@@ -5,16 +5,51 @@
 
 import * as readline from 'readline'
 
+export class PromptCancelledError extends Error {
+  constructor() {
+    super('Init cancelled')
+    this.name = 'PromptCancelledError'
+  }
+}
+
 function ask(question: string): Promise<string> {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const rl = readline.createInterface({
       input: process.stdin,
       output: process.stdout,
     })
 
+    let settled = false
+
+    const settle = (fn: () => void) => {
+      if (settled) return
+      settled = true
+      rl.removeListener('SIGINT', onCancel)
+      rl.removeListener('close', onClose)
+      fn()
+    }
+
+    const onCancel = () => {
+      settle(() => {
+        rl.close()
+        reject(new PromptCancelledError())
+      })
+    }
+
+    const onClose = () => {
+      settle(() => {
+        reject(new PromptCancelledError())
+      })
+    }
+
+    rl.once('SIGINT', onCancel)
+    rl.once('close', onClose)
+
     rl.question(question, (answer) => {
-      rl.close()
-      resolve(answer)
+      settle(() => {
+        resolve(answer)
+        rl.close()
+      })
     })
   })
 }

--- a/tests/cli-init-from-mcp.test.ts
+++ b/tests/cli-init-from-mcp.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'bun:test'
+import { resolve } from 'path'
+
+describe('init --from-mcp cancellation and lint severity handling', () => {
+  it('passes the isolated CLI runner checks', async () => {
+    const runner = './tests/helpers/cli-init-from-mcp-runner.ts'
+    const proc = Bun.spawn(['bun', 'test', runner], {
+      cwd: resolve(import.meta.dir, '..'),
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+
+    const stdout = await new Response(proc.stdout).text()
+    const stderr = await new Response(proc.stderr).text()
+    const exitCode = await proc.exited
+
+    expect(exitCode).toBe(0)
+    expect(`${stdout}${stderr}`).toContain('2 pass')
+  })
+})

--- a/tests/helpers/cli-init-from-mcp-runner.ts
+++ b/tests/helpers/cli-init-from-mcp-runner.ts
@@ -1,0 +1,242 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { resolve } from 'path'
+
+const originalArgv = [...process.argv]
+const originalCwd = process.cwd()
+const CLI_INDEX_PATH = resolve(import.meta.dir, '../../src/cli/index.ts')
+const INTROSPECT_PATH = resolve(import.meta.dir, '../../src/mcp/introspect.ts')
+const INIT_FROM_MCP_PATH = resolve(import.meta.dir, '../../src/cli/init-from-mcp.ts')
+const LINT_PATH = resolve(import.meta.dir, '../../src/cli/lint.ts')
+const LOAD_CONFIG_PATH = resolve(import.meta.dir, '../../src/config/load.ts')
+const GENERATORS_PATH = resolve(import.meta.dir, '../../src/generators/index.ts')
+const INSTALL_PATH = resolve(import.meta.dir, '../../src/cli/install.ts')
+const DEV_PATH = resolve(import.meta.dir, '../../src/cli/dev.ts')
+const MIGRATE_PATH = resolve(import.meta.dir, '../../src/cli/migrate.ts')
+const SYNC_PATH = resolve(import.meta.dir, '../../src/cli/sync-from-mcp.ts')
+
+type Issue = {
+  level: 'error' | 'warning'
+  code: string
+  message: string
+  file?: string
+  platform?: string
+}
+
+function installMocks(options: {
+  cancelToken?: symbol
+  textResponses?: Array<string | symbol>
+  selectResponses?: Array<string | symbol>
+  lintResult?: {
+    errors: number
+    warnings: number
+    issues: Issue[]
+  }
+}) {
+  const CANCEL = options.cancelToken ?? Symbol('cancel')
+  const calls = {
+    cancel: [] as string[],
+    success: [] as string[],
+    warn: [] as string[],
+    error: [] as string[],
+    note: [] as Array<{ title: string; message: string }>,
+  }
+  const textQueue = [...(options.textResponses ?? [])]
+  const selectQueue = [...(options.selectResponses ?? [])]
+
+  mock.module('@clack/prompts', () => ({
+    intro() {},
+    outro() {},
+    note(message: string, title: string) {
+      calls.note.push({ title, message })
+    },
+    spinner() {
+      return {
+        start() {},
+        stop() {},
+      }
+    },
+    log: {
+      step() {},
+      info() {},
+      success(message: string) {
+        calls.success.push(message)
+      },
+      warn(message: string) {
+        calls.warn.push(message)
+      },
+      error(message: string) {
+        calls.error.push(message)
+      },
+    },
+    cancel(message: string) {
+      calls.cancel.push(message)
+    },
+    text: async () => textQueue.shift() ?? '',
+    select: async () => selectQueue.shift() ?? 'workflow',
+    isCancel(value: unknown) {
+      return value === CANCEL
+    },
+  }))
+
+  mock.module(INTROSPECT_PATH, () => ({
+    McpIntrospectionError: class McpIntrospectionError extends Error {
+      status?: number
+      constructor(message: string, status?: number) {
+        super(message)
+        this.name = 'McpIntrospectionError'
+        this.status = status
+      }
+    },
+    introspectMcpServer: async () => ({
+      serverInfo: {
+        name: 'stub-server',
+        title: 'Stub Server',
+        version: '1.0.0',
+        description: 'A fake MCP server for CLI tests.',
+      },
+      instructions: 'Use the fake tools carefully.',
+      tools: [
+        {
+          name: 'FindOrganizations',
+          description: 'Search organizations.',
+          inputSchema: { type: 'object', properties: {}, required: [] },
+        },
+      ],
+    }),
+  }))
+
+  mock.module(INIT_FROM_MCP_PATH, () => ({
+    MCP_HOOK_MODES: ['none', 'safe'],
+    MCP_SKILL_GROUPINGS: ['workflow', 'tool'],
+    buildToolExampleRequest: () => 'Find organizations for Acme',
+    derivePluginName: () => 'stub-server',
+    parseMcpSourceInput: (raw: string) => ({ transport: 'http', url: raw }),
+    writeMcpScaffold: async () => ({
+      generatedFiles: ['pluxx.config.ts', './INSTRUCTIONS.md'],
+      generatedHookMode: 'none',
+      generatedHookEvents: [],
+      instructionsPath: 'INSTRUCTIONS.md',
+      skillDirectories: ['skills/account-research'],
+      metadataPath: '.pluxx/mcp.json',
+    }),
+  }))
+
+  mock.module(LINT_PATH, () => ({
+    lintProject: async () => options.lintResult ?? {
+      errors: 0,
+      warnings: 0,
+      issues: [],
+    },
+    printLintResult() {},
+    runLint: async () => 0,
+  }))
+
+  mock.module(LOAD_CONFIG_PATH, () => ({
+    loadConfig: async () => {
+      throw new Error('loadConfig should not be called in init --from-mcp tests')
+    },
+  }))
+
+  mock.module(GENERATORS_PATH, () => ({
+    build: async () => {
+      throw new Error('build should not be called in init --from-mcp tests')
+    },
+  }))
+
+  mock.module(INSTALL_PATH, () => ({
+    ensureHookTrust: async () => {},
+    installPlugin: async () => {},
+    uninstallPlugin: async () => {},
+  }))
+
+  mock.module(DEV_PATH, () => ({
+    runDev: async () => {},
+  }))
+
+  mock.module(MIGRATE_PATH, () => ({
+    migrate: async () => {},
+  }))
+
+  mock.module(SYNC_PATH, () => ({
+    formatSyncSummary: () => [],
+    syncFromMcp: async () => ({
+      updatedFiles: [],
+      removedFiles: [],
+      preservedFiles: [],
+      skippedFiles: [],
+    }),
+  }))
+
+  return { calls }
+}
+
+async function loadCli(tag: string) {
+  return await import(`${CLI_INDEX_PATH}?${tag}`)
+}
+
+afterEach(() => {
+  process.argv = [...originalArgv]
+  process.chdir(originalCwd)
+  mock.restore()
+})
+
+describe('isolated init --from-mcp CLI checks', () => {
+  it('treats clack cancellation as a clean exit', async () => {
+    const cwd = mkdtempSync(resolve(tmpdir(), 'pluxx-init-cancel-'))
+
+    try {
+      process.chdir(cwd)
+      process.argv = ['bun', 'pluxx', 'init', '--from-mcp', 'https://example.com/mcp']
+      const cancelToken = Symbol('cancel')
+
+      const { calls } = installMocks({
+        cancelToken,
+        textResponses: [cancelToken],
+      })
+
+      const { main } = await loadCli('cancel')
+
+      await expect(main()).resolves.toBeUndefined()
+      expect(calls.cancel).toEqual(['Init cancelled'])
+      expect(calls.error).toEqual([])
+      expect(calls.warn).toEqual([])
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  it('logs lint errors and warnings at the correct severity', async () => {
+    const cwd = mkdtempSync(resolve(tmpdir(), 'pluxx-init-severity-'))
+
+    try {
+      process.chdir(cwd)
+      process.argv = ['bun', 'pluxx', 'init', '--from-mcp', 'https://example.com/mcp']
+
+      const { calls } = installMocks({
+        textResponses: ['stub-server', 'Stub Server', 'Test Author', 'claude-code,codex'],
+        selectResponses: ['workflow', 'none'],
+        lintResult: {
+          errors: 1,
+          warnings: 1,
+          issues: [
+            { level: 'error', code: 'bad-rule', message: 'broken rule' },
+            { level: 'warning', code: 'warn-rule', message: 'soft warning' },
+          ],
+        },
+      })
+
+      const { main } = await loadCli('severity')
+
+      await expect(main()).resolves.toBeUndefined()
+      expect(calls.cancel).toEqual([])
+      expect(calls.error.some((message) => message === 'Lint: 1 errors, 1 warnings')).toBe(true)
+      expect(calls.error.some((message) => message.includes('bad-rule'))).toBe(true)
+      expect(calls.warn.some((message) => message.includes('warn-rule'))).toBe(true)
+      expect(calls.success).toEqual([])
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Replaces raw readline prompts with `@clack/prompts` in the `init --from-mcp` flow
- Adds `intro()`, `spinner()`, `select()`, `text()`, `note()`, `outro()` for Ultracite-style UX
- Groups prompts into numbered steps: Connect → Identity → Build Settings → Generate
- Shows concrete test prompt from first tool's example request in end-of-flow guidance
- Graceful cancellation via `isCancel()` throughout
- `--yes` and `--json` non-interactive paths preserved

## Linear
Addresses PLUXX-39 — Ultracite-style interactive init wizard.

## Test plan
- [ ] `bun run typecheck` clean
- [ ] Interactive: `pluxx init --from-mcp <url>` shows step numbers, spinner during connection, select menus
- [ ] Non-interactive: `pluxx init --from-mcp <url> --yes --json` still works without prompts
- [ ] Ctrl+C during any prompt exits gracefully
- [ ] End-of-flow shows concrete test prompt and install command

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned CLI init flow with interactive prompts, step-by-step progress, clearer completion notes, and improved cancellation handling.
  * Non-interactive mode for scripted/CI usage.

* **Chores**
  * Added a new CLI prompt library dependency.

* **Tests**
  * Added end-to-end tests and a test helper for the init-from-mcp CLI flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->