### PR TITLE
Simplify Mintlify docs structure

### DIFF
--- a/site/docs.json
+++ b/site/docs.json
@@ -15,54 +15,41 @@
   "navigation": {
     "groups": [
       {
-        "group": "Overview",
+        "group": "Start",
+        "pages": [
+          "overview/start-here",
+          "getting-started/getting-started",
+          "getting-started/command-decision-tree"
+        ]
+      },
+      {
+        "group": "Build",
+        "pages": [
+          "workflows/import-from-mcp",
+          "workflows/autopilot",
+          "workflows/sync-mcp",
+          "getting-started/create-a-pluxx-plugin"
+        ]
+      },
+      {
+        "group": "Learn",
         "pages": [
           "overview/why-pluxx",
           "overview/what-pluxx-is",
           "overview/core-primitives",
-          "overview/core-four-primitive-matrix",
-          "overview/core-four-branding-metadata-audit",
-          "overview/what-pluxx-does-not-model-yet"
-        ]
-      },
-      {
-        "group": "Getting Started",
-        "pages": [
-          "getting-started/getting-started",
-          "getting-started/command-decision-tree",
-          "getting-started/create-a-pluxx-plugin",
-          "getting-started/use-pluxx-in-host-agents",
-          "getting-started/practical-handbook"
-        ]
-      },
-      {
-        "group": "How It Works",
-        "pages": [
           "how-it-works/how-it-works",
-          "how-it-works/architecture",
           "how-it-works/agent-mode",
-          "how-it-works/compatibility-limits"
+          "how-it-works/compatibility-limits",
+          "workflows/local-core-four-proof"
         ]
       },
       {
-        "group": "Workflows",
+        "group": "Examples",
         "pages": [
-          "workflows/import-from-mcp",
-          "workflows/local-core-four-proof",
-          "workflows/refine-taxonomy",
-          "workflows/rewrite-instructions",
-          "workflows/review-scaffold",
-          "workflows/sync-mcp",
-          "workflows/autopilot"
-        ]
-      },
-      {
-        "group": "Platform Guides",
-        "pages": [
-          "platform-guides/claude-code",
-          "platform-guides/cursor",
-          "platform-guides/codex",
-          "platform-guides/opencode"
+          "examples/which-example",
+          "examples/docs-ops-flagship",
+          "examples/exa-research-example",
+          "examples/platform-change-ops"
         ]
       },
       {
@@ -72,26 +59,7 @@
           "reference/pluxx-config",
           "reference/auth-runtime-auth",
           "reference/hooks-commands-agents",
-          "reference/validation-and-size-limits",
-          "reference/privacy-policy",
-          "reference/terms-of-service"
-        ]
-      },
-      {
-        "group": "Examples",
-        "pages": [
-          "examples/docs-ops-flagship",
-          "examples/exa-research-example",
-          "examples/sumble-proof-run",
-          "examples/self-hosting-pluxx",
-          "examples/firecrawl-sumble-playkit"
-        ]
-      },
-      {
-        "group": "Roadmap / Boundaries",
-        "pages": [
-          "roadmap-boundaries/core-vs-deferred-primitives",
-          "roadmap-boundaries/compatibility-caveats"
+          "reference/validation-and-size-limits"
         ]
       }
     ]

