### PR TITLE
Harden Claude local runtime install contracts

### DIFF
--- a/docs/core-four-install-update-lifecycle.md
+++ b/docs/core-four-install-update-lifecycle.md
@@ -1,6 +1,6 @@
 # Core-Four Install And Update Lifecycle
 
-Last updated: 2026-04-28
+Last updated: 2026-04-30
 
 This doc explains the practical install, update, and reload behavior for the four primary Pluxx targets:
 
@@ -65,6 +65,51 @@ When a Pluxx-generated Codex plugin includes `.mcp.json`, Codex may display that
 - confirm tools are visible from the plugin inside chat
 
 If a Codex plugin-owned MCP needs an API key, install-time `userConfig` is the expected Pluxx path. Codex may not provide a global MCP settings form for that plugin-owned secret, so reinstall with the real env var exported or rerun the installer interactively. Generated `pluxx publish` installer scripts should prompt consumers for required secrets, materialize them into the installed bundle, reject obvious placeholder values, and let `doctor --consumer` warn if an older install contains one.
+
+## Installer-Owned Runtime Scripts
+
+Some files are intentionally installer-owned after a local install.
+
+The most important current example is:
+
+- `scripts/check-env.sh`
+
+When Pluxx materializes required `userConfig` into an installed local bundle, install rewrites `scripts/check-env.sh` into a no-op marker file.
+
+That means plugin runtime must not depend on sourcing or chaining through `scripts/check-env.sh` for critical startup behavior.
+
+Treat it as:
+
+- install-time validation only
+- mutable after install
+- unsafe as a runtime dependency for MCP startup or richer startup hooks
+
+This now exists as an explicit product contract because SendLens failed in Claude after install when runtime startup still sourced `check-env.sh` even though install had already rewritten it.
+
+## Claude Local Stdio Runtime Contract
+
+Claude Code should not be treated as guaranteeing plugin-root cwd for stdio MCP launch.
+
+For project-local Claude stdio runtimes, the generated `.mcp.json` should anchor runtime paths under `${CLAUDE_PLUGIN_ROOT}` instead of assuming relative `./...` paths will resolve from the plugin root after install.
+
+The practical rule is:
+
+- relative source paths in a Pluxx project are fine
+- generated Claude bundle output should be plugin-root anchored for local stdio runtime paths
+- plugin authors should reason about installed Claude runtime using `${CLAUDE_PLUGIN_ROOT}`, not cwd assumptions
+
+## Portable Native Runtime Pattern
+
+If a plugin needs native Node dependencies such as `@duckdb/node-api`, do not assume a CI-built `node_modules` tree is portable across user machines.
+
+The safer pattern is:
+
+- `load-env.sh` for runtime env loading
+- `bootstrap-runtime.sh` for first-run local native dependency install
+- `start-mcp.sh` as the MCP entrypoint
+- no runtime dependence on installer-mutated `check-env.sh`
+
+This is the pattern that stabilized SendLens on macOS after the earlier Linux-built `node_modules` release failed to run with DuckDB native bindings.
 
 ## What Pluxx Should Emit
 

--- a/docs/create-a-pluxx-plugin.md
+++ b/docs/create-a-pluxx-plugin.md
@@ -132,6 +132,8 @@ npx @orchid-labs/pluxx init \
 
 If the stdio command points at a project-relative runtime such as `./build/index.js`, Pluxx now infers the parent runtime directory into `passthrough` automatically. That matters because installed host bundles need both the MCP config and the executable payload, not just the config.
 
+For Claude Code specifically, generated local stdio MCP bundle output should treat plugin-root anchoring as the runtime contract. In practice, installed Claude bundles should use `${CLAUDE_PLUGIN_ROOT}` for project-local stdio runtime paths rather than assuming Claude will launch the MCP with plugin-root cwd.
+
 ### 4. Inspect the scaffold
 
 You should now have a source repo that looks roughly like:
@@ -232,6 +234,25 @@ Important:
 - the editable source of truth is the root project
 - `dist/` is generated output
 - do not hand-edit `dist/` unless you are debugging a generator
