### PR TITLE
Unify stdio MCP path normalization across build and install

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -94,6 +94,9 @@ The closure plan is now narrower than it was before:
   - `doctor --consumer` now makes broken installed `.mcp.json` runtime references obvious
   - Claude-generated local stdio MCP output now anchors project-local runtime paths under `${CLAUDE_PLUGIN_ROOT}` instead of assuming plugin-root cwd
   - `lint` now warns when MCP startup or custom runtime hooks depend on installer-owned `scripts/check-env.sh`
+  - build output and install-time MCP materialization now share the same stdio path normalization, so host-specific root vars no longer leak between Claude, Cursor, and Codex bundles
+  - `lint` now warns when global stdio MCP config uses host-specific root vars such as `${CLAUDE_PLUGIN_ROOT}`
+  - `doctor --consumer` now warns when an installed bundle still carries the wrong host root contract in stdio MCP config
   - the recommended native-runtime pattern now explicitly splits `load-env.sh`, `bootstrap-runtime.sh`, and `start-mcp.sh`
 - host-visible branding completeness is now surfaced earlier:
   - `lint` warns when Cursor or Codex can render richer branding but the plugin is missing `brand.icon` and/or `brand.screenshots`

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -183,6 +183,9 @@ The repo already proves a lot.
   - `doctor --consumer` now warns when an installed bundle's `.mcp.json` points at missing stdio runtime files
   - Claude-generated local stdio MCP config now anchors project-local runtime paths under `${CLAUDE_PLUGIN_ROOT}` instead of assuming plugin-root cwd after install
   - `lint` now warns if MCP startup or custom runtime hooks depend on installer-owned `scripts/check-env.sh`, which local install may rewrite into a no-op after config materialization
+  - build output and install-time MCP materialization now share the same stdio path normalization, so host-specific root vars no longer leak from Claude-style source config into Cursor or Codex bundles
+  - `lint` now warns when global stdio MCP config uses host-specific root vars such as `${CLAUDE_PLUGIN_ROOT}` instead of a cross-host source expression
+  - `doctor --consumer` now warns when an installed bundle still contains the wrong host root contract in stdio MCP config
   - the docs now capture a portable native-runtime pattern for plugins that need first-run local bootstrap scripts such as `load-env.sh`, `bootstrap-runtime.sh`, and `start-mcp.sh`
 - host-visible branding completeness is now surfaced earlier:
   - `lint` warns when Cursor or Codex can render richer branding but the plugin is missing `brand.icon` and/or `brand.screenshots`

--- a/docs/todo/master-backlog.md
+++ b/docs/todo/master-backlog.md
@@ -108,6 +108,9 @@ Any person or agent should be able to enter the repo and answer:
   - `doctor --consumer` now warns when installed `.mcp.json` files reference missing stdio runtime payloads
   - Claude-generated local stdio MCP output now anchors project-local runtime paths under `${CLAUDE_PLUGIN_ROOT}` instead of assuming plugin-root cwd
   - `lint` now warns when MCP startup or custom runtime hooks depend on installer-owned `scripts/check-env.sh`
+  - build output and install-time MCP materialization now share the same stdio path normalization, so host-specific root vars no longer leak between Claude, Cursor, and Codex bundles
+  - `lint` now warns when global stdio MCP config uses host-specific root vars such as `${CLAUDE_PLUGIN_ROOT}`
+  - `doctor --consumer` now warns when an installed bundle still carries the wrong host root contract in stdio MCP config
   - docs now capture the portable `load-env.sh` / `bootstrap-runtime.sh` / `start-mcp.sh` pattern for native Node runtime dependencies
 - [x] Surface host-visible branding gaps earlier in author workflows:
   - `lint` now warns when Cursor or Codex can render richer branding but the plugin is missing `brand.icon` and/or `brand.screenshots`