--- a/site/examples/platform-change-ops.mdx
+++ b/site/examples/platform-change-ops.mdx
@@ -1,0 +1,66 @@
+---
+title: Platform Change Ops Reference
+---
+
+This is the maximal enterprise reference plugin in the Pluxx repo.
+
+Use it when you want the shortest answer to:
+
+- can one Pluxx source project combine most compiler primitives at once
+- does local stdio runtime packaging work with hooks, permissions, agents, and readiness
+- does installed-state verification catch runtime behavior instead of only file shape
+
+## What this example pressures
+
+The source project in [`example/platform-change-ops`](https://github.com/orchidautomation/pluxx/tree/main/example/platform-change-ops) intentionally combines:
+
+- instructions
+- skills
+- commands
+- specialist agents
+- matcher-based hooks
+- canonical permissions
+- runtime readiness
+- local stdio MCP packaging
+- install and listing metadata
+
+The domain is internal platform / DevEx change operations: intake, blast-radius inspection, external impact research, policy review, release gating, rollout comms, rollback planning, and installed-state verification.
+
+## Why it exists
+
+`docs-ops` proves live workflow depth. `exa-plugin` proves branded research workflows and specialist agents. `sumble-plugin` and `prospeo-mcp` pressured real MCP/auth/runtime cases.
+
+`platform-change-ops` exists to combine those pressures in one maintained source project, so the compiler has a demanding all-primitive fixture instead of only isolated examples.
+
+## Current proof state
+
+The example now builds, installs, and passes `verify-install` across:
+
+- Claude Code
+- Cursor
+- Codex
+- OpenCode
+
+It includes a bundled local stdio MCP runtime with real long-lived tools:
+
+- `readiness_status`
+- `open_change_window`
+- `record_audit_event`
+
+That matters because `doctor --consumer` and `verify-install` now smoke-launch installed stdio MCP commands. The example has to work as an installed runtime, not just as generated files.
+
+## What is still not claimed
+
+This is not yet a polished public demo at the same level as the Docs Ops or Exa pages.
+
+It does not yet prove:
+
+- a real authenticated mutation target
+- a live publish plus rollback against a safe private endpoint
+- a customer-ready walkthrough asset
+
+## Best next pages
+
+- [Docs Ops Flagship Proof](/examples/docs-ops-flagship)
+- [Exa Research Example](/examples/exa-research-example)
+- [Local core-four proof](/workflows/local-core-four-proof)

--- a/site/examples/which-example.mdx
+++ b/site/examples/which-example.mdx
@@ -1,0 +1,48 @@
+---
+title: Which Example Should I Use?
+---
+
+Start with the smallest example that matches your question.
+
+## The short answer
+
+| If you want to prove... | Start here | Why |
+|---|---|---|
+| A real docs workflow across the core four | [Docs Ops Flagship Proof](/examples/docs-ops-flagship) | Best public proof that one source project builds, installs, verifies, and runs useful read-only workflows in Claude Code, Cursor, Codex, and OpenCode |
+| A branded research plugin with specialist agents | [Exa Research Example](/examples/exa-research-example) | Best example for commands, agents, auth/setup guidance, brand metadata, and real host workflows |
+| A demanding enterprise plugin shape | [Platform Change Ops Reference](/examples/platform-change-ops) | Best stress fixture for runtime readiness, local stdio MCP packaging, hooks, permissions, and installed-runtime verification |
+
+Most readers should only read one of those three.
+
+## Use Docs Ops when
+
+- you want the clearest public proof page
+- your plugin rewrites, reviews, or improves docs/content
+- you care about install and `verify-install` proof across Claude Code, Cursor, Codex, and OpenCode
+- you want to see read-only access separated from a private publish lane
+
+## Use Exa when
+
+- your product already has an MCP
+- you want richer workflow packaging around research or search
+- you care about specialist agents and explicit commands
+- you want a public example that is not a docs workflow
+
+## Use Platform Change Ops when
+
+- your plugin has more enterprise/runtime complexity
+- you need local stdio runtime packaging
+- you need readiness gates, hooks, permissions, and specialist agents together
+- you want to pressure-test Pluxx itself, not just copy a minimal product example
+
+## Long-tail examples
+
+These are still useful, but they should not be the first pages most people read:
+
+- [Self-hosting Pluxx Plugin](/examples/self-hosting-pluxx): use when you want to see Pluxx package itself.
+- [Sumble Example](/examples/sumble-proof-run): use when you want a live commercial MCP example with bearer auth.
+- [Firecrawl, Sumble, and PlayKit-style Examples](/examples/firecrawl-sumble-playkit): use when you need import patterns for large tool surfaces or custom header auth.
+
+## Command path
+
+After choosing an example, use [Command Decision Tree](/getting-started/command-decision-tree) for the shortest command sequence.

--- a/site/getting-started/command-decision-tree.mdx
+++ b/site/getting-started/command-decision-tree.mdx
@@ -1,168 +1,48 @@
-# Command Decision Tree
+---
+title: Command Decision Tree
+---
 
-This page shows the practical Pluxx command flow from first import to local install, validation, agent refinement, and later maintenance.
+Use this page to choose the next command without reading the whole CLI reference.
 
-Legend:
+## Pick your path
 
-- `[D]` = deterministic command, no host coding agent invoked
-- `[A]` = agent-invoking command, uses Claude Code, Cursor, Codex, or OpenCode
+| Situation | Run this | Why |
+|---|---|---|
+| You have a raw MCP URL or stdio command | `pluxx init --from-mcp <source> --yes` | Creates the first source project without invoking a host agent |
+| You already configured the MCP in Claude Code, Cursor, Codex, or OpenCode | `pluxx discover-mcp` then `pluxx init --from-installed-mcp <host:name> --yes` | Imports the existing MCP shape without copying literal secret values |
+| You want import, refinement, build, install, and verification in one flow | `pluxx autopilot --from-mcp <source> --runner codex --mode standard --install --install-target codex --trust` | Fastest end-to-end proof in one selected host |
+| You already have a Pluxx project and the MCP changed | `pluxx sync --from-mcp <source>` | Refreshes generated MCP-derived content while preserving custom sections |
+| You already have a host-native plugin | `pluxx migrate <path>` | Converts an existing plugin into a Pluxx source project |
 
-## Full tree
+## Normal manual flow
 
-```text
-START
-|
-+-- Do you already have a Pluxx project?
-|   |
-|   +-- NO
-|   |   |
-|   |   +-- Starting from a live MCP?
-|   |   |   |
-|   |   |   +-- YES
-|   |   |   |   |
-|   |   |   |   +-- Want just the scaffold first? [D]
-|   |   |   |   |   `-- pluxx init --from-mcp <source> --yes --targets claude-code,cursor,codex,opencode [--approve-mcp-tools]
-|   |   |   |   |
-|   |   |   |   `-- Want scaffold + agent refinement in one shot? [A]
-|   |   |   |       `-- pluxx autopilot --from-mcp <source> --runner <claude|codex|cursor|opencode> [--approve-mcp-tools]
-|   |   |   |
-|   |   |   `-- NO
-|   |   |       |
-|   |   |       +-- Starting from scratch? [D]
-|   |   |       |   `-- pluxx init
-|   |   |       |
-|   |   |       `-- Already have a host-native plugin? [D]
-|   |   |           `-- pluxx migrate <path>
-|   |   |
-|   |   `-- After init or migrate:
-|   |       |
-|   |       +-- Inspect source project health [D]
-|   |       |   `-- pluxx doctor
-|   |       |
-|   |       +-- Check source and platform rules [D]
-|   |       |   `-- pluxx lint
-|   |       |
-|   |       +-- Check scaffold quality [D]
-|   |       |   `-- pluxx eval
-|   |       |
-|   |       +-- Generate host bundles [D]
-|   |       |   `-- pluxx build
-|   |       |
-|   |       `-- Run full verification [D]
-|   |           `-- pluxx test
-|   |
-|   `-- YES
-|       |
-|       +-- Need to inspect the source project? [D]
-|       |   `-- pluxx doctor
-|       |
-|       +-- Need to refresh from the MCP? [D]
-|       |   `-- pluxx sync
-|       |
-|       +-- Need to rebuild bundles? [D]
-|       |   `-- pluxx build
-|       |
-|       +-- Need to re-run verification? [D]
-|       |   `-- pluxx test
-|       |
-|       `-- Need semantic refinement? [A]
-|           |
-|           +-- Prepare context first [D]
-|           |   `-- pluxx agent prepare [--website <url>] [--docs <url>] [--context <file...>]
-|           |
-|           +-- Refine taxonomy [A]
-|           |   `-- pluxx agent run taxonomy --runner <runner>
-|           |
-|           +-- Rewrite instructions [A]
-|           |   `-- pluxx agent run instructions --runner <runner>
-|           |
-|           `-- Review the scaffold [A]
-|               `-- pluxx agent run review --runner <runner>
-|
-+-- Want one command for import + optional refinement + verification? [A]
-|   |
-|   `-- pluxx autopilot --from-mcp <source> --runner <runner>
-|       |
-|       +-- quick
-|       +-- standard
-|       `-- thorough
-|
-+-- Want local installs into host CLIs?
-|   |
-|   +-- Install after build [D]
-|   |   `-- pluxx install
-|   |
-|   +-- Install while building [D]
-|   |   `-- pluxx build --install
-|   |
-|   +-- Install while testing [D]
-|   |   `-- pluxx test --install
-|   |
-|   +-- Need to inspect the installed bundle after install? [D]
-|   |   `-- pluxx doctor --consumer <installed-path>
-|   |
-|   +-- Hooks run local shell commands?
-|   |   |
-|   |   `-- add --trust
-|   |       +-- pluxx install --trust
-|   |       +-- pluxx build --install --trust
-|   |       `-- pluxx test --install --trust
-|   |
-|   `-- Remove local installs [D]
-|       `-- pluxx uninstall
-|
-+-- Need to inspect the shipped or installed bundle itself? [D]
-|   |
-|   `-- pluxx doctor --consumer <bundle-or-install-path>
-|
-+-- Need deterministic MCP debugging or replay? [D]
-|   |
-|   +-- Record a live MCP session
-|   |   `-- pluxx mcp proxy --from-mcp <source> --record tape.json
-|   |
-|   `-- Replay it later
-|       `-- pluxx mcp proxy --replay tape.json
-|
-`-- Ready to publish?
-    |
-    +-- pluxx doctor
-    +-- pluxx lint
-    +-- pluxx eval
-    +-- pluxx build
-    `-- pluxx test
-```
-
-## Most common flow
-
-The normal deterministic path is:
+Use this when you want to inspect each stage:
 
 ```bash
-npx @orchid-labs/pluxx init --from-mcp https://example.com/mcp --name acme --yes
+npx @orchid-labs/pluxx init --from-mcp https://example.com/mcp --yes --name acme
 cd acme
 npx @orchid-labs/pluxx doctor
 npx @orchid-labs/pluxx lint
 npx @orchid-labs/pluxx eval
-npx @orchid-labs/pluxx build
 npx @orchid-labs/pluxx test
 ```
 
-If you want local installs too:
+Add local install proof:
 
 ```bash
 npx @orchid-labs/pluxx test --install
+npx @orchid-labs/pluxx verify-install --target codex
 ```
 
-That is now the preferred local proof command because it installs and verifies installed consumer bundle state in one pass.
-
-If the generated plugin includes local hook commands:
+If the plugin contains local hook commands, review them first, then pass `--trust`:
 
 ```bash
 npx @orchid-labs/pluxx test --install --trust
 ```
 
-## Agent path
+## When to use Agent Mode
 
-Use the agent layer only when the scaffold is structurally correct but still needs better taxonomy, naming, routing guidance, or examples.
+Use Agent Mode only after the deterministic scaffold is valid but still reads too generic, too lexical, or too tool-shaped.
 
 ```bash
 npx @orchid-labs/pluxx agent prepare \
@@ -171,29 +51,22 @@ npx @orchid-labs/pluxx agent prepare \
 
 npx @orchid-labs/pluxx agent run taxonomy --runner codex
 npx @orchid-labs/pluxx agent run instructions --runner codex
+```
+
+Use `review` when you want critique before shipping:
+
+```bash
 npx @orchid-labs/pluxx agent run review --runner codex --no-verify
 ```
 
-These are the agent-invoking commands:
+## What each check answers
 
-- `pluxx autopilot`
-- `pluxx agent prepare`
-- `pluxx agent run taxonomy`
-- `pluxx agent run instructions`
-- `pluxx agent run review`
+| Command | Question it answers |
+|---|---|
+| `doctor` | Is the source project structurally healthy? |
+| `lint` | Will platform-specific rules reject this? |
+| `eval` | Is the scaffold coherent enough to publish or refine? |
+| `test` | Do config, lint, build, and smoke checks pass together? |
+| `verify-install` | Does the host-visible installed bundle actually exist and work? |
 
-Everything else in the normal maintenance loop is deterministic.
-
-## Runner note
-
-Pluxx inherits local model defaults unless you pass `--model`.
-
-Example:
-
-```bash
-npx @orchid-labs/pluxx agent run review --runner cursor --model auto
-```
-
-That is especially useful on Cursor free plans, where headless mode may require `auto` instead of a named default model.
-
-For plugin visibility, treat the Cursor **app** as the verification surface. Cursor CLI is useful for headless agent passes, not as the strongest proof that an installed plugin is visible to users.
+For every flag and edge case, use [CLI Reference](/reference/cli-reference).

--- a/site/getting-started/getting-started.mdx
+++ b/site/getting-started/getting-started.mdx
@@ -1,284 +1,107 @@
-# Getting Started
+---
+title: Quickstart
+---
 
-This guide walks through the normal Pluxx flow:
+This is the shortest useful path from an MCP to a verified local plugin.
 
-1. import an MCP into a source project
-2. validate the deterministic scaffold
-3. optionally refine taxonomy and instructions with a host coding agent
-4. build and install host bundles
-5. sync later when the MCP changes
+## 1. Create a source project
 
-If you want proof before process, start with:
-
-- [Docs Ops Flagship Proof](/examples/docs-ops-flagship)
-- [Exa Research Example](/examples/exa-research-example)
-- [Self-hosting Pluxx Plugin](/examples/self-hosting-pluxx)
-- [Local Core-Four Proof](/workflows/local-core-four-proof)
-
-If you want the full command-by-command flow, see [Command Decision Tree](/getting-started/command-decision-tree).
-
-## Before you start
-
-Pluxx accepts three MCP source shapes:
-
-- remote HTTP: `npx @orchid-labs/pluxx init --from-mcp https://example.com/mcp`
-- legacy SSE: `npx @orchid-labs/pluxx init --from-mcp https://example.com/sse --transport sse`
-- local stdio: `npx @orchid-labs/pluxx init --from-mcp "npx -y -p @acme/mcp acme-mcp"`
-
-For local stdio imports, pass the real executable command. Do not assume the npm package name is also the runnable bin name.
-
-Examples:
-
-- installed locally: `npx @orchid-labs/pluxx init --from-mcp "./node_modules/.bin/acme-mcp" --yes`
-- one-shot via npm: `npx @orchid-labs/pluxx init --from-mcp "npx -y -p @acme/mcp acme-mcp" --yes`
-
-The default target set is:
-
-- Claude Code
-- Cursor
-- Codex
-- OpenCode
-
-## 1. Import a plugin source project
-
-The normal starting point is `init`.
-
-Interactive:
+For a remote MCP:
 
 ```bash
-npx @orchid-labs/pluxx init --from-mcp https://example.com/mcp
+npx @orchid-labs/pluxx init --from-mcp https://example.com/mcp --yes --name acme
+cd acme
 ```
 
-Headless:
+For a local stdio MCP:
 
 ```bash
-npx @orchid-labs/pluxx init \
-  --from-mcp https://example.com/mcp \
-  --yes \
-  --name acme \
-  --display-name "Acme" \
-  --author "Acme" \
-  --targets claude-code,cursor,codex,opencode \
-  --grouping workflow \
-  --hooks safe
+npx @orchid-labs/pluxx init --from-mcp "npx -y -p @acme/mcp acme-mcp" --yes --name acme
+cd acme
 ```
 
-Use `--dry-run --json` to preview the scaffold without writing files:
+For an MCP already configured in a host:
 
 ```bash
-npx @orchid-labs/pluxx init \
-  --from-mcp https://example.com/mcp \
-  --yes \
-  --dry-run \
-  --json
+npx @orchid-labs/pluxx discover-mcp
+npx @orchid-labs/pluxx init --from-installed-mcp codex:acme --yes
 ```
 
-### Auth examples
-
-Bearer auth:
+For an existing host-native plugin:
 
 ```bash
-npx @orchid-labs/pluxx init \
-  --from-mcp https://mcp.sumble.com \
-  --yes \
-  --auth-env SUMBLE_API_KEY \
-  --auth-type bearer
+npx @orchid-labs/pluxx migrate ./existing-plugin
 ```
 
-Custom header auth:
-
-```bash
-npx @orchid-labs/pluxx init \
-  --from-mcp https://mcp.playkit.sh/mcp \
-  --yes \
-  --auth-env PLAYKIT_API_KEY \
-  --auth-type header \
-  --auth-header X-API-Key \
-  --auth-template '${value}'
-```
-
-OAuth-first MCPs can also be scaffolded. If the provider requires an OAuth-managed runtime shape, use the platform-auth path:
-
-```bash
-npx @orchid-labs/pluxx init \
-  --from-mcp https://example.com/mcp \
-  --yes \
-  --auth-type platform \
-  --runtime-auth platform
-```
-
-If the provider requires browser-interactive OAuth during handshake, use `--oauth-wrapper` so Pluxx introspects through the local wrapper path and still keeps the remote MCP as the source of truth.
-
-## 2. Understand what gets generated
-
-Pluxx writes a maintained source project:
-
-- `pluxx.config.ts`
-- `INSTRUCTIONS.md`
-- `skills/<name>/SKILL.md`
-- `commands/<name>.md`
-- optional `scripts/` for generated hooks
-- `.pluxx/mcp.json`
-- `.pluxx/taxonomy.json`
-
-Generated Markdown files use managed boundaries so later syncs can refresh generated sections without discarding preserved custom sections.
-
-## 3. Validate the deterministic scaffold
-
-Before you involve an agent, run the deterministic checks:
+## 2. Check the project
 
 ```bash
 npx @orchid-labs/pluxx doctor
 npx @orchid-labs/pluxx lint
 npx @orchid-labs/pluxx eval
-npx @orchid-labs/pluxx build
 npx @orchid-labs/pluxx test
 ```
 
-What each command does:
+What these answer:
 
-- `doctor` checks config, paths, runtime availability, transport/auth shape, and install caveats
-- `lint` checks source-project and platform rules
-- `eval` checks scaffold and prompt-pack quality
-- `build` writes host bundles under `dist/`
-- `test` runs the default verification contract across the built outputs
+| Command | Question |
+|---|---|
+| `doctor` | Is the project structurally healthy? |
+| `lint` | Will host rules reject anything? |
+| `eval` | Is the scaffold coherent enough to trust? |
+| `test` | Do config, lint, build, and smoke checks pass together? |
 
-These commands do not invoke Claude Code, Codex, Cursor, or OpenCode.
-
-### Build and install in one step
-
-If you want local bundle output and local installs together:
+## 3. Install and verify one host
 
 ```bash
-npx @orchid-labs/pluxx build --install
+npx @orchid-labs/pluxx test --install --trust
+npx @orchid-labs/pluxx verify-install --target codex
 ```
 
-Or:
+Use `--trust` only after reviewing generated hook scripts.
 
-```bash
-npx @orchid-labs/pluxx test --install
-```
+`verify-install` checks the host-visible installed bundle, not just files under `dist/`.
 
-If the generated plugin contains local hook commands, add `--trust`:
+## 4. Refine only when needed
 
-```bash
-npx @orchid-labs/pluxx build --install --trust
-```
-
-## 4. Refine taxonomy and instructions with a host coding agent
-
-Agent Mode is optional. Use it when the scaffold is structurally correct but needs better naming, routing guidance, or review.
-
-Prepare the context pack:
+If the scaffold is valid but too generic, run Agent Mode:
 
 ```bash
 npx @orchid-labs/pluxx agent prepare \
   --docs https://docs.example.com/overview \
   --website https://example.com
-```
 
-Run a refinement pass:
-
-```bash
 npx @orchid-labs/pluxx agent run taxonomy --runner codex
 npx @orchid-labs/pluxx agent run instructions --runner codex
 ```
 
-Run a review pass:
+Agent Mode is for taxonomy cleanup, instruction rewriting, and review. It is not required for import, lint, build, install, test, or migration.
 
-```bash
-npx @orchid-labs/pluxx agent run review --runner opencode --no-verify
-```
+## One-command path
 
-The agent layer is only used for:
-
-- taxonomy refinement
-- instruction rewriting
-- review passes
-
-It is not used for:
-
-- import
-- lint
-- eval
-- build
-- install
-- test
-- migrate
-- consumer doctor
-- MCP proxy record/replay
-
-## 5. Use autopilot when you want one coordinated flow
-
-`autopilot` combines import, optional semantic refinement, and final verification.
-
-Example:
+Use autopilot when you want import, optional refinement, verification, install, and installed-state proof in one flow:
 
 ```bash
 npx @orchid-labs/pluxx autopilot \
   --from-mcp https://example.com/mcp \
   --runner codex \
-  --name acme \
-  --display-name "Acme" \
-  --author "Acme" \
-  --grouping workflow \
-  --hooks safe
+  --mode standard \
+  --install \
+  --install-target codex \
+  --trust
 ```
 
-Add richer context when the MCP metadata is thin:
-
-```bash
-npx @orchid-labs/pluxx autopilot \
-  --from-mcp https://example.com/mcp \
-  --runner claude \
-  --docs https://docs.example.com/overview \
-  --website https://example.com \
-  --review
-```
-
-See [Autopilot](/workflows/autopilot) for the exact behavior.
-
-## 6. Extra deterministic commands worth knowing
-
-Import an existing host-native plugin:
-
-```bash
-npx @orchid-labs/pluxx migrate ./path/to/existing-plugin
-```
-
-Inspect a built or installed bundle from the consumer side:
-
-```bash
-npx @orchid-labs/pluxx doctor --consumer dist/claude-code
-```
-
-Record and replay an MCP session:
-
-```bash
-npx @orchid-labs/pluxx mcp proxy --from-mcp https://example.com/mcp --record tape.json
-npx @orchid-labs/pluxx mcp proxy --replay tape.json
-```
-
-## 7. Sync later
+## Sync later
 
 When the MCP changes:
 
 ```bash
-npx @orchid-labs/pluxx sync
+npx @orchid-labs/pluxx sync --from-mcp https://example.com/mcp
 ```
 
-If the source moved:
+## Next
 
-```bash
-npx @orchid-labs/pluxx sync --from-mcp https://mcp.example.com/mcp
-```
-
-Preview sync changes:
-
-```bash
-npx @orchid-labs/pluxx sync --dry-run --json
-```
-
-## Real example
-
-For a complete remote-MCP example with real auth, workflow grouping, build output, and verification, see [Sumble Example](/examples/sumble-proof-run).
+- [Command Decision Tree](/getting-started/command-decision-tree): choose the next command.
+- [Import From MCP](/workflows/import-from-mcp): handle auth and source shapes.
+- [Which Example Should I Use?](/examples/which-example): pick one concrete proof.
+- [CLI Reference](/reference/cli-reference): look up flags.

--- a/site/how-it-works/how-it-works.mdx
+++ b/site/how-it-works/how-it-works.mdx
@@ -25,16 +25,15 @@ The product now has two intentional layers:
 Pluxx is intentionally the plugin authoring/distribution layer, not the MCP hosting layer. You still deploy and operate your MCP backend service.
 
 See [Agent Mode](/how-it-works/agent-mode) for the semantic-authoring layer.
-See [Architecture](/how-it-works/architecture) for the system view and [Customer Journey](/workflows/import-from-mcp) for the end-to-end user path.
-See [Practical handbook](/getting-started/practical-handbook) for the operational command-by-command workflow.
+See [Command Decision Tree](/getting-started/command-decision-tree) for the shortest command path.
 See [Core primitives](/overview/core-primitives) for the tightened product scope.
 
 If you want proof before theory, start with:
 
-- [Local core-four proof](/workflows/local-core-four-proof)
+- [Which Example Should I Use?](/examples/which-example)
 - [Docs Ops Flagship Proof](/examples/docs-ops-flagship)
 - [Exa Research Example](/examples/exa-research-example)
-- [Self-hosting Pluxx Plugin](/examples/self-hosting-pluxx)
+- [Platform Change Ops Reference](/examples/platform-change-ops)
 
 ## What Pluxx Treats As Core
 
@@ -414,16 +413,17 @@ export default definePlugin({
 ```bash
 $ npx @orchid-labs/pluxx build
 
-Building for: claude-code, cursor, codex, opencode, github-copilot, openhands, warp
+Building for: claude-code, cursor, codex, opencode
 
   dist/claude-code/    .claude-plugin/plugin.json, .mcp.json, CLAUDE.md, hooks/hooks.json
   dist/cursor/         .cursor-plugin/plugin.json, mcp.json, hooks/hooks.json, rules/
   dist/codex/          .codex-plugin/plugin.json, .mcp.json, AGENTS.md, interface metadata
   dist/opencode/       package.json, index.ts wrapper
-  ...
 
-Done! 85 files generated across 11 platforms.
+Done! Output in dist/
 ```
+
+The prime-time target set is still Claude Code, Cursor, Codex, and OpenCode. Additional generators exist, but the release-smoke proof is centered on the core four.
 
 ### Step 3: Lint
 
@@ -479,6 +479,14 @@ $ npx @orchid-labs/pluxx install --target claude-code
 Installed 1 plugin(s). Reload or restart your tools to pick them up.
 Claude Code note: if Claude is already open, run /reload-plugins in the session to pick up the new install.
 ```
+
+After install, verify the host-visible state instead of trusting `dist/` alone:
+
+```bash
+$ npx @orchid-labs/pluxx verify-install --target claude-code
+```
+
+`verify-install` checks installed paths, stale cache/version issues, consumer-side bundle shape, and installed stdio MCP runtime launch behavior.
 
 ### Step 6: Sync later
 
@@ -569,7 +577,7 @@ Your single `INSTRUCTIONS.md` becomes the right file for each platform:
 | Cline | `.clinerules` |
 | AMP | `AGENT.md` |
 
-### 47 Lint Checks
+### Validation And Install Checks
 
 pluxx catches platform-specific gotchas before you ship:
 
@@ -580,20 +588,24 @@ pluxx catches platform-specific gotchas before you ship:
 - Claude Code hook events must be PascalCase (26 valid events)
 - Manifest paths must start with `./` and cannot contain `../`
 - Plugin directories must be at root, not inside `.claude-plugin/`
-- And 40 more checks across all 11 platforms
+- local stdio MCP bundles must carry the runtime payloads their installed config references
+- installed stdio MCP commands must survive smoke-launch checks during `doctor --consumer` and `verify-install`
+- Cursor and Codex warn earlier when richer listing metadata could be rendered but `brand.icon` or `brand.screenshots` are missing
 
 ## The Next Product Delta
 
-The most important remaining gaps from the tightened extension-systems review are:
+The core-four compiler sprint has moved past the old "define the buckets" phase.
 
-1. `userConfig`
-2. `permissions`
-3. build-time target cap validation
-4. publish / marketplace generation
-5. deeper MCP protocol support beyond `tools/list`
-6. portable agent / subagent delegation
+The current follow-on work is narrower:
 
-That is the real delta from the current strong engine to the mature cross-host plugin product.
+1. finish the deeper hook-registry rollout so generator routing and docs rows use one registry-backed truth
+2. continue the shared `skills` parser into a richer canonical skill spec
+3. extend command IR beyond `argument-hint` into richer argument and routing metadata
+4. reduce lossy import paths in `migrate` and installed-MCP discovery
+5. make installed hook env parity portable outside the Claude-specific wrapper path
+6. keep public proof packaging aligned with the `docs-ops`, `exa-plugin`, self-hosted Pluxx, and `platform-change-ops` examples
+
+The later trust/distribution layer remains strategically interesting, but it is not the current build center.
 
 ## Supported Platforms
 

--- a/site/overview/core-primitives.mdx
+++ b/site/overview/core-primitives.mdx
@@ -32,7 +32,7 @@ Everything else is secondary until this layer is strong.
 
 ## Compiler Buckets
 
-The list above is the detailed authoring model.
+The list above is the detailed authoring model. The eight compiler buckets below are the important top-level primitives.
 
 For cross-host compilation, Pluxx should reason about that model through eight larger buckets:
 

--- a/site/overview/start-here.mdx
+++ b/site/overview/start-here.mdx
@@ -1,0 +1,107 @@
+---
+title: Start Here
+---
+
+Pluxx turns one plugin source project into native plugin bundles for Claude Code, Cursor, Codex, and OpenCode.
+
+## What Pluxx does
+
+Pluxx takes either:
+
+- a raw MCP server
+- an MCP already configured in a host
+- an existing host-native plugin
+- a hand-authored Pluxx source project
+
+and produces:
+
+- one maintained source project
+- validation and install checks
+- native host bundles under `dist/`
+- local installs that can be verified with `pluxx verify-install`
+
+The point is not to make every host identical. The point is to preserve plugin intent once and compile the strongest honest native version for each host.
+
+## Problems Pluxx solves
+
+| Problem | What Pluxx does |
+|---|---|
+| One MCP is not a good plugin experience by itself | Adds skills, commands, instructions, setup guidance, hooks, permissions, and packaging around the MCP |
+| Four hosts have four plugin formats | Compiles one source project into Claude Code, Cursor, Codex, and OpenCode outputs |
+| Auth and local runtime wiring drift across hosts | Models import auth, runtime auth, user config, local stdio runtimes, and installed-runtime checks explicitly |
+| One strong Claude or Cursor plugin is hard to port | `pluxx migrate <path>` imports it into a cross-host source project |
+| Generated files can look valid but fail after install | `pluxx test --install` and `pluxx verify-install` inspect the host-visible installed bundle |
+| Raw tool lists become noisy plugins | Agent Mode and taxonomy refinement turn low-level tools into workflow-shaped skills and commands |
+
+## The core 8 primitives
+
+These are the compiler buckets Pluxx preserves and translates:
+
+| Primitive | What it means |
+|---|---|
+| `instructions` | Shared host guidance: `CLAUDE.md`, `AGENTS.md`, Cursor rules, OpenCode instructions |
+| `skills` | The main workflow units users and agents should discover |
+| `commands` | Explicit native entrypoints where the host supports them |
+| `agents` | Specialist or delegated execution surfaces |
+| `hooks` | Deterministic lifecycle automation and policy checks |
+| `permissions` | Portable `allow` / `ask` / `deny` intent |
+| `runtime` | MCP config, auth, local stdio runtimes, scripts, passthrough files |
+| `distribution` | `userConfig`, brand metadata, icons, screenshots, install and publish metadata |
+
+`taxonomy` is internal glue. It helps Pluxx derive useful skills, commands, instructions, and agents, but it is not a host-facing primitive.
+
+## Which path should I use?
+
+| Starting point | Command |
+|---|---|
+| Raw remote MCP | `pluxx init --from-mcp https://example.com/mcp --yes` |
+| Local stdio MCP | `pluxx init --from-mcp "npx -y -p @acme/mcp acme-mcp" --yes` |
+| MCP already configured in a host | `pluxx discover-mcp` then `pluxx init --from-installed-mcp codex:acme --yes` |
+| Existing host-native plugin | `pluxx migrate ./existing-plugin` |
+| One-shot proof | `pluxx autopilot --from-mcp <source> --runner codex --mode standard --install --install-target codex --trust` |
+
+After any import or migration:
+
+```bash
+pluxx doctor
+pluxx lint
+pluxx eval
+pluxx test
+```
+
+For local install proof:
+
+```bash
+pluxx test --install --trust
+pluxx verify-install --target codex
+```
+
+## How to navigate the codebase
+
+| Area | Where to look |
+|---|---|
+| CLI command routing | `src/cli/index.ts` |
+| MCP import | `src/cli/init-from-mcp.ts`, `src/mcp/introspect.ts` |
+| Installed MCP discovery | `src/cli/discover-installed-mcp.ts` |
+| Migration | `src/cli/migrate.ts` |
+| Agent Mode and autopilot context | `src/cli/agent.ts` |
+| Build generators | `src/generators/*/index.ts` |
+| Shared Claude-family generation | `src/generators/shared/claude-family.ts` |
+| Config schema | `src/schema.ts`, `src/config/load.ts`, `src/config/define.ts` |
+| Lint and validation rules | `src/cli/lint.ts`, `src/validation/platform-rules.ts` |
+| Install and verify-install | `src/cli/install.ts`, `src/cli/verify-install.ts` |
+| Runtime readiness | `src/readiness.ts`, `src/runtime-readiness-registry.ts` |
+| Hook translation | `src/hook-events.ts`, `src/hook-translation-registry.ts` |
+| Permissions | `src/permissions.ts` |
+| Shared skill parsing | `src/skills.ts` |
+| Examples | `example/docs-ops`, `example/exa-plugin`, `example/platform-change-ops`, `example/pluxx` |
+| Mintlify docs | `site/` |
+| Repo planning docs | `docs/start-here.md`, `docs/todo/queue.md`, `docs/todo/master-backlog.md`, `docs/roadmap.md` |
+
+## What to read next
+
+- [Getting Started](/getting-started/getting-started): build your first source project.
+- [Command Decision Tree](/getting-started/command-decision-tree): choose the next command.
+- [Which Example Should I Use?](/examples/which-example): pick one concrete proof example.
+- [Core Primitives](/overview/core-primitives): see the fuller primitive model.
+- [CLI Reference](/reference/cli-reference): look up flags and edge cases.

--- a/site/overview/what-pluxx-is.mdx
+++ b/site/overview/what-pluxx-is.mdx
@@ -2,11 +2,13 @@
 title: What Pluxx Is
 ---
 
-Pluxx is the cross-host compiler for MCP-backed plugins.
+Pluxx is the cross-host compiler for MCP-backed and host-native agent plugins.
 
 It gives you one maintained source project, normalizes the plugin primitives that drift across hosts, and compiles native outputs for Claude Code, Cursor, Codex, and OpenCode.
 
-You can start from a raw MCP with `pluxx init --from-mcp ...` or import an existing host-native plugin with `pluxx migrate <path>`.
+You can start from a raw MCP with `pluxx init --from-mcp ...`, import an MCP that is already configured in a local host with `pluxx discover-mcp` and `pluxx init --from-installed-mcp ...`, or import an existing host-native plugin with `pluxx migrate <path>`.
+
+For the shortest product, primitive, migration, and codebase map, read [Start Here](/overview/start-here).
 
 ## The source project
 
@@ -47,6 +49,8 @@ Pluxx has two command layers.
 These commands do not invoke Claude Code, Codex, Cursor, or OpenCode:
 
 - `pluxx init --from-mcp ...`
+- `pluxx discover-mcp`
+- `pluxx init --from-installed-mcp ...`
 - `pluxx sync`
 - `pluxx doctor`
 - `pluxx doctor --consumer <bundle>`
@@ -55,11 +59,14 @@ These commands do not invoke Claude Code, Codex, Cursor, or OpenCode:
 - `pluxx build`
 - `pluxx test`
 - `pluxx install`
+- `pluxx verify-install`
 - `pluxx migrate <path>`
 - `pluxx mcp proxy --record ...`
 - `pluxx mcp proxy --replay ...`
+- `pluxx --version`
+- `pluxx upgrade`
 
-This layer handles import, file generation, validation, build, install, migration, and deterministic MCP replay.
+This layer handles import, file generation, validation, build, install, installed-state verification, migration, lifecycle ergonomics, and deterministic MCP replay.
 
 ### Agent layer
 
@@ -79,6 +86,26 @@ This layer is for semantic refinement:
 Pluxx keeps ownership of structure and packaging. The host agent only works inside the refinement boundary Pluxx prepares.
 
 ## What the main commands are for
+
+### `pluxx discover-mcp` and `pluxx init --from-installed-mcp ...`
+
+Use installed MCP discovery when the MCP already exists in a local host config and you want Pluxx to turn that setup into a maintained source project.
+
+Example user story:
+
+> I already configured an MCP in Codex or Claude Code. I want to import that server without copying secrets by hand.
+
+`discover-mcp` reads common Claude Code, Cursor, Codex, and OpenCode MCP config locations. `init --from-installed-mcp <host:name>` imports the selected server and normalizes auth without copying literal secret values.
+
+### `pluxx verify-install`
+
+Use `verify-install` after local install when you need to know whether the host-visible bundle is actually present and shaped correctly.
+
+Example user story:
+
+> The build passed, but I need to know whether Codex or Claude Code will see the installed plugin I just generated.
+
+`verify-install` checks installed paths, stale cache/version problems, installed bundle shape, and consumer-side runtime checks. For installed stdio MCP bundles, it also smoke-launches the installed command instead of passing on file shape alone.
 
 ### `pluxx eval`
 
@@ -131,6 +158,15 @@ npx @orchid-labs/pluxx lint
 npx @orchid-labs/pluxx eval
 npx @orchid-labs/pluxx build
 npx @orchid-labs/pluxx test
+npx @orchid-labs/pluxx install --target codex
+npx @orchid-labs/pluxx verify-install --target codex
+```
+
+If the MCP is already installed in a host:
+
+```bash
+npx @orchid-labs/pluxx discover-mcp
+npx @orchid-labs/pluxx init --from-installed-mcp codex:acme --yes
 ```
 
 If the scaffold needs better naming or instructions:

--- a/site/overview/why-pluxx.mdx
+++ b/site/overview/why-pluxx.mdx
@@ -8,6 +8,8 @@ Each host has its own plugin model, runtime wiring, install surface, and idea of
 
 Without Pluxx, teams usually end up with one "real" plugin and a growing pile of weaker ports for the other hosts.
 
+If you want the shortest product and codebase map first, read [Start Here](/overview/start-here).
+
 ## The status quo
 
 Before Pluxx, teams typically had to:

--- a/site/reference/cli-reference.mdx
+++ b/site/reference/cli-reference.mdx
@@ -13,6 +13,25 @@ That split is intentional. Pluxx owns import, validation, packaging, installatio
 
 These commands do not invoke Claude Code, Codex, Cursor, or OpenCode.
 
+### `pluxx --version`
+
+Print the installed CLI version.
+
+```bash
+pluxx --version
+```
+
+### `pluxx upgrade [--version ...]`
+
+Upgrade the global npm install used by `pluxx` on your `PATH`.
+
+```bash
+pluxx upgrade
+pluxx upgrade --version x.y.z
+```
+
+Repo-local `node ../../bin/pluxx.js ...` and `npx @orchid-labs/pluxx ...` are separate entrypoints.
+
 ### `pluxx init --from-mcp ...`
 
 Scaffold a Pluxx source project from a live MCP server or local stdio command.
@@ -51,6 +70,27 @@ npx @orchid-labs/pluxx init --from-mcp https://example.com/mcp --approve-mcp-too
 That flag writes canonical permission intent into `pluxx.config.ts`:
 
 - `permissions.allow = ["MCP(<server>.*)"]`
+
+### `pluxx discover-mcp`
+
+List MCP servers already configured in supported local host configs.
+
+```bash
+npx @orchid-labs/pluxx discover-mcp
+npx @orchid-labs/pluxx discover-mcp --host codex opencode --json
+```
+
+Discovery covers Claude Code, Cursor, Codex, and OpenCode. Use it when a working MCP already exists in a host and you want to turn that setup into a maintained Pluxx source project.
+
+### `pluxx init --from-installed-mcp <host:name>`
+
+Scaffold from one discovered installed MCP server.
+
+```bash
+npx @orchid-labs/pluxx init --from-installed-mcp codex:acme --yes
+```
+
+The import preserves source shape and env references without copying literal secret values from host config.
 
 ### `pluxx sync [--from-mcp ...]`
 
@@ -142,6 +182,12 @@ If a host still looks wrong after install, follow it with:
 npx @orchid-labs/pluxx doctor --consumer <installed-path>
 ```
 
+Use `--behavioral` with `--install --trust` when the project includes an installed-host example-query smoke set:
+
+```bash
+npx @orchid-labs/pluxx test --install --trust --behavioral
+```
+
 ### `pluxx install --target ...`
 
 Install built bundles into local host tooling for testing.
@@ -149,6 +195,22 @@ Install built bundles into local host tooling for testing.
 ```bash
 npx @orchid-labs/pluxx install --target claude-code,codex
 ```
+
+If the plugin contains local hooks, pass `--trust` after reviewing them:
+
+```bash
+npx @orchid-labs/pluxx install --target codex --trust
+```
+
+### `pluxx verify-install --target ...`
+
+Inspect installed host-visible plugin state.
+
+```bash
+npx @orchid-labs/pluxx verify-install --target codex
+```
+
+`verify-install` checks installed paths, stale cache/version problems, consumer-side bundle shape, and installed stdio MCP runtime launch behavior.
 
 ### `pluxx migrate <path>`
 
@@ -256,6 +318,18 @@ Use `--mode quick|standard|thorough` to control how much semantic refinement aut
 
 `pluxx autopilot` accepts the same `--ingest-provider auto|local|firecrawl` flag and passes it through to the shared docs-ingestion layer used by Agent Mode.
 
+Autopilot can also build, install one selected host, and run installed-state verification in the same flow:
+
+```bash
+npx @orchid-labs/pluxx autopilot \
+  --from-mcp https://example.com/mcp \
+  --runner codex \
+  --mode standard \
+  --install \
+  --install-target codex \
+  --trust
+```
+
 If you want autopilot to seed a fully preapproved MCP permission policy in the generated source project:
 
 ```bash
@@ -282,6 +356,7 @@ The host agent is not used for:
 - evaluation
 - bundle generation
 - install
+- installed-state verification
 - proxy record/replay
 - migration
 - consumer-side doctor checks

--- a/site/workflows/import-from-mcp.mdx
+++ b/site/workflows/import-from-mcp.mdx
@@ -7,6 +7,7 @@ This workflow creates the deterministic first scaffold from a raw MCP source.
 Use it when you want to:
 
 - inspect a live MCP surface
+- import an MCP that is already configured in a local host
 - generate a Pluxx source project
 - validate the baseline before any agent-driven refinement
 
@@ -63,6 +64,15 @@ Legacy SSE MCP:
 npx @orchid-labs/pluxx init --from-mcp https://example.com/sse --transport sse --yes
 ```
 
+Already-installed MCP config:
+
+```bash
+npx @orchid-labs/pluxx discover-mcp
+npx @orchid-labs/pluxx init --from-installed-mcp codex:acme --yes
+```
+
+`discover-mcp` reads common Claude Code, Cursor, Codex, and OpenCode config locations. The import normalizes env/auth references without copying literal secret values into the generated project.
+
 ## What gets generated
 
 The first pass creates a maintained source project, typically including:
@@ -80,6 +90,8 @@ my-plugin/
 ```
 
 Keep editing the source project. Treat `dist/` as generated output after `pluxx build`.
+
+For local stdio MCPs, the current import and validation path also checks whether project-relative runtime files are bundled. Pluxx can infer `passthrough` for common project-relative runtime paths, warns when installed `.mcp.json` files would point at missing payloads, and smoke-launches installed stdio MCP commands during consumer-side verification.
 
 ## Auth examples
 


### PR DESCRIPTION
## Summary
- simplify the visible Mintlify navigation into Start, Build, Learn, Examples, and Reference
- add a Start Here page that explains what Pluxx does, the problems it solves, the core 8 primitives, migration paths, and codebase navigation
- replace the long quickstart and command tree with concise practical flows
- add clearer example selection and Platform Change Ops reference pages

## Validation
- validated site/docs.json
- validated Mintlify nav page targets
- validated internal site links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Reorganized documentation navigation into Start, Build, Learn, and Examples sections
  * Streamlined getting started guide with quickstart workflow
  * Added guidance for selecting the right example for your use case
  * Updated CLI reference with new commands: `discover-mcp`, `init --from-installed-mcp`, `--version`, `upgrade`, and `verify-install`
  * Refactored command decision tree with situation-to-command table
  * Enhanced example documentation including Platform Change Ops reference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->