### PR TITLE
Warn when host branding metadata is missing

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -95,6 +95,9 @@ The closure plan is now narrower than it was before:
   - Claude-generated local stdio MCP output now anchors project-local runtime paths under `${CLAUDE_PLUGIN_ROOT}` instead of assuming plugin-root cwd
   - `lint` now warns when MCP startup or custom runtime hooks depend on installer-owned `scripts/check-env.sh`
   - the recommended native-runtime pattern now explicitly splits `load-env.sh`, `bootstrap-runtime.sh`, and `start-mcp.sh`
+- host-visible branding completeness is now surfaced earlier:
+  - `lint` warns when Cursor or Codex can render richer branding but the plugin is missing `brand.icon` and/or `brand.screenshots`
+  - `doctor` surfaces the same source-project warning before a plugin is treated as finished
 - installed MCP discovery now closes the adjacent "I already configured this MCP in a host" path:
   - `pluxx discover-mcp` lists configured MCP servers from Claude Code, Cursor, Codex, and OpenCode config locations
   - `pluxx init --from-installed-mcp <host:name>` imports the selected MCP into a maintained Pluxx source project

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -184,6 +184,9 @@ The repo already proves a lot.
   - Claude-generated local stdio MCP config now anchors project-local runtime paths under `${CLAUDE_PLUGIN_ROOT}` instead of assuming plugin-root cwd after install
   - `lint` now warns if MCP startup or custom runtime hooks depend on installer-owned `scripts/check-env.sh`, which local install may rewrite into a no-op after config materialization
   - the docs now capture a portable native-runtime pattern for plugins that need first-run local bootstrap scripts such as `load-env.sh`, `bootstrap-runtime.sh`, and `start-mcp.sh`
+- host-visible branding completeness is now surfaced earlier:
+  - `lint` warns when Cursor or Codex can render richer branding but the plugin is missing `brand.icon` and/or `brand.screenshots`
+  - `doctor` now surfaces the same source-project warning before a plugin is treated as finished
 - installed MCP discovery is now a first-class import path:
   - `pluxx discover-mcp` lists MCP servers already configured in Claude Code, Cursor, Codex, and OpenCode
   - `pluxx init --from-installed-mcp <host:name>` turns one discovered server into a Pluxx source project

--- a/docs/todo/master-backlog.md
+++ b/docs/todo/master-backlog.md
@@ -109,6 +109,9 @@ Any person or agent should be able to enter the repo and answer:
   - Claude-generated local stdio MCP output now anchors project-local runtime paths under `${CLAUDE_PLUGIN_ROOT}` instead of assuming plugin-root cwd
   - `lint` now warns when MCP startup or custom runtime hooks depend on installer-owned `scripts/check-env.sh`
   - docs now capture the portable `load-env.sh` / `bootstrap-runtime.sh` / `start-mcp.sh` pattern for native Node runtime dependencies
+- [x] Surface host-visible branding gaps earlier in author workflows:
+  - `lint` now warns when Cursor or Codex can render richer branding but the plugin is missing `brand.icon` and/or `brand.screenshots`
+  - `doctor` now surfaces the same source-project warning before a plugin is treated as finished
 - [x] Add installed MCP discovery for the common "I already configured this MCP in my agent" workflow:
   - `pluxx discover-mcp` reads Claude Code, Cursor, Codex, and OpenCode config locations
   - `pluxx init --from-installed-mcp <host:name>` imports a selected discovered server into a Pluxx project

--- a/docs/todo/queue.md
+++ b/docs/todo/queue.md
@@ -86,6 +86,9 @@ The core-four compiler sprint is done.
   - Claude-generated local stdio MCP output now anchors project-local runtime paths under `${CLAUDE_PLUGIN_ROOT}`
   - `lint` warns when MCP startup or custom runtime hooks depend on installer-owned `scripts/check-env.sh`
   - the install/runtime docs now recommend the `load-env.sh` + `bootstrap-runtime.sh` + `start-mcp.sh` split pattern for native Node deps
+- host-visible branding completeness is now surfaced earlier:
+  - `lint` warns when Cursor or Codex can render richer branding but the plugin is missing `brand.icon` and/or `brand.screenshots`
+  - `doctor` now surfaces the same source-project warning before a plugin is treated as finished
 - installed MCP discovery is now a first-class import path:
   - `pluxx discover-mcp` reads Claude Code, Cursor, Codex, and OpenCode config locations
   - `pluxx init --from-installed-mcp <host:name>` imports a selected discovered server into a Pluxx project