+
+### Runtime Pattern For Native Node Dependencies
+
+If your plugin needs platform-native Node dependencies such as `@duckdb/node-api`, do not rely on shipping one prebuilt `node_modules` tree from CI and assuming it will run everywhere.
+
+Use a split runtime pattern instead:
+
+- `load-env.sh`
+- `bootstrap-runtime.sh`
+- `start-mcp.sh`
+
+Recommended contract:
+
+- `load-env.sh` loads runtime env and plugin-owned secrets
+- `bootstrap-runtime.sh` installs or repairs native runtime dependencies locally on first run
+- `start-mcp.sh` is the MCP entrypoint that launches the real server
+- `scripts/check-env.sh` remains install-time validation only and must not be part of the runtime startup chain
+
+This is the portable pattern that resolved SendLens after the original release shipped Linux-built `node_modules` that were not portable to macOS DuckDB bindings.
 
 ### 9. Install and test one host first
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -92,6 +92,9 @@ The closure plan is now narrower than it was before:
   - `init --from-mcp` auto-recovers `passthrough` for project-relative runtimes such as `./build/index.js`
   - `lint` catches unbundled stdio runtime payloads earlier
   - `doctor --consumer` now makes broken installed `.mcp.json` runtime references obvious
+  - Claude-generated local stdio MCP output now anchors project-local runtime paths under `${CLAUDE_PLUGIN_ROOT}` instead of assuming plugin-root cwd
+  - `lint` now warns when MCP startup or custom runtime hooks depend on installer-owned `scripts/check-env.sh`
+  - the recommended native-runtime pattern now explicitly splits `load-env.sh`, `bootstrap-runtime.sh`, and `start-mcp.sh`
 - installed MCP discovery now closes the adjacent "I already configured this MCP in a host" path:
   - `pluxx discover-mcp` lists configured MCP servers from Claude Code, Cursor, Codex, and OpenCode config locations
   - `pluxx init --from-installed-mcp <host:name>` imports the selected MCP into a maintained Pluxx source project

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -181,6 +181,9 @@ The repo already proves a lot.
   - `init --from-mcp` infers `passthrough` directories for project-relative stdio runtimes such as `./build/index.js`
   - `lint` now warns when a local stdio runtime will not be bundled into installed outputs
   - `doctor --consumer` now warns when an installed bundle's `.mcp.json` points at missing stdio runtime files
+  - Claude-generated local stdio MCP config now anchors project-local runtime paths under `${CLAUDE_PLUGIN_ROOT}` instead of assuming plugin-root cwd after install
+  - `lint` now warns if MCP startup or custom runtime hooks depend on installer-owned `scripts/check-env.sh`, which local install may rewrite into a no-op after config materialization
+  - the docs now capture a portable native-runtime pattern for plugins that need first-run local bootstrap scripts such as `load-env.sh`, `bootstrap-runtime.sh`, and `start-mcp.sh`
 - installed MCP discovery is now a first-class import path:
   - `pluxx discover-mcp` lists MCP servers already configured in Claude Code, Cursor, Codex, and OpenCode
   - `pluxx init --from-installed-mcp <host:name>` turns one discovered server into a Pluxx source project

--- a/docs/todo/master-backlog.md
+++ b/docs/todo/master-backlog.md
@@ -106,6 +106,9 @@ Any person or agent should be able to enter the repo and answer:
   - `init --from-mcp` now infers `passthrough` for project-relative runtimes like `./build/index.js`
   - `lint` now warns when a local stdio runtime is not bundled into passthrough
   - `doctor --consumer` now warns when installed `.mcp.json` files reference missing stdio runtime payloads
