### PR TITLE
Add rename detection to sync --from-mcp

### DIFF
--- a/src/cli/sync-from-mcp.ts
+++ b/src/cli/sync-from-mcp.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, rmSync, readdirSync, rmdirSync, writeFileSync } from 'fs'
-import { dirname, relative, resolve } from 'path'
+import { dirname, isAbsolute, relative, resolve } from 'path'
 import { loadConfig } from '../config/load'
 import { introspectMcpServer, type IntrospectedMcpTool } from '../mcp/introspect'
 import type { McpServer } from '../schema'
@@ -29,7 +29,7 @@ export interface SyncFromMcpResult {
 }
 
 export async function readMcpScaffoldMetadata(rootDir: string): Promise<McpScaffoldMetadata> {
-  const filepath = resolve(rootDir, MCP_SCAFFOLD_METADATA_PATH)
+  const filepath = resolveWithinRoot(rootDir, MCP_SCAFFOLD_METADATA_PATH)
   if (!existsSync(filepath)) {
     throw new Error(
       `No MCP scaffold metadata found at ${MCP_SCAFFOLD_METADATA_PATH}. Run "pluxx init --from-mcp" first.`,
@@ -47,21 +47,7 @@ export async function syncFromMcp(options: SyncFromMcpOptions): Promise<SyncFrom
   const beforeContents = snapshotManagedFiles(options.rootDir, metadata.managedFiles)
 
   // Step 1: Detect renames between old and new tool lists
-  const renames = detectToolRenames(metadata.tools, introspection.tools)
-
-  // Step 2: Read custom content from old skill files that are being renamed
-  const renamedCustomContent = new Map<string, string>()
-  for (const [oldToolName, newToolName] of renames) {
-    const oldSkill = metadata.skills.find((s) => s.toolNames.includes(oldToolName))
-    if (!oldSkill) continue
-    const oldSkillPath = resolve(options.rootDir, `skills/${oldSkill.dirName}/SKILL.md`)
-    if (!existsSync(oldSkillPath)) continue
-    const oldContent = readFileSync(oldSkillPath, 'utf-8')
-    const extracted = extractMixedMarkdownContent(oldContent, '')
-    if (extracted.customContent && extracted.customContent.trim()) {
-      renamedCustomContent.set(newToolName, extracted.customContent)
-    }
-  }
+  const toolRenames = detectToolRenames(metadata.tools, introspection.tools)
 
   // Step 3: Generate new scaffold
   const result = await writeMcpScaffold({
@@ -76,16 +62,25 @@ export async function syncFromMcp(options: SyncFromMcpOptions): Promise<SyncFrom
     hookMode: metadata.settings.requestedHookMode,
   })
 
-  // Step 4: Inject preserved custom content into renamed skill files
-  const newMetadataPath = resolve(options.rootDir, MCP_SCAFFOLD_METADATA_PATH)
+  const newMetadataPath = resolveWithinRoot(options.rootDir, MCP_SCAFFOLD_METADATA_PATH)
   const newMetadata: McpScaffoldMetadata = JSON.parse(readFileSync(newMetadataPath, 'utf-8'))
-  for (const [newToolName, customContent] of renamedCustomContent) {
-    const newSkill = newMetadata.skills.find((s) => s.toolNames.includes(newToolName))
+  const skillRenames = detectSkillRenames(metadata.skills, newMetadata.skills, toolRenames)
+
+  // Step 4: Inject preserved custom content into renamed skill files
+  for (const [oldSkillDir, newSkillDir] of skillRenames) {
+    const oldSkillPath = resolveWithinRoot(options.rootDir, `skills/${oldSkillDir}/SKILL.md`)
+    if (!existsSync(oldSkillPath)) continue
+    const oldContent = readFileSync(oldSkillPath, 'utf-8')
+    const extracted = extractMixedMarkdownContent(oldContent, '')
+    if (!hasMeaningfulCustomContent(oldContent)) continue
+
+    const newSkill = newMetadata.skills.find((s) => s.dirName === newSkillDir)
     if (!newSkill) continue
-    const newSkillPath = resolve(options.rootDir, `skills/${newSkill.dirName}/SKILL.md`)
+
+    const newSkillPath = resolveWithinRoot(options.rootDir, `skills/${newSkill.dirName}/SKILL.md`)
     if (!existsSync(newSkillPath)) continue
     const currentContent = readFileSync(newSkillPath, 'utf-8')
-    const updatedContent = injectCustomContent(currentContent, customContent)
+    const updatedContent = injectCustomContent(currentContent, extracted.customContent)
     writeFileSync(newSkillPath, updatedContent, 'utf-8')
   }
 
@@ -93,17 +88,13 @@ export async function syncFromMcp(options: SyncFromMcpOptions): Promise<SyncFrom
   const renamedFiles: Array<{ from: string; to: string }> = []
   const renamedOldDirs = new Set<string>()
   const renamedNewDirs = new Set<string>()
-  for (const [oldToolName, newToolName] of renames) {
-    const oldSkill = metadata.skills.find((s) => s.toolNames.includes(oldToolName))
-    const newSkill = newMetadata.skills.find((s) => s.toolNames.includes(newToolName))
-    if (!oldSkill || !newSkill || oldSkill.dirName === newSkill.dirName) continue
-    const fromDir = `skills/${oldSkill.dirName}/`
-    const toDir = `skills/${newSkill.dirName}/`
-    if (!renamedOldDirs.has(fromDir) && !renamedNewDirs.has(toDir)) {
-      renamedFiles.push({ from: fromDir, to: toDir })
-      renamedOldDirs.add(fromDir)
-      renamedNewDirs.add(toDir)
-    }
+  for (const [oldSkillDir, newSkillDir] of skillRenames) {
+    const fromDir = `skills/${oldSkillDir}/`
+    const toDir = `skills/${newSkillDir}/`
+    if (renamedOldDirs.has(fromDir) || renamedNewDirs.has(toDir)) continue
+    renamedFiles.push({ from: fromDir, to: toDir })
+    renamedOldDirs.add(fromDir)
+    renamedNewDirs.add(toDir)
   }
 
   const afterManaged = new Set(result.generatedFiles)
@@ -139,7 +130,7 @@ export async function syncFromMcp(options: SyncFromMcpOptions): Promise<SyncFrom
   const updatedFiles = [...afterManaged].filter((file) => {
     if (!beforeManaged.has(file)) return false
     const before = beforeContents.get(file)
-    const currentPath = resolve(options.rootDir, file)
+    const currentPath = resolveWithinRoot(options.rootDir, file)
     if (!existsSync(currentPath)) return false
     const after = readFileSync(currentPath, 'utf-8')
     return before !== after
@@ -159,7 +150,7 @@ export async function syncFromMcp(options: SyncFromMcpOptions): Promise<SyncFrom
 function snapshotManagedFiles(rootDir: string, files: string[]): Map<string, string> {
   const contents = new Map<string, string>()
   for (const file of files) {
-    const filepath = resolve(rootDir, file)
+    const filepath = resolveWithinRoot(rootDir, file)
     if (!existsSync(filepath)) continue
     contents.set(file, readFileSync(filepath, 'utf-8'))
   }
@@ -167,7 +158,7 @@ function snapshotManagedFiles(rootDir: string, files: string[]): Map<string, str
 }
 
 function removeManagedFile(rootDir: string, relativePath: string): void {
-  const filepath = resolve(rootDir, relativePath)
+  const filepath = resolveWithinRoot(rootDir, relativePath)
   if (!existsSync(filepath)) return
 
   rmSync(filepath, { force: true })
@@ -177,7 +168,7 @@ function removeManagedFile(rootDir: string, relativePath: string): void {
 function shouldPreserveManagedFile(rootDir: string, relativePath: string): boolean {
   if (!relativePath.endsWith('.md')) return false
 
-  const filepath = resolve(rootDir, relativePath)
+  const filepath = resolveWithinRoot(rootDir, relativePath)
   if (!existsSync(filepath)) return false
 
   return hasMeaningfulCustomContent(readFileSync(filepath, 'utf-8'))
@@ -245,16 +236,15 @@ export function detectToolRenames(
 }
 
 const RENAME_SCORE_THRESHOLD = 0.5
+const SKILL_RENAME_SCORE_THRESHOLD = 0.6
 
 function computeRenameScore(oldTool: IntrospectedMcpTool, newTool: IntrospectedMcpTool): number {
   let score = 0
-  let signals = 0
+  let hasCorroboratingSignal = false
 
-  // Same description -> high confidence
   if (oldTool.description && newTool.description) {
-    signals++
     if (oldTool.description === newTool.description) {
-      score += 1.0
+      score += 0.45
     } else {
       // Partial description similarity (Jaccard on words)
       const oldWords = new Set(oldTool.description.toLowerCase().split(/\s+/))
@@ -263,39 +253,42 @@ function computeRenameScore(oldTool: IntrospectedMcpTool, newTool: IntrospectedM
       const union = new Set([...oldWords, ...newWords]).size
       const jaccard = union > 0 ? intersection / union : 0
       if (jaccard >= 0.7) {
-        score += 0.6
+        score += 0.35
       }
     }
   }
 
-  // Similar name (edit distance)
-  signals++
   const distance = levenshteinDistance(oldTool.name, newTool.name)
   if (distance <= 3) {
-    score += 0.8
+    score += 0.35
+    hasCorroboratingSignal = true
   } else if (distance <= 6 && Math.max(oldTool.name.length, newTool.name.length) > 10) {
-    score += 0.3
+    score += 0.2
+    hasCorroboratingSignal = true
   }
 
-  // Same input schema shape (same required field names)
   const oldRequired = getRequiredFieldNames(oldTool.inputSchema)
   const newRequired = getRequiredFieldNames(newTool.inputSchema)
   if (oldRequired.length > 0 || newRequired.length > 0) {
-    signals++
     if (oldRequired.length === newRequired.length && oldRequired.every((f) => newRequired.includes(f))) {
-      score += 0.7
+      score += 0.35
+      hasCorroboratingSignal = true
     } else {
       // Partial overlap
       const overlap = oldRequired.filter((f) => newRequired.includes(f)).length
       const total = new Set([...oldRequired, ...newRequired]).size
       if (total > 0 && overlap / total >= 0.7) {
-        score += 0.4
+        score += 0.2
+        hasCorroboratingSignal = true
       }
     }
   }
 
-  // Normalize by number of signals considered
-  return signals > 0 ? score / signals : 0
+  if (oldTool.description && newTool.description && oldTool.description === newTool.description) {
+    return hasCorroboratingSignal ? score : 0
+  }
+
+  return score
 }
 
 function getRequiredFieldNames(inputSchema?: Record<string, unknown>): string[] {
@@ -347,6 +340,82 @@ function injectCustomContent(fileContent: string, customContent: string): string
     '\n' +
     fileContent.slice(customEnd)
   )
+}
+
+interface SkillRenameCandidate {
+  oldSkill: McpScaffoldMetadata['skills'][number]
+  newSkill: McpScaffoldMetadata['skills'][number]
+  score: number
+}
+
+export function detectSkillRenames(
+  oldSkills: McpScaffoldMetadata['skills'],
+  newSkills: McpScaffoldMetadata['skills'],
+  toolRenames: Map<string, string>,
+): Map<string, string> {
+  const candidates: SkillRenameCandidate[] = []
+
+  for (const oldSkill of oldSkills) {
+    for (const newSkill of newSkills) {
+      if (oldSkill.dirName === newSkill.dirName) continue
+
+      const score = computeSkillRenameScore(oldSkill, newSkill, toolRenames)
+      if (score >= SKILL_RENAME_SCORE_THRESHOLD) {
+        candidates.push({ oldSkill, newSkill, score })
+      }
+    }
+  }
+
+  candidates.sort((a, b) => b.score - a.score)
+
+  const renames = new Map<string, string>()
+  const usedOld = new Set<string>()
+  const usedNew = new Set<string>()
+
+  for (const candidate of candidates) {
+    if (usedOld.has(candidate.oldSkill.dirName) || usedNew.has(candidate.newSkill.dirName)) continue
+    renames.set(candidate.oldSkill.dirName, candidate.newSkill.dirName)
+    usedOld.add(candidate.oldSkill.dirName)
+    usedNew.add(candidate.newSkill.dirName)
+  }
+
+  return renames
+}
+
+function computeSkillRenameScore(
+  oldSkill: McpScaffoldMetadata['skills'][number],
+  newSkill: McpScaffoldMetadata['skills'][number],
+  toolRenames: Map<string, string>,
+): number {
+  const mappedOldTools = new Set(oldSkill.toolNames.map((toolName) => toolRenames.get(toolName) ?? toolName))
+  const newTools = new Set(newSkill.toolNames)
+  const overlap = [...mappedOldTools].filter((toolName) => newTools.has(toolName)).length
+
+  if (overlap === 0) return 0
+
+  const precision = overlap / newTools.size
+  const recall = overlap / mappedOldTools.size
+  let score = (precision + recall) / 2
+
+  const normalizedOldTitle = oldSkill.title.toLowerCase().replace(/[^a-z0-9]+/g, '')
+  const normalizedNewTitle = newSkill.title.toLowerCase().replace(/[^a-z0-9]+/g, '')
+  if (normalizedOldTitle === normalizedNewTitle) {
+    score += 0.1
+  }
+
+  return score
+}
+
+function resolveWithinRoot(rootDir: string, relativePath: string): string {
+  const rootPath = resolve(rootDir)
+  const filepath = resolve(rootPath, relativePath)
+  const relativePathFromRoot = relative(rootPath, filepath)
+
+  if (relativePathFromRoot === '' || (!relativePathFromRoot.startsWith('..') && !isAbsolute(relativePathFromRoot))) {
+    return filepath
+  }
+
+  throw new Error(`Refusing to access path outside root: ${relativePath}`)
 }
 
 export function formatSyncSummary(result: SyncFromMcpResult, rootDir: string): string[] {

--- a/src/cli/sync-from-mcp.ts
+++ b/src/cli/sync-from-mcp.ts
@@ -1,10 +1,13 @@
-import { existsSync, readFileSync, rmSync, readdirSync, rmdirSync } from 'fs'
+import { existsSync, readFileSync, rmSync, readdirSync, rmdirSync, writeFileSync } from 'fs'
 import { dirname, relative, resolve } from 'path'
 import { loadConfig } from '../config/load'
-import { introspectMcpServer, type IntrospectedMcpServer } from '../mcp/introspect'
+import { introspectMcpServer, type IntrospectedMcpTool } from '../mcp/introspect'
 import type { McpServer } from '../schema'
 import {
   MCP_SCAFFOLD_METADATA_PATH,
+  PLUXX_CUSTOM_START,
+  PLUXX_CUSTOM_END,
+  extractMixedMarkdownContent,
   hasMeaningfulCustomContent,
   type McpScaffoldMetadata,
   writeMcpScaffold,
@@ -22,6 +25,7 @@ export interface SyncFromMcpResult {
   updatedFiles: string[]
   removedFiles: string[]
   preservedFiles: string[]
+  renamedFiles: Array<{ from: string; to: string }>
 }
 
 export async function readMcpScaffoldMetadata(rootDir: string): Promise<McpScaffoldMetadata> {
@@ -42,6 +46,24 @@ export async function syncFromMcp(options: SyncFromMcpOptions): Promise<SyncFrom
   const introspection = await introspectMcpServer(source)
   const beforeContents = snapshotManagedFiles(options.rootDir, metadata.managedFiles)
 
+  // Step 1: Detect renames between old and new tool lists
+  const renames = detectToolRenames(metadata.tools, introspection.tools)
+
+  // Step 2: Read custom content from old skill files that are being renamed
+  const renamedCustomContent = new Map<string, string>()
+  for (const [oldToolName, newToolName] of renames) {
+    const oldSkill = metadata.skills.find((s) => s.toolNames.includes(oldToolName))
+    if (!oldSkill) continue
+    const oldSkillPath = resolve(options.rootDir, `skills/${oldSkill.dirName}/SKILL.md`)
+    if (!existsSync(oldSkillPath)) continue
+    const oldContent = readFileSync(oldSkillPath, 'utf-8')
+    const extracted = extractMixedMarkdownContent(oldContent, '')
+    if (extracted.customContent && extracted.customContent.trim()) {
+      renamedCustomContent.set(newToolName, extracted.customContent)
+    }
+  }
+
+  // Step 3: Generate new scaffold
   const result = await writeMcpScaffold({
     rootDir: options.rootDir,
     pluginName: config.name,
@@ -54,14 +76,51 @@ export async function syncFromMcp(options: SyncFromMcpOptions): Promise<SyncFrom
     hookMode: metadata.settings.requestedHookMode,
   })
 
+  // Step 4: Inject preserved custom content into renamed skill files
+  const newMetadataPath = resolve(options.rootDir, MCP_SCAFFOLD_METADATA_PATH)
+  const newMetadata: McpScaffoldMetadata = JSON.parse(readFileSync(newMetadataPath, 'utf-8'))
+  for (const [newToolName, customContent] of renamedCustomContent) {
+    const newSkill = newMetadata.skills.find((s) => s.toolNames.includes(newToolName))
+    if (!newSkill) continue
+    const newSkillPath = resolve(options.rootDir, `skills/${newSkill.dirName}/SKILL.md`)
+    if (!existsSync(newSkillPath)) continue
+    const currentContent = readFileSync(newSkillPath, 'utf-8')
+    const updatedContent = injectCustomContent(currentContent, customContent)
+    writeFileSync(newSkillPath, updatedContent, 'utf-8')
+  }
+
+  // Step 5: Build rename mapping (old skill dir -> new skill dir)
+  const renamedFiles: Array<{ from: string; to: string }> = []
+  const renamedOldDirs = new Set<string>()
+  const renamedNewDirs = new Set<string>()
+  for (const [oldToolName, newToolName] of renames) {
+    const oldSkill = metadata.skills.find((s) => s.toolNames.includes(oldToolName))
+    const newSkill = newMetadata.skills.find((s) => s.toolNames.includes(newToolName))
+    if (!oldSkill || !newSkill || oldSkill.dirName === newSkill.dirName) continue
+    const fromDir = `skills/${oldSkill.dirName}/`
+    const toDir = `skills/${newSkill.dirName}/`
+    if (!renamedOldDirs.has(fromDir) && !renamedNewDirs.has(toDir)) {
+      renamedFiles.push({ from: fromDir, to: toDir })
+      renamedOldDirs.add(fromDir)
+      renamedNewDirs.add(toDir)
+    }
+  }
+
   const afterManaged = new Set(result.generatedFiles)
   const beforeManaged = new Set(metadata.managedFiles)
 
+  // Step 6: Handle removed files, excluding those that are part of renames
   const removedCandidates = [...beforeManaged].filter((file) => !afterManaged.has(file))
   const removedFiles: string[] = []
   const preservedFiles: string[] = []
 
   for (const file of removedCandidates) {
+    const isPartOfRename = [...renamedOldDirs].some((dir) => file.startsWith(dir))
+    if (isPartOfRename) {
+      removeManagedFile(options.rootDir, file)
+      continue
+    }
+
     if (shouldPreserveManagedFile(options.rootDir, file)) {
       preservedFiles.push(file)
       continue
@@ -71,7 +130,12 @@ export async function syncFromMcp(options: SyncFromMcpOptions): Promise<SyncFrom
     removedFiles.push(file)
   }
 
-  const addedFiles = [...afterManaged].filter((file) => !beforeManaged.has(file))
+  // Step 7: Compute added/updated, excluding files that are part of renames from "added"
+  const addedFiles = [...afterManaged].filter((file) => {
+    if (beforeManaged.has(file)) return false
+    const isPartOfRename = [...renamedNewDirs].some((dir) => file.startsWith(dir))
+    return !isPartOfRename
+  })
   const updatedFiles = [...afterManaged].filter((file) => {
     if (!beforeManaged.has(file)) return false
     const before = beforeContents.get(file)
@@ -88,6 +152,7 @@ export async function syncFromMcp(options: SyncFromMcpOptions): Promise<SyncFrom
     updatedFiles: updatedFiles.sort(),
     removedFiles: removedFiles.sort(),
     preservedFiles: preservedFiles.sort(),
+    renamedFiles: renamedFiles.sort((a, b) => a.from.localeCompare(b.from)),
   }
 }
 
@@ -131,12 +196,169 @@ function pruneEmptyDirectories(rootDir: string, startDir: string): void {
   }
 }
 
+/**
+ * Detect tool renames by comparing old and new tool lists.
+ * Returns a map of oldName -> newName for likely renames.
+ * Only matches 1:1 (each old tool maps to at most one new tool and vice versa).
+ */
+export function detectToolRenames(
+  oldTools: IntrospectedMcpTool[],
+  newTools: IntrospectedMcpTool[],
+): Map<string, string> {
+  const oldNames = new Set(oldTools.map((t) => t.name))
+  const newNames = new Set(newTools.map((t) => t.name))
+
+  // Only consider tools that were removed or added (not tools that stayed the same)
+  const removedTools = oldTools.filter((t) => !newNames.has(t.name))
+  const addedTools = newTools.filter((t) => !oldNames.has(t.name))
+
+  if (removedTools.length === 0 || addedTools.length === 0) {
+    return new Map()
+  }
+
+  // Score all candidate pairs
+  const candidates: Array<{ oldName: string; newName: string; score: number }> = []
+
+  for (const oldTool of removedTools) {
+    for (const newTool of addedTools) {
+      const score = computeRenameScore(oldTool, newTool)
+      if (score >= RENAME_SCORE_THRESHOLD) {
+        candidates.push({ oldName: oldTool.name, newName: newTool.name, score })
+      }
+    }
+  }
+
+  // Greedy 1:1 matching: take best scores first
+  candidates.sort((a, b) => b.score - a.score)
+  const renames = new Map<string, string>()
+  const usedOld = new Set<string>()
+  const usedNew = new Set<string>()
+
+  for (const candidate of candidates) {
+    if (usedOld.has(candidate.oldName) || usedNew.has(candidate.newName)) continue
+    renames.set(candidate.oldName, candidate.newName)
+    usedOld.add(candidate.oldName)
+    usedNew.add(candidate.newName)
+  }
+
+  return renames
+}
+
+const RENAME_SCORE_THRESHOLD = 0.5
+
+function computeRenameScore(oldTool: IntrospectedMcpTool, newTool: IntrospectedMcpTool): number {
+  let score = 0
+  let signals = 0
+
+  // Same description -> high confidence
+  if (oldTool.description && newTool.description) {
+    signals++
+    if (oldTool.description === newTool.description) {
+      score += 1.0
+    } else {
+      // Partial description similarity (Jaccard on words)
+      const oldWords = new Set(oldTool.description.toLowerCase().split(/\s+/))
+      const newWords = new Set(newTool.description.toLowerCase().split(/\s+/))
+      const intersection = [...oldWords].filter((w) => newWords.has(w)).length
+      const union = new Set([...oldWords, ...newWords]).size
+      const jaccard = union > 0 ? intersection / union : 0
+      if (jaccard >= 0.7) {
+        score += 0.6
+      }
+    }
+  }
+
+  // Similar name (edit distance)
+  signals++
+  const distance = levenshteinDistance(oldTool.name, newTool.name)
+  if (distance <= 3) {
+    score += 0.8
+  } else if (distance <= 6 && Math.max(oldTool.name.length, newTool.name.length) > 10) {
+    score += 0.3
+  }
+
+  // Same input schema shape (same required field names)
+  const oldRequired = getRequiredFieldNames(oldTool.inputSchema)
+  const newRequired = getRequiredFieldNames(newTool.inputSchema)
+  if (oldRequired.length > 0 || newRequired.length > 0) {
+    signals++
+    if (oldRequired.length === newRequired.length && oldRequired.every((f) => newRequired.includes(f))) {
+      score += 0.7
+    } else {
+      // Partial overlap
+      const overlap = oldRequired.filter((f) => newRequired.includes(f)).length
+      const total = new Set([...oldRequired, ...newRequired]).size
+      if (total > 0 && overlap / total >= 0.7) {
+        score += 0.4
+      }
+    }
+  }
+
+  // Normalize by number of signals considered
+  return signals > 0 ? score / signals : 0
+}
+
+function getRequiredFieldNames(inputSchema?: Record<string, unknown>): string[] {
+  if (!inputSchema) return []
+  const required = inputSchema.required
+  if (!Array.isArray(required)) return []
+  return required
+    .filter((v): v is string => typeof v === 'string')
+    .sort()
+}
+
+function levenshteinDistance(a: string, b: string): number {
+  const m = a.length
+  const n = b.length
+  const dp: number[][] = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0))
+
+  for (let i = 0; i <= m; i++) dp[i][0] = i
+  for (let j = 0; j <= n; j++) dp[0][j] = j
+
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1
+      dp[i][j] = Math.min(
+        dp[i - 1][j] + 1,
+        dp[i][j - 1] + 1,
+        dp[i - 1][j - 1] + cost,
+      )
+    }
+  }
+
+  return dp[m][n]
+}
+
+/**
+ * Replace the custom content section in a managed markdown file.
+ */
+function injectCustomContent(fileContent: string, customContent: string): string {
+  const customStart = fileContent.indexOf(PLUXX_CUSTOM_START)
+  const customEnd = fileContent.indexOf(PLUXX_CUSTOM_END)
+
+  if (customStart === -1 || customEnd === -1 || customEnd <= customStart) {
+    return fileContent
+  }
+
+  return (
+    fileContent.slice(0, customStart + PLUXX_CUSTOM_START.length) +
+    '\n' +
+    customContent.trim() +
+    '\n' +
+    fileContent.slice(customEnd)
+  )
+}
+
 export function formatSyncSummary(result: SyncFromMcpResult, rootDir: string): string[] {
   const lines = [
     `Synced ${result.toolCount} MCP tool(s).`,
     '',
   ]
 
+  if (result.renamedFiles.length > 0) {
+    lines.push(`Renamed: ${result.renamedFiles.length}`)
+    result.renamedFiles.forEach((rename) => lines.push(`  → ${rename.from} → ${rename.to}`))
+  }
   lines.push(`Added: ${result.addedFiles.length}`)
   result.addedFiles.forEach((file) => lines.push(`  + ${relative(rootDir, resolve(rootDir, file))}`))
   lines.push(`Updated: ${result.updatedFiles.length}`)

--- a/tests/sync-from-mcp.test.ts
+++ b/tests/sync-from-mcp.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { resolve } from 'path'
 import { introspectMcpServer } from '../src/mcp/introspect'
-import { syncFromMcp } from '../src/cli/sync-from-mcp'
+import { detectSkillRenames, detectToolRenames, syncFromMcp } from '../src/cli/sync-from-mcp'
 import { writeMcpScaffold } from '../src/cli/init-from-mcp'
 
 const TEST_DIR = resolve(import.meta.dir, '.sync-from-mcp')
@@ -65,6 +65,59 @@ afterEach(() => {
 })
 
 describe('sync-from-mcp', () => {
+  it('does not treat identical descriptions as a rename without corroborating evidence', () => {
+    const renames = detectToolRenames(
+      [
+        {
+          name: 'SearchCustomers',
+          description: 'Search customer records.',
+        },
+      ],
+      [
+        {
+          name: 'ArchiveInvoices',
+          description: 'Search customer records.',
+        },
+      ],
+    )
+
+    expect(renames.size).toBe(0)
+  })
+
+  it('matches skills 1:1 before transferring custom content', () => {
+    const toolRenames = new Map([
+      ['FindOrganizations', 'SearchOrganizations'],
+      ['FindPeople', 'SearchPeople'],
+    ])
+
+    const skillRenames = detectSkillRenames(
+      [
+        {
+          dirName: 'legacy-organizations',
+          title: 'Legacy Organizations',
+          toolNames: ['FindOrganizations'],
+        },
+        {
+          dirName: 'legacy-people',
+          title: 'Legacy People',
+          toolNames: ['FindPeople'],
+        },
+      ],
+      [
+        {
+          dirName: 'account-research',
+          title: 'Account Research',
+          toolNames: ['SearchOrganizations', 'SearchPeople'],
+        },
+      ],
+      toolRenames,
+    )
+
+    expect(skillRenames.size).toBe(1)
+    expect([...skillRenames.values()]).toEqual(['account-research'])
+    expect([...skillRenames.keys()]).toContain('legacy-organizations')
+  })
+
   it('updates managed MCP-derived files and preserves user-owned files', async () => {
     writeFileSync(
       STATE_PATH,


### PR DESCRIPTION
## Summary
- Adds `detectToolRenames()` that finds renamed MCP tools using description similarity, name edit distance, and schema shape matching
- Transfers custom content from old skill SKILL.md to renamed skill's SKILL.md
- Conservative 1:1 matching with score threshold (0.5) to avoid false positives
- Renamed files excluded from added/removed lists; shown in new "Renamed" summary section
- `renamedFiles` added to `SyncFromMcpResult` interface

## Linear
Addresses PLUXX-40 — smarter rename/change detection in sync diffs.

## Test plan
- [ ] `bun run typecheck` clean
- [ ] Sync after MCP tool rename preserves custom content from old skill
- [ ] Sync summary shows "Renamed" section with arrow notation
- [ ] Similar-but-different tools are not falsely matched as renames
- [ ] Completely new/removed tools still reported correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced tool rename detection during synchronization to identify renamed tools across updates.
  * Custom content in skill files is now preserved and automatically transferred when tools are renamed.
  * Added "Renamed" section to sync summary reports for better visibility into tool changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->