--- a/src/branding-completeness.ts
+++ b/src/branding-completeness.ts
@@ -1,0 +1,73 @@
+import type { PluginConfig } from './schema'
+
+export interface BrandingCompletenessWarning {
+  code: string
+  platform: string
+  title: string
+  message: string
+  fix: string
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  return value as Record<string, unknown>
+}
+
+function hasNonEmptyString(value: unknown): boolean {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+function hasNonEmptyStringArray(value: unknown): boolean {
+  return Array.isArray(value) && value.some((entry) => hasNonEmptyString(entry))
+}
+
+export function getBrandingCompletenessWarnings(config: PluginConfig): BrandingCompletenessWarning[] {
+  const warnings: BrandingCompletenessWarning[] = []
+  const codexInterface = asRecord(config.platforms?.codex?.interface)
+
+  if (config.targets.includes('codex')) {
+    const codexHasIcon = hasNonEmptyString(config.brand?.icon)
+      || hasNonEmptyString(codexInterface?.composerIcon)
+      || hasNonEmptyString(codexInterface?.logo)
+    const codexHasScreenshots = hasNonEmptyStringArray(config.brand?.screenshots)
+      || hasNonEmptyStringArray(codexInterface?.screenshots)
+
+    if (!codexHasIcon && !codexHasScreenshots) {
+      warnings.push({
+        code: 'codex-branding-metadata-missing',
+        platform: 'Codex',
+        title: 'Codex branding metadata is incomplete',
+        message: 'Codex supports icon/logo and screenshots, but this plugin will fall back to generic iconography and ship without screenshots because `brand.icon` and `brand.screenshots` are missing.',
+        fix: 'Declare `brand.icon` and `brand.screenshots` in pluxx.config.ts, or add equivalent `platforms.codex.interface` overrides if you need a host-specific exception.',
+      })
+    } else if (!codexHasIcon) {
+      warnings.push({
+        code: 'codex-branding-metadata-missing',
+        platform: 'Codex',
+        title: 'Codex branding metadata is incomplete',
+        message: 'Codex supports composer icon/logo metadata, but this plugin will fall back to generic host visuals because `brand.icon` is missing.',
+        fix: 'Declare `brand.icon` in pluxx.config.ts, or add `platforms.codex.interface.composerIcon` / `logo` if you need a host-specific exception.',
+      })
+    } else if (!codexHasScreenshots) {
+      warnings.push({
+        code: 'codex-branding-metadata-missing',
+        platform: 'Codex',
+        title: 'Codex branding metadata is incomplete',
+        message: 'Codex supports screenshots in the plugin detail surface, but this plugin will ship without them because `brand.screenshots` is missing.',
+        fix: 'Declare `brand.screenshots` in pluxx.config.ts, or add `platforms.codex.interface.screenshots` if you need a host-specific exception.',
+      })
+    }
+  }
+
+  if (config.targets.includes('cursor') && !hasNonEmptyString(config.brand?.icon)) {
+    warnings.push({
+      code: 'cursor-branding-metadata-missing',
+      platform: 'Cursor',
+      title: 'Cursor branding metadata is incomplete',
+      message: 'Cursor supports logo metadata in the plugin manifest, but this plugin will fall back to generic host visuals because `brand.icon` is missing.',
+      fix: 'Declare `brand.icon` in pluxx.config.ts so Pluxx can emit Cursor logo metadata.',
+    })
+  }
+
+  return warnings
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -8,6 +8,7 @@ import { PLUXX_COMPILER_INTENT_PATH, readCompilerIntent } from '../compiler-inte
 import { MCP_SCAFFOLD_METADATA_PATH, type McpScaffoldMetadata } from './init-from-mcp'
 import { buildPrimitiveTranslationSummary, renderPrimitiveTranslationSummary, type PrimitiveTranslationSummary } from './primitive-summary'
 import { isPlaceholderSecretValue } from '../user-config'
+import { getBrandingCompletenessWarnings } from '../branding-completeness'
 
 export type DoctorLevel = 'error' | 'warning' | 'info' | 'success'
 
@@ -442,6 +443,19 @@ function checkHookTrust(checks: DoctorCheck[], config: PluginConfig): void {
     fix: 'Review the commands carefully. Users will need to opt in with pluxx install --trust.',
     path: 'pluxx.config.ts',
   })
+}
+
+function checkBrandMetadataCompleteness(checks: DoctorCheck[], config: PluginConfig): void {
+  for (const warning of getBrandingCompletenessWarnings(config)) {
+    addCheck(checks, {
+      level: 'warning',
+      code: warning.code,
+      title: warning.title,
+      detail: warning.message,
+      fix: warning.fix,
+      path: 'pluxx.config.ts',
+    })
+  }
 }
 
 function isSafeManagedPath(path: string): boolean {
@@ -1302,6 +1316,7 @@ export async function doctorProject(rootDir: string = process.cwd()): Promise<Do
   checkScaffoldMetadata(checks, rootDir, config)
   checkCompilerIntent(checks, rootDir)
   checkHookTrust(checks, config)
+  checkBrandMetadataCompleteness(checks, config)
 
   for (const target of config.targets) {
     const limits = PLATFORM_LIMITS[target]

--- a/src/cli/lint.ts
+++ b/src/cli/lint.ts
@@ -6,6 +6,7 @@ import { PLATFORM_LIMITS, PLATFORM_LIMIT_POLICIES, getCoreFourPrimitiveCapabilit
 import { collectPermissionRules, permissionRulesNeedToolLevelDowngrade } from '../permissions'
 import { readCanonicalAgentFiles } from '../agents'
 import { buildPrimitiveTranslationSummary, renderPrimitiveTranslationSummary, type PrimitiveTranslationSummary } from './primitive-summary'
+import { getBrandingCompletenessWarnings } from '../branding-completeness'
 import {
   CURSOR_LOOP_LIMIT_HOOK_EVENTS,
   CURSOR_SUPPORTED_HOOK_EVENTS,
@@ -343,9 +344,7 @@ function lintSkillFile(
 }
 
 function lintBrandMetadata(config: PluginConfig, issues: LintIssue[]): void {
-  if (!config.brand) return
-
-  if (config.brand.color && !HEX_COLOR_REGEX.test(config.brand.color)) {
+  if (config.brand?.color && !HEX_COLOR_REGEX.test(config.brand.color)) {
     pushIssue(issues, {
       level: 'error',
       code: 'brand-color-hex',
@@ -355,7 +354,7 @@ function lintBrandMetadata(config: PluginConfig, issues: LintIssue[]): void {
     })
   }
 
-  if (config.brand.defaultPrompts) {
+  if (config.brand?.defaultPrompts) {
     if (config.brand.defaultPrompts.length > MAX_CODEX_DEFAULT_PROMPTS) {
       pushIssue(issues, {
         level: 'error',
@@ -377,6 +376,16 @@ function lintBrandMetadata(config: PluginConfig, issues: LintIssue[]): void {
         })
       }
     }
+  }
+
+  for (const warning of getBrandingCompletenessWarnings(config)) {
+    pushIssue(issues, {
+      level: 'warning',
+      code: warning.code,
+      message: warning.message,
+      file: 'pluxx.config.ts',
+      platform: warning.platform,
+    })
   }
 }
 

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -402,6 +402,32 @@ describe('doctorProject', () => {
     }
   })
 
+  it('warns when host-supported branding metadata is absent', async () => {
+    const dir = createProjectFixture()
+    writeFileSync(
+      resolve(dir, 'pluxx.config.json'),
+      JSON.stringify({
+        name: 'doctor-fixture',
+        version: '0.1.0',
+        description: 'Doctor fixture',
+        author: { name: 'Test Author' },
+        skills: './skills/',
+        targets: ['cursor', 'codex'],
+        brand: {
+          displayName: 'Doctor Fixture',
+        },
+      }, null, 2),
+    )
+
+    try {
+      const report = await doctorProject(dir)
+      expect(report.checks.some((check) => check.code === 'cursor-branding-metadata-missing' && check.level === 'warning')).toBe(true)
+      expect(report.checks.some((check) => check.code === 'codex-branding-metadata-missing' && check.level === 'warning')).toBe(true)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
   it('prints stable JSON from the CLI', async () => {
     const dir = createProjectFixture()
 

--- a/tests/lint.test.ts
+++ b/tests/lint.test.ts
@@ -35,6 +35,8 @@ describe('lintProject', () => {
         brand: {
           displayName: 'Valid Plugin',
           color: '#12AB34',
+          icon: './assets/icon.svg',
+          screenshots: ['./assets/screenshots/overview.svg'],
           defaultPrompts: ['Prompt 1', 'Prompt 2'],
         },
         mcp: {
@@ -220,6 +222,95 @@ describe('lintProject', () => {
 
     const result = await lintProject(projectDir)
     expect(result.issues.some(issue => issue.code === 'installer-owned-check-env-runtime')).toBe(true)
+  })
+
+  it('warns when Codex target is missing richer branding metadata', async () => {
+    const projectDir = createTempProject()
+    mkdirSync(resolve(projectDir, 'skills/my-skill'), { recursive: true })
+
+    writeFileSync(
+      resolve(projectDir, 'pluxx.config.json'),
+      JSON.stringify({
+        name: 'test-plugin',
+        version: '0.1.0',
+        description: 'test',
+        author: { name: 'Test Author' },
+        skills: './skills/',
+        targets: ['codex'],
+        brand: {
+          displayName: 'Test Plugin',
+        },
+      }, null, 2),
+    )
+
+    writeFileSync(
+      resolve(projectDir, 'skills/my-skill/SKILL.md'),
+      ['---', 'name: my-skill', 'description: "A valid skill description"', '---', '', '# My Skill'].join('\n'),
+    )
+
+    const result = await lintProject(projectDir)
+    expect(result.issues.some(issue => issue.code === 'codex-branding-metadata-missing' && issue.platform === 'Codex')).toBe(true)
+  })
+
+  it('warns when Cursor target is missing brand.icon', async () => {
+    const projectDir = createTempProject()
+    mkdirSync(resolve(projectDir, 'skills/my-skill'), { recursive: true })
+
+    writeFileSync(
+      resolve(projectDir, 'pluxx.config.json'),
+      JSON.stringify({
+        name: 'test-plugin',
+        version: '0.1.0',
+        description: 'test',
+        author: { name: 'Test Author' },
+        skills: './skills/',
+        targets: ['cursor'],
+        brand: {
+          displayName: 'Test Plugin',
+        },
+      }, null, 2),
+    )
+
+    writeFileSync(
+      resolve(projectDir, 'skills/my-skill/SKILL.md'),
+      ['---', 'name: my-skill', 'description: "A valid skill description"', '---', '', '# My Skill'].join('\n'),
+    )
+
+    const result = await lintProject(projectDir)
+    expect(result.issues.some(issue => issue.code === 'cursor-branding-metadata-missing' && issue.platform === 'Cursor')).toBe(true)
+  })
+
+  it('does not warn when Codex branding is satisfied through brand fields or interface overrides', async () => {
+    const projectDir = createTempProject()
+    mkdirSync(resolve(projectDir, 'skills/my-skill'), { recursive: true })
+
+    writeFileSync(
+      resolve(projectDir, 'pluxx.config.json'),
+      JSON.stringify({
+        name: 'test-plugin',
+        version: '0.1.0',
+        description: 'test',
+        author: { name: 'Test Author' },
+        skills: './skills/',
+        targets: ['codex'],
+        platforms: {
+          codex: {
+            interface: {
+              composerIcon: './assets/icon.svg',
+              screenshots: ['./assets/screenshots/overview.svg'],
+            },
+          },
+        },
+      }, null, 2),
+    )
+
+    writeFileSync(
+      resolve(projectDir, 'skills/my-skill/SKILL.md'),
+      ['---', 'name: my-skill', 'description: "A valid skill description"', '---', '', '# My Skill'].join('\n'),
+    )
+
+    const result = await lintProject(projectDir)
+    expect(result.issues.some(issue => issue.code === 'codex-branding-metadata-missing')).toBe(false)
   })
 
   it('does not warn for the direct install-time check-env hook scaffold', async () => {


### PR DESCRIPTION
## Summary
- add shared branding completeness warnings for hosts that support richer listing metadata
- surface the warning in both pluxx lint and source-project pluxx doctor
- cover Codex, Cursor, and doc truth updates in tests and planning docs

## Testing
- npm test -- --run tests/lint.test.ts tests/doctor.test.ts
- npm run typecheck