+  - Claude-generated local stdio MCP output now anchors project-local runtime paths under `${CLAUDE_PLUGIN_ROOT}` instead of assuming plugin-root cwd
+  - `lint` now warns when MCP startup or custom runtime hooks depend on installer-owned `scripts/check-env.sh`
+  - docs now capture the portable `load-env.sh` / `bootstrap-runtime.sh` / `start-mcp.sh` pattern for native Node runtime dependencies
 - [x] Add installed MCP discovery for the common "I already configured this MCP in my agent" workflow:
   - `pluxx discover-mcp` reads Claude Code, Cursor, Codex, and OpenCode config locations
   - `pluxx init --from-installed-mcp <host:name>` imports a selected discovered server into a Pluxx project

--- a/docs/todo/queue.md
+++ b/docs/todo/queue.md
@@ -83,6 +83,9 @@ The core-four compiler sprint is done.
   - `init --from-mcp` infers `passthrough` for project-relative runtimes like `./build/index.js`
   - `lint` warns when a local stdio runtime is not bundled into passthrough
   - `doctor --consumer` warns when installed `.mcp.json` files reference missing stdio runtime payloads
+  - Claude-generated local stdio MCP output now anchors project-local runtime paths under `${CLAUDE_PLUGIN_ROOT}`
+  - `lint` warns when MCP startup or custom runtime hooks depend on installer-owned `scripts/check-env.sh`
+  - the install/runtime docs now recommend the `load-env.sh` + `bootstrap-runtime.sh` + `start-mcp.sh` split pattern for native Node deps
 - installed MCP discovery is now a first-class import path:
   - `pluxx discover-mcp` reads Claude Code, Cursor, Codex, and OpenCode config locations
   - `pluxx init --from-installed-mcp <host:name>` imports a selected discovered server into a Pluxx project

--- a/src/cli/lint.ts
+++ b/src/cli/lint.ts
@@ -82,6 +82,12 @@ const MAX_SKILL_NAME = AGENT_SKILLS_RULES.name.maxLength
 const MAX_CODEX_DEFAULT_PROMPTS = CODEX_RULES.interface.maxDefaultPrompts
 const MAX_CODEX_PROMPT_LENGTH = CODEX_RULES.interface.maxDefaultPromptLength
 const HEX_COLOR_REGEX = CODEX_RULES.interface.brandColorPattern