--- a/docs/todo/queue.md
+++ b/docs/todo/queue.md
@@ -85,6 +85,9 @@ The core-four compiler sprint is done.
   - `doctor --consumer` warns when installed `.mcp.json` files reference missing stdio runtime payloads
   - Claude-generated local stdio MCP output now anchors project-local runtime paths under `${CLAUDE_PLUGIN_ROOT}`
   - `lint` warns when MCP startup or custom runtime hooks depend on installer-owned `scripts/check-env.sh`
+  - build output and install-time MCP materialization now share the same stdio path normalization, so host-specific root vars no longer leak between Claude, Cursor, and Codex bundles
+  - `lint` now warns when global stdio MCP config uses host-specific root vars such as `${CLAUDE_PLUGIN_ROOT}`
+  - `doctor --consumer` now warns when an installed bundle still carries the wrong host root contract in stdio MCP config
   - the install/runtime docs now recommend the `load-env.sh` + `bootstrap-runtime.sh` + `start-mcp.sh` split pattern for native Node deps
 - host-visible branding completeness is now surfaced earlier:
   - `lint` warns when Cursor or Codex can render richer branding but the plugin is missing `brand.icon` and/or `brand.screenshots`

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -9,6 +9,7 @@ import { MCP_SCAFFOLD_METADATA_PATH, type McpScaffoldMetadata } from './init-fro
 import { buildPrimitiveTranslationSummary, renderPrimitiveTranslationSummary, type PrimitiveTranslationSummary } from './primitive-summary'
 import { isPlaceholderSecretValue } from '../user-config'
 import { getBrandingCompletenessWarnings } from '../branding-completeness'
+import { findLeakedPluginRootVars } from '../mcp-stdio-paths'
 
 export type DoctorLevel = 'error' | 'warning' | 'info' | 'success'
 
@@ -944,6 +945,26 @@ function checkInstalledMcpConfig(checks: DoctorCheck[], rootDir: string, layout:
           title: 'Bundled stdio MCP runtime files are missing',
           detail: `This installed MCP config references local runtime path${missingRuntimePaths.length === 1 ? '' : 's'} that do not exist in the bundle: ${missingRuntimePaths.join(', ')}.`,
           fix: 'Rebuild the plugin with the MCP runtime directory included in passthrough, then reinstall the host bundle.',
+          path: layout.mcpConfigPath,
+        })
+      }
+
+      const leakedPluginRootVars = [...new Set(
+        stdioEntries.flatMap((server) => {
+          const values = [
+            typeof server.command === 'string' ? server.command : '',
+            ...(Array.isArray(server.args) ? server.args.filter((value): value is string => typeof value === 'string') : []),
+          ]
+          return findLeakedPluginRootVars(layout.platform, values)
+        }),
+      )].sort()
+      if (leakedPluginRootVars.length > 0) {
+        addCheck(checks, {
+          level: 'warning',
+          code: 'consumer-mcp-stdio-host-root-leak',
+          title: 'Installed stdio MCP config contains the wrong host root contract',
+          detail: `This installed ${layout.platform} MCP config still contains plugin root variable${leakedPluginRootVars.length === 1 ? '' : 's'} that do not belong in this host bundle: ${leakedPluginRootVars.map((pluginRootVar) => `\${${pluginRootVar}}`).join(', ')}.`,
+          fix: 'Author global stdio MCP paths as `./...` or `${PLUGIN_ROOT}/...`, then rebuild and reinstall so Pluxx can normalize the correct host-specific path.',
           path: layout.mcpConfigPath,
         })
       }

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -12,6 +12,7 @@ import {
   resolveUserConfigEntriesForTarget,
   type ResolvedUserConfigEntry,
 } from '../user-config'
