### PR TITLE
Fix Claude hook multiline secret rehydration

### DIFF
--- a/src/generators/shared/claude-family.ts
+++ b/src/generators/shared/claude-family.ts
@@ -51,6 +51,8 @@ function buildClaudeHookCommandWrapperScript(command: string): string {
   const exportLoader = [
     'import { readFileSync } from "node:fs"',
     '',
+    'const shellSingleQuote = (input) => `\'${String(input ?? "").replace(/\'/g, `\'"\'"\'`)}\'`',
+    '',
     'const filepath = process.argv[1]',
     'if (!filepath) process.exit(0)',
     'const payload = JSON.parse(readFileSync(filepath, "utf8"))',
@@ -60,7 +62,7 @@ function buildClaudeHookCommandWrapperScript(command: string): string {
     '',
     'for (const [key, value] of Object.entries(env)) {',
     '  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue',
-    '  console.log(`export ${key}=${JSON.stringify(String(value ?? ""))}`)',
+    '  process.stdout.write(`export ${key}=${shellSingleQuote(value)}\\0`)',
     '}',
   ].join('\n')
 
@@ -72,11 +74,11 @@ function buildClaudeHookCommandWrapperScript(command: string): string {
     'PLUXX_USER_CONFIG_PATH="$PLUXX_PLUGIN_ROOT/.pluxx-user.json"',
     '',
     'if [ -f "$PLUXX_USER_CONFIG_PATH" ]; then',
-    '  while IFS= read -r pluxx_export; do',
+    '  while IFS= read -r -d \'\' pluxx_export; do',
     '    if [ -n "$pluxx_export" ]; then',
     '      eval "$pluxx_export"',
     '      if [ -n "${CLAUDE_ENV_FILE:-}" ]; then',
-    '        printf \'%s\\n\' "$pluxx_export" >> "$CLAUDE_ENV_FILE"',
+        '        printf \'%s\\n\' "$pluxx_export" >> "$CLAUDE_ENV_FILE"',
     '      fi',
     '    fi',
     '  done < <(',

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -420,6 +420,7 @@ describe('build', () => {
   })
 
   it('wraps Claude hook commands so installed userConfig env reaches SessionStart hooks and child processes', async () => {
+    const multilineSecret = 'secret-token\nline-two'
     const hookEnvConfig: PluginConfig = {
       ...testConfig,
       name: 'hook-env-plugin',
@@ -449,7 +450,7 @@ describe('build', () => {
         '  console.error("missing env")',
         '  process.exit(1)',
         '}',
-        'console.log(process.env.SENDLENS_INSTANTLY_API_KEY)',
+        'process.stdout.write(JSON.stringify(process.env.SENDLENS_INSTANTLY_API_KEY))',
       ].join('\n'),
     )
 
@@ -472,10 +473,10 @@ describe('build', () => {
       resolve(TEST_DIR, 'hook-env-dist/claude-code/.pluxx-user.json'),
       JSON.stringify({
         values: {
-          'sendlens-instantly-api-key': 'secret-token',
+          'sendlens-instantly-api-key': multilineSecret,
         },
         env: {
-          SENDLENS_INSTANTLY_API_KEY: 'secret-token',
+          SENDLENS_INSTANTLY_API_KEY: multilineSecret,
         },
       }, null, 2),
     )
@@ -492,10 +493,23 @@ describe('build', () => {
     })
 
     expect(run.status).toBe(0)
-    expect(run.stdout.trim()).toBe('secret-token')
-    expect(readFileSync(resolve(TEST_DIR, 'hook-env-dist/claude-code/.claude-env.sh'), 'utf-8')).toContain(
-      'export SENDLENS_INSTANTLY_API_KEY="secret-token"',
-    )
+    expect(run.stdout).toBe(JSON.stringify(multilineSecret))
+
+    const sourcedEnv = spawnSync('bash', [
+      '-lc',
+      'source "$1" && node -e \'process.stdout.write(JSON.stringify(process.env.SENDLENS_INSTANTLY_API_KEY ?? ""))\'',
+      'pluxx-env-check',
+      resolve(TEST_DIR, 'hook-env-dist/claude-code/.claude-env.sh'),
+    ], {
+      cwd: resolve(TEST_DIR, 'hook-env-dist/claude-code'),
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+      },
+    })
+
+    expect(sourcedEnv.status).toBe(0)
+    expect(sourcedEnv.stdout).toBe(JSON.stringify(multilineSecret))
   })
 
   it('carries a rich Claude-style skill fixture and supporting files into all core-four outputs', async () => {


### PR DESCRIPTION
## Summary
- preserve literal newlines when rehydrating saved `.pluxx-user.json` env into Claude hook shells
- switch the generated export stream to NUL-delimited single-quoted shell assignments
- extend the Claude hook wrapper regression test to round-trip a multiline secret through both the hook process and `CLAUDE_ENV_FILE`

## Problem
PR #251 fixed installed Claude hook env rehydration for single-line secrets, but the export serialization path corrupted multiline values such as PEM keys and certificates. That meant installed `SessionStart` hooks could still diverge from the MCP/runtime path when plugin-owned env contained real newlines.

## Testing
- `npm test -- --run tests/build.test.ts`
- `npm test -- --run tests/install.test.ts`
- `npm test -- --run tests/verify-install.test.ts`
- `npm run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment variable export generation to reliably handle special characters and multiline secrets
  * Fixed conditional block nesting in environment configuration file operations to ensure proper execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->