+const DIRECT_INSTALL_VALIDATION_HOOKS = new Set([
+  'bash "${PLUGIN_ROOT}/scripts/check-env.sh"',
+  'bash "${CLAUDE_PLUGIN_ROOT}/scripts/check-env.sh"',
+  'bash "${CURSOR_PLUGIN_ROOT}/scripts/check-env.sh"',
+  'bash "./scripts/check-env.sh"',
+])
 
 function pushIssue(issues: LintIssue[], issue: LintIssue): void {
   issues.push(issue)
@@ -634,6 +640,50 @@ function isLikelyLocalRuntimePath(value: string): boolean {
     || value.startsWith('../')
     || value.startsWith('.\\')
     || value.startsWith('..\\')
+}
+
+function referencesInstallerOwnedCheckEnv(command: string): boolean {
+  return command.includes('check-env.sh')
+}
+
+function lintInstallerOwnedRuntimeScripts(config: PluginConfig, issues: LintIssue[]): void {
+  if (config.mcp) {
+    for (const [serverName, server] of Object.entries(config.mcp)) {
+      if (server.transport !== 'stdio') continue
+
+      const runtimeTokens = [server.command, ...(server.args ?? [])]
+      if (!runtimeTokens.some((token) => referencesInstallerOwnedCheckEnv(token))) continue
+
+      pushIssue(issues, {
+        level: 'warning',
+        code: 'installer-owned-check-env-runtime',
+        message: `MCP server "${serverName}" references scripts/check-env.sh in its runtime command or args. Pluxx install rewrites that file into a no-op after userConfig materialization, so runtime startup must not depend on it. Use separate runtime scripts such as load-env.sh, bootstrap-runtime.sh, and start-mcp.sh instead.`,
+        file: 'pluxx.config.ts',
+        platform: 'Runtime',
+      })
+    }
+  }
+
+  if (!config.hooks) return
+
+  for (const [eventName, hookEntries] of Object.entries(config.hooks)) {
+    if (!Array.isArray(hookEntries)) continue
+
+    for (const entry of hookEntries) {
+      if (!entry || typeof entry !== 'object') continue
+      const command = (entry as Record<string, unknown>).command
+      if (typeof command !== 'string' || !referencesInstallerOwnedCheckEnv(command)) continue
+      if (DIRECT_INSTALL_VALIDATION_HOOKS.has(command.trim())) continue
+
+      pushIssue(issues, {
+        level: 'warning',
+        code: 'installer-owned-check-env-hook',
+        message: `Hook "${eventName}" references scripts/check-env.sh as part of a broader runtime command. Treat that script as installer-owned and install-time only, because local installs may rewrite it into a no-op after required config is materialized.`,
+        file: 'pluxx.config.ts',
+        platform: 'Runtime',
+      })
+    }
+  }
 }
 
 function lintCodexHookCompatibility(config: PluginConfig, issues: LintIssue[]): void {
@@ -1487,6 +1537,7 @@ export async function lintProject(
   // MCP and brand
   lintMcpUrls(lintConfig, issues)
   lintMcpRuntimeState(dir, lintConfig, issues)
+  lintInstallerOwnedRuntimeScripts(lintConfig, issues)
   lintBrandMetadata(lintConfig, issues)
   lintCodexOverrides(lintConfig, issues)
   lintCodexHookCompatibility(lintConfig, issues)

--- a/src/generators/shared/claude-family.ts
+++ b/src/generators/shared/claude-family.ts
@@ -46,6 +46,21 @@ function shellSingleQuote(value: string): string {
   return `'${value.replace(/'/g, `'\"'\"'`)}'`
 }
 
+function rewriteClaudePluginRootReference(value: string): string {
+  const normalized = value.replace(/\\/g, '/')
+  if (normalized.startsWith('${CLAUDE_PLUGIN_ROOT}/')) return normalized
+  if (normalized.startsWith('${PLUGIN_ROOT}/')) {
+    return normalized.replace('${PLUGIN_ROOT}', '${CLAUDE_PLUGIN_ROOT}')
+  }
+  if (normalized.startsWith('./')) {
+    return `\${CLAUDE_PLUGIN_ROOT}/${normalized.slice(2)}`
+  }
+  if (normalized.startsWith('../')) {
+    return `\${CLAUDE_PLUGIN_ROOT}/${normalized}`
+  }
+  return value
+}
+
 function buildClaudeHookCommandWrapperScript(command: string): string {
   const serializedCommand = shellSingleQuote(command)
   const exportLoader = [
@@ -149,9 +164,16 @@ async function writeMcpConfig(
 
   for (const [name, server] of Object.entries(config.mcp)) {
     if (server.transport === 'stdio' && server.command) {
+      const command = platform === 'claude-code'
+        ? rewriteClaudePluginRootReference(server.command)
+        : server.command
+      const args = platform === 'claude-code'
+        ? (server.args ?? []).map(rewriteClaudePluginRootReference)
+        : (server.args ?? [])
+
       mcpServers[name] = {
-        command: server.command,
-        args: server.args ?? [],
+        command,
+        args,
         env: server.env ?? {},
       }
     } else {

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -605,7 +605,7 @@ describe('build', () => {
 
     expect(claudeMcp.mcpServers['local-server']).toEqual({
       command: 'node',
-      args: ['./mcp-server/dist/index.js', '--stdio'],
+      args: ['${CLAUDE_PLUGIN_ROOT}/mcp-server/dist/index.js', '--stdio'],
       env: {
         LOCAL_FIXTURE_TOKEN: '${LOCAL_FIXTURE_TOKEN}',
       },

--- a/tests/lint.test.ts
+++ b/tests/lint.test.ts
@@ -190,6 +190,69 @@ describe('lintProject', () => {
     expect(result.issues.some(issue => issue.code === 'mcp-stdio-runtime-unbundled')).toBe(true)
   })
 
+  it('warns when stdio runtime startup depends on installer-owned check-env.sh', async () => {
+    const projectDir = createTempProject()
+    mkdirSync(resolve(projectDir, 'skills/my-skill'), { recursive: true })
+
+    writeFileSync(
+      resolve(projectDir, 'pluxx.config.json'),
+      JSON.stringify({
+        name: 'test-plugin',
+        version: '0.1.0',
+        description: 'test',
+        author: { name: 'Test Author' },
+        skills: './skills/',
+        targets: ['claude-code'],
+        mcp: {
+          localRuntime: {
+            transport: 'stdio',
+            command: 'bash',
+            args: ['./scripts/check-env.sh'],
+          },
+        },
+      }, null, 2),
+    )
+
+    writeFileSync(
+      resolve(projectDir, 'skills/my-skill/SKILL.md'),
+      ['---', 'name: my-skill', 'description: "A valid skill description"', '---', '', '# My Skill'].join('\n'),
+    )
+
+    const result = await lintProject(projectDir)
+    expect(result.issues.some(issue => issue.code === 'installer-owned-check-env-runtime')).toBe(true)
+  })
+
+  it('does not warn for the direct install-time check-env hook scaffold', async () => {
+    const projectDir = createTempProject()
+    mkdirSync(resolve(projectDir, 'skills/my-skill'), { recursive: true })
+
+    writeFileSync(
+      resolve(projectDir, 'pluxx.config.json'),
+      JSON.stringify({
+        name: 'test-plugin',
+        version: '0.1.0',
+        description: 'test',
+        author: { name: 'Test Author' },
+        skills: './skills/',
+        targets: ['claude-code'],
+        hooks: {
+          sessionStart: [{
+            type: 'command',
+            command: 'bash "${PLUGIN_ROOT}/scripts/check-env.sh"',
+          }],
+        },
+      }, null, 2),
+    )
+
+    writeFileSync(
+      resolve(projectDir, 'skills/my-skill/SKILL.md'),
+      ['---', 'name: my-skill', 'description: "A valid skill description"', '---', '', '# My Skill'].join('\n'),
+    )
+
+    const result = await lintProject(projectDir)
+    expect(result.issues.some(issue => issue.code === 'installer-owned-check-env-hook')).toBe(false)
+  })
+
   it('reports skill-description-truncation warning for display max', async () => {
     const projectDir = createTempProject()
     mkdirSync(resolve(projectDir, 'skills/my-skill'), { recursive: true })


### PR DESCRIPTION
## Summary
- anchor Claude local stdio MCP runtime paths under `${CLAUDE_PLUGIN_ROOT}` in generated `.mcp.json`
- add lint warnings when MCP startup or broader runtime hooks depend on installer-owned `scripts/check-env.sh`
- document the portable `load-env.sh` + `bootstrap-runtime.sh` + `start-mcp.sh` pattern for native Node runtime dependencies
- update the repo source-of-truth docs to reflect the shipped Claude/runtime contract

## Why
- `PLUXX-206`: local installs can rewrite `scripts/check-env.sh` into a no-op after userConfig materialization, so runtime startup must not depend on it
- `PLUXX-207`: Claude stdio MCP startup should not assume plugin-root cwd; generated local runtime paths need plugin-root anchoring
- `PLUXX-208`: plugins with native Node deps need a documented portable runtime pattern instead of assuming a CI-built `node_modules` tree will run everywhere

## Testing
- `npm test -- --run tests/build.test.ts`
- `npm test -- --run tests/lint.test.ts`
- `npm run typecheck`

Closes PLUXX-206
Closes PLUXX-207
Closes PLUXX-208

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified MCP local stdio runtime path anchoring and portability contracts
  * Added guidance for native Node dependency bootstrap patterns
  * Updated roadmap with local-stdio quality criteria

* **New Features**
  * Added lint warnings for unsafe installer-owned dependencies in MCP startup and custom hooks

* **Bug Fixes**
  * Improved path resolution for Claude Code MCP configurations to use consistent runtime anchoring

<!-- end of auto-generated comment: release notes by coderabbit.ai -->