+import { normalizePluginOwnedStdioPathForPlatform } from '../mcp-stdio-paths'
 
 interface InstallTarget {
   platform: TargetPlatform
@@ -656,8 +657,8 @@ function patchInstalledMcpConfig(
     for (const [name, server] of Object.entries(config.mcp)) {
       if (server.transport === 'stdio') {
         mcpServers[name] = {
-          command: server.command,
-          args: server.args ?? [],
+          command: normalizePluginOwnedStdioPathForPlatform(server.command, platform),
+          args: (server.args ?? []).map((value) => normalizePluginOwnedStdioPathForPlatform(value, platform)),
           env: materializeEnvRecord(server.env, env),
         }
         continue
@@ -694,8 +695,8 @@ function patchInstalledMcpConfig(
     for (const [name, server] of Object.entries(config.mcp)) {
       if (server.transport === 'stdio') {
         mcpServers[name] = {
-          command: server.command,
-          args: server.args ?? [],
+          command: normalizePluginOwnedStdioPathForPlatform(server.command, platform),
+          args: (server.args ?? []).map((value) => normalizePluginOwnedStdioPathForPlatform(value, platform)),
           env: materializeEnvRecord(server.env, env),
         }
         continue

--- a/src/cli/lint.ts
+++ b/src/cli/lint.ts
@@ -12,6 +12,7 @@ import {
   CURSOR_SUPPORTED_HOOK_EVENTS,
   mapHookEventToPascalCase,
 } from '../hook-events'
+import { findHostPluginRootVars } from '../mcp-stdio-paths'
 
 const AGENT_SKILLS_RULES = { name: { pattern: /^[a-z0-9-]+$/, maxLength: 64 }, description: { maxLength: 1024 } }
 const CLAUDE_CODE_RULES = { description: { maxDisplayLength: 250 } }
@@ -690,6 +691,29 @@ function lintInstallerOwnedRuntimeScripts(config: PluginConfig, issues: LintIssu
         message: `Hook "${eventName}" references scripts/check-env.sh as part of a broader runtime command. Treat that script as installer-owned and install-time only, because local installs may rewrite it into a no-op after required config is materialized.`,
         file: 'pluxx.config.ts',
         platform: 'Runtime',
+      })
+    }
+  }
+}
+
+function lintGlobalMcpHostRootVariables(config: PluginConfig, issues: LintIssue[]): void {
+  if (!config.mcp) return
+
+  for (const [serverName, server] of Object.entries(config.mcp)) {
+    if (server.transport !== 'stdio') continue
+
+    const values = [server.command, ...(server.args ?? [])]
+    for (const [index, value] of values.entries()) {
+      const hostSpecificVars = findHostPluginRootVars(value).filter((pluginRootVar) => pluginRootVar !== 'PLUGIN_ROOT')
+      if (hostSpecificVars.length === 0) continue
+
+      const location = index === 0 ? 'command' : `args[${index - 1}]`
+      pushIssue(issues, {
+        level: 'warning',
+        code: 'mcp-stdio-host-root-var',
+        message: `MCP server "${serverName}" uses host-specific plugin root variable ${hostSpecificVars.map((pluginRootVar) => `\${${pluginRootVar}}`).join(', ')} in ${location}. Author global stdio MCP paths as \`./...\` or \`\${PLUGIN_ROOT}/...\` so Pluxx can normalize them per host during build and install.`,
+        file: 'pluxx.config.ts',
+        platform: 'MCP',
       })
     }
   }
@@ -1547,6 +1571,7 @@ export async function lintProject(
   lintMcpUrls(lintConfig, issues)
   lintMcpRuntimeState(dir, lintConfig, issues)
   lintInstallerOwnedRuntimeScripts(lintConfig, issues)
+  lintGlobalMcpHostRootVariables(lintConfig, issues)
   lintBrandMetadata(lintConfig, issues)
   lintCodexOverrides(lintConfig, issues)
   lintCodexHookCompatibility(lintConfig, issues)

--- a/src/generators/base.ts
+++ b/src/generators/base.ts
@@ -3,6 +3,7 @@ import { mkdirSync, existsSync, cpSync } from 'fs'
 import type { PluginConfig, TargetPlatform, McpServer } from '../schema'
 import { readCompilerIntent, type CompilerIntentFile } from '../compiler-intent'
 import { writeTextFile } from '../text-files'
+import { normalizePluginOwnedStdioPathForPlatform } from '../mcp-stdio-paths'
 
 type McpRemoteServer = Exclude<McpServer, { transport: 'stdio' }>
 
@@ -126,8 +127,8 @@ export abstract class Generator {
     for (const [name, server] of Object.entries(this.config.mcp)) {
       if (server.transport === 'stdio') {
         mcpServers[name] = {
-          command: server.command,
-          args: server.args ?? [],
+          command: normalizePluginOwnedStdioPathForPlatform(server.command, this.platform),
+          args: (server.args ?? []).map((value) => normalizePluginOwnedStdioPathForPlatform(value, this.platform)),
           env: server.env ?? {},
         }
         continue

--- a/src/generators/shared/claude-family.ts
+++ b/src/generators/shared/claude-family.ts
@@ -6,6 +6,7 @@ import { mapHookEventToPascalCase } from '../../hook-events'
 import { buildGeneratedPermissionHookScript } from '../../permissions'
 import { readTextFile } from '../../text-files'
 import { readCanonicalAgentFiles } from '../../agents'
+import { normalizePluginOwnedStdioPathForPlatform } from '../../mcp-stdio-paths'
 
 export interface ClaudeFamilyOptions {
   manifestPath: string
@@ -44,21 +45,6 @@ export async function generateClaudeFamilyOutputs(args: {
 
 function shellSingleQuote(value: string): string {
   return `'${value.replace(/'/g, `'\"'\"'`)}'`
-}
-
-function rewriteClaudePluginRootReference(value: string): string {
-  const normalized = value.replace(/\\/g, '/')
-  if (normalized.startsWith('${CLAUDE_PLUGIN_ROOT}/')) return normalized
-  if (normalized.startsWith('${PLUGIN_ROOT}/')) {
-    return normalized.replace('${PLUGIN_ROOT}', '${CLAUDE_PLUGIN_ROOT}')
-  }
-  if (normalized.startsWith('./')) {
-    return `\${CLAUDE_PLUGIN_ROOT}/${normalized.slice(2)}`
-  }
-  if (normalized.startsWith('../')) {
-    return `\${CLAUDE_PLUGIN_ROOT}/${normalized}`
-  }
-  return value
 }
 
 function buildClaudeHookCommandWrapperScript(command: string): string {
@@ -164,16 +150,9 @@ async function writeMcpConfig(
 
   for (const [name, server] of Object.entries(config.mcp)) {
     if (server.transport === 'stdio' && server.command) {
-      const command = platform === 'claude-code'
-        ? rewriteClaudePluginRootReference(server.command)
-        : server.command
-      const args = platform === 'claude-code'
-        ? (server.args ?? []).map(rewriteClaudePluginRootReference)
-        : (server.args ?? [])
-
       mcpServers[name] = {
-        command,
-        args,
+        command: normalizePluginOwnedStdioPathForPlatform(server.command, platform),
+        args: (server.args ?? []).map((value) => normalizePluginOwnedStdioPathForPlatform(value, platform)),
         env: server.env ?? {},
       }
     } else {

--- a/src/mcp-stdio-paths.ts
+++ b/src/mcp-stdio-paths.ts
@@ -1,0 +1,71 @@
+import type { TargetPlatform } from './schema'
+
+const HOST_PLUGIN_ROOT_VARS = ['CLAUDE_PLUGIN_ROOT', 'CURSOR_PLUGIN_ROOT', 'PLUGIN_ROOT'] as const
+
+export type HostPluginRootVar = typeof HOST_PLUGIN_ROOT_VARS[number]
+
+export function normalizePluginOwnedStdioPathForPlatform(
+  value: string,
+  platform: TargetPlatform,
+): string {
+  const normalized = value.replace(/\\/g, '/')
+  const rootRef = parsePluginRootReference(normalized)
+
+  if (rootRef) {
+    if (platform === 'claude-code') {
+      return `\${CLAUDE_PLUGIN_ROOT}/${rootRef.suffix}`
+    }
+    return `./${rootRef.suffix}`
+  }
+
+  if (normalized.startsWith('./')) {
+    return platform === 'claude-code'
+      ? `\${CLAUDE_PLUGIN_ROOT}/${normalized.slice(2)}`
+      : normalized
+  }
+
+  if (normalized.startsWith('../')) {
+    return platform === 'claude-code'
+      ? `\${CLAUDE_PLUGIN_ROOT}/${normalized}`
+      : normalized
+  }
+
+  return value
+}
+
+export function findHostPluginRootVars(value: string): HostPluginRootVar[] {
+  const matches = value.match(/\$\{(?:CLAUDE_PLUGIN_ROOT|CURSOR_PLUGIN_ROOT|PLUGIN_ROOT)\}/g) ?? []
+  return [...new Set(matches.map((match) => match.slice(2, -1) as HostPluginRootVar))]
+}
+
+export function findLeakedPluginRootVars(
+  platform: TargetPlatform,
+  values: string[],
+): HostPluginRootVar[] {
+  const leaks = new Set<HostPluginRootVar>()
+
+  for (const value of values) {
+    for (const pluginRootVar of findHostPluginRootVars(value)) {
+      if (platform === 'claude-code') {
+        if (pluginRootVar !== 'CLAUDE_PLUGIN_ROOT') {
+          leaks.add(pluginRootVar)
+        }
+        continue
+      }
+
+      leaks.add(pluginRootVar)
+    }
+  }
+
+  return [...leaks]
+}
+
+function parsePluginRootReference(value: string): { rootVar: HostPluginRootVar; suffix: string } | null {
+  const match = value.match(/^\$\{(CLAUDE_PLUGIN_ROOT|CURSOR_PLUGIN_ROOT|PLUGIN_ROOT)\}[\\/](.+)$/)
+  if (!match) return null
+
+  return {
+    rootVar: match[1] as HostPluginRootVar,
+    suffix: match[2],
+  }
+}

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -634,6 +634,59 @@ describe('build', () => {
     expect(opencodeIndex).not.toContain('"type": "platform"')
   })
 
+  it('normalizes host-specific stdio root vars back to the target-local contract during build', async () => {
+    const runtimeConfig: PluginConfig = {
+      ...testConfig,
+      name: 'runtime-normalization-fixture',
+      mcp: {
+        'local-server': {
+          transport: 'stdio',
+          command: 'bash',
+          args: ['${CLAUDE_PLUGIN_ROOT}/scripts/start-mcp.sh'],
+          env: {
+            LOCAL_FIXTURE_TOKEN: '${LOCAL_FIXTURE_TOKEN}',
+          },
+        },
+      },
+      targets: ['claude-code', 'cursor', 'codex'],
+      outDir: './runtime-normalization-dist',
+    }
+
+    await build(runtimeConfig, TEST_DIR)
+
+    const claudeMcp = JSON.parse(
+      readFileSync(resolve(TEST_DIR, 'runtime-normalization-dist/claude-code/.mcp.json'), 'utf-8')
+    )
+    const cursorMcp = JSON.parse(
+      readFileSync(resolve(TEST_DIR, 'runtime-normalization-dist/cursor/mcp.json'), 'utf-8')
+    )
+    const codexMcp = JSON.parse(
+      readFileSync(resolve(TEST_DIR, 'runtime-normalization-dist/codex/.mcp.json'), 'utf-8')
+    )
+
+    expect(claudeMcp.mcpServers['local-server']).toEqual({
+      command: 'bash',
+      args: ['${CLAUDE_PLUGIN_ROOT}/scripts/start-mcp.sh'],
+      env: {
+        LOCAL_FIXTURE_TOKEN: '${LOCAL_FIXTURE_TOKEN}',
+      },
+    })
+    expect(cursorMcp.mcpServers['local-server']).toEqual({
+      command: 'bash',
+      args: ['./scripts/start-mcp.sh'],
+      env: {
+        LOCAL_FIXTURE_TOKEN: '${LOCAL_FIXTURE_TOKEN}',
+      },
+    })
+    expect(codexMcp.mcpServers['local-server']).toEqual({
+      command: 'bash',
+      args: ['./scripts/start-mcp.sh'],
+      env: {
+        LOCAL_FIXTURE_TOKEN: '${LOCAL_FIXTURE_TOKEN}',
+      },
+    })
+  })
+
   it('generates Codex manifest with interface metadata', async () => {
     const manifest = JSON.parse(
       readFileSync(resolve(OUT_DIR, 'codex/.codex-plugin/plugin.json'), 'utf-8')

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -587,6 +587,31 @@ describe('doctorConsumer', () => {
     }
   })
 
+  it('warns when an installed non-Claude bundle still contains another host root variable', async () => {
+    const dir = createCodexConsumerFixture({ includeRuntime: true })
+    writeFileSync(
+      resolve(dir, '.mcp.json'),
+      JSON.stringify({
+        mcpServers: {
+          localFixture: {
+            command: 'bash',
+            args: ['${CLAUDE_PLUGIN_ROOT}/scripts/start-mcp.sh'],
+            env: {
+              LOCAL_FIXTURE_TOKEN: '${LOCAL_FIXTURE_TOKEN}',
+            },
+          },
+        },
+      }, null, 2),
+    )
+
+    try {
+      const report = await doctorConsumer(dir)
+      expect(report.checks.some((check) => check.code === 'consumer-mcp-stdio-host-root-leak' && check.level === 'warning')).toBe(true)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
   it('validates OpenCode host-visible wrapper and exported skills for installed bundles', async () => {
     const dir = createOpenCodeConsumerFixture()
 

--- a/tests/install.test.ts
+++ b/tests/install.test.ts
@@ -515,4 +515,73 @@ describe('install', () => {
     expect(readFileSync(resolve(opencodeSkill, 'SKILL.md'), 'utf-8')).toContain('name: megamind/client-intel')
     expect(readFileSync(resolve(cursorInstall, 'scripts/check-env.sh'), 'utf-8')).toContain('materialized required config')
   })
+
+  it('normalizes plugin-owned stdio MCP paths consistently during local install materialization', async () => {
+    mkdirSync(resolve(DIST_DIR, 'cursor/scripts'), { recursive: true })
+    mkdirSync(resolve(DIST_DIR, 'codex/scripts'), { recursive: true })
+
+    await Bun.write(resolve(DIST_DIR, 'cursor/mcp.json'), JSON.stringify({ mcpServers: {} }, null, 2))
+    await Bun.write(resolve(DIST_DIR, 'codex/.mcp.json'), JSON.stringify({ mcpServers: {} }, null, 2))
+    await Bun.write(resolve(DIST_DIR, 'cursor/scripts/start-mcp.sh'), '#!/usr/bin/env bash\nexit 0\n')
+    await Bun.write(resolve(DIST_DIR, 'codex/scripts/start-mcp.sh'), '#!/usr/bin/env bash\nexit 0\n')
+
+    const config: PluginConfig = {
+      name: 'megamind',
+      version: '1.0.0',
+      description: 'Fixture plugin',
+      author: { name: 'Test Author' },
+      license: 'MIT',
+      skills: './skills/',
+      mcp: {
+        sendlens: {
+          transport: 'stdio',
+          command: 'bash',
+          args: ['${CLAUDE_PLUGIN_ROOT}/scripts/start-mcp.sh'],
+          env: {
+            SENDLENS_TOKEN: '${SENDLENS_TOKEN}',
+          },
+        },
+      },
+      targets: ['cursor', 'codex'],
+      outDir: './dist',
+    }
+
+    await installPlugin(DIST_DIR, 'megamind', ['cursor', 'codex'], {
+      config,
+      resolvedUserConfig: [{
+        field: {
+          key: 'sendlens-token',
+          title: 'SendLens Token',
+          description: 'Fixture token',
+          type: 'secret',
+          required: true,
+          envVar: 'SENDLENS_TOKEN',
+        },
+        value: 'shh-secret',
+        envVar: 'SENDLENS_TOKEN',
+      }],
+      useNativeClaudeInstall: false,
+      quiet: true,
+    })
+
+    const cursorInstall = resolve(HOME_DIR, INSTALL_PATHS.cursor)
+    const codexInstall = resolve(HOME_DIR, INSTALL_PATHS.codex)
+    const cursorMcp = JSON.parse(readFileSync(resolve(cursorInstall, 'mcp.json'), 'utf-8'))
+    const codexMcp = JSON.parse(readFileSync(resolve(codexInstall, '.mcp.json'), 'utf-8'))
+
+    expect(cursorMcp.mcpServers.sendlens).toEqual({
+      command: 'bash',
+      args: ['./scripts/start-mcp.sh'],
+      env: {
+        SENDLENS_TOKEN: 'shh-secret',
+      },
+    })
+    expect(codexMcp.mcpServers.sendlens).toEqual({
+      command: 'bash',
+      args: ['./scripts/start-mcp.sh'],
+      env: {
+        SENDLENS_TOKEN: 'shh-secret',
+      },
+    })
+  })
 })

--- a/tests/lint.test.ts
+++ b/tests/lint.test.ts
@@ -224,6 +224,38 @@ describe('lintProject', () => {
     expect(result.issues.some(issue => issue.code === 'installer-owned-check-env-runtime')).toBe(true)
   })
 
+  it('warns when global stdio MCP config uses host-specific plugin root vars', async () => {
+    const projectDir = createTempProject()
+    mkdirSync(resolve(projectDir, 'skills/my-skill'), { recursive: true })
+
+    writeFileSync(
+      resolve(projectDir, 'pluxx.config.json'),
+      JSON.stringify({
+        name: 'test-plugin',
+        version: '0.1.0',
+        description: 'test',
+        author: { name: 'Test Author' },
+        skills: './skills/',
+        targets: ['claude-code', 'cursor', 'codex'],
+        mcp: {
+          sendlens: {
+            transport: 'stdio',
+            command: 'bash',
+            args: ['${CLAUDE_PLUGIN_ROOT}/scripts/start-mcp.sh'],
+          },
+        },
+      }, null, 2),
+    )
+
+    writeFileSync(
+      resolve(projectDir, 'skills/my-skill/SKILL.md'),
+      ['---', 'name: my-skill', 'description: "A valid skill description"', '---', '', '# My Skill'].join('\n'),
+    )
+
+    const result = await lintProject(projectDir)
+    expect(result.issues.some(issue => issue.code === 'mcp-stdio-host-root-var')).toBe(true)
+  })
+
   it('warns when Codex target is missing richer branding metadata', async () => {
     const projectDir = createTempProject()
     mkdirSync(resolve(projectDir, 'skills/my-skill'), { recursive: true })


### PR DESCRIPTION
## Summary
- share plugin-owned stdio MCP path normalization across build output and install-time materialization
- warn when global stdio MCP config uses host-specific root vars and detect leaked host-root contracts in installed bundles
- add regression coverage for build, install, lint, and doctor plus update repo truth docs

## Testing
- npm test -- --run tests/build.test.ts tests/install.test.ts tests/lint.test.ts tests/doctor.test.ts
- npm run typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Platform-aware stdio MCP path normalization preventing host-specific variables from propagating across Claude/Cursor/Codex bundles
  * `lint` now warns when global MCP config references host-specific root variables
  * `doctor --consumer` now warns when installed bundles retain mismatched host-root contracts

* **Tests**
  * Comprehensive test coverage for path normalization, validation warnings, and diagnostics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->