### PR TITLE
Reuse saved installer userConfig on reinstall

### DIFF
--- a/src/cli/publish.ts
+++ b/src/cli/publish.ts
@@ -553,17 +553,23 @@ process.exit(1)
 NODE
 }
 
+pluxx_can_prompt_config() {
+  [[ -r /dev/tty && -w /dev/tty ]] && { [[ -t 0 ]] || [[ -t 1 ]] || [[ -t 2 ]]; }
+}
+
 pluxx_prompt_secret_config() {
   local key="$1"
   local env_var="$2"
   local label="$3"
   local required="$4"
   local current_value="\${!env_var:-}"
+  local saved_value_invalid=0
 
   if [[ -z "$current_value" && "\${PLUXX_RECONFIGURE:-0}" != "1" ]]; then
     local saved_value=""
     if saved_value="$(pluxx_saved_config_value "$key" "$env_var")"; then
       if pluxx_is_placeholder_secret "$saved_value"; then
+        saved_value_invalid=1
         echo "Ignoring placeholder-looking saved config for $env_var." >&2
       else
         current_value="$saved_value"
@@ -573,11 +579,15 @@ pluxx_prompt_secret_config() {
   fi
 
   if [[ -z "$current_value" && "$required" == "1" ]]; then
-    if [[ -t 0 || -r /dev/tty ]]; then
+    if pluxx_can_prompt_config; then
       read -r -s -p "$label [$env_var]: " current_value </dev/tty
       echo >/dev/tty
     else
-      echo "Missing required config: export $env_var before running this installer." >&2
+      if [[ "$saved_value_invalid" == "1" ]]; then
+        echo "Refusing placeholder-looking saved config for $env_var. Set a real value and rerun the installer." >&2
+      else
+        echo "Missing required config: export $env_var before running this installer." >&2
+      fi
       exit 1
     fi
   fi
@@ -606,7 +616,7 @@ pluxx_prompt_text_config() {
   fi
 
   if [[ -z "$current_value" && "$required" == "1" ]]; then
-    if [[ -t 0 || -r /dev/tty ]]; then
+    if pluxx_can_prompt_config; then
       read -r -p "$label [$env_var]: " current_value </dev/tty
     else
       echo "Missing required config: export $env_var before running this installer." >&2
@@ -620,7 +630,7 @@ pluxx_prompt_text_config() {
 ${promptLines.join('\n')}
 
 if [[ "$PLUXX_REUSED_USER_CONFIG" == "1" ]]; then
-  echo "Found existing plugin config; reusing saved install values."
+  echo "Found existing $PLUGIN_NAME config; reusing saved install values."
 fi
 
 export PLUXX_USER_CONFIG_SPEC

--- a/tests/publish.test.ts
+++ b/tests/publish.test.ts
@@ -633,7 +633,7 @@ describe('runPublish', () => {
 
       expect(run.status).toBe(0)
       expect(run.stderr).toBe('')
-      expect(run.stdout).toContain('Found existing plugin config; reusing saved install values.')
+      expect(run.stdout).toContain('Found existing publish-plugin config; reusing saved install values.')
       if (platform === 'codex') {
         expect(run.installedUserConfig?.values?.['instantly-api-key']).toBeUndefined()
         expect(run.installedUserConfig?.env?.SENDLENS_INSTANTLY_API_KEY).toBeUndefined()
@@ -646,20 +646,29 @@ describe('runPublish', () => {
   })
 
   it('lets explicit env vars override saved generated-installer user config', () => {
-    const run = runGeneratedInstaller('codex', {
-      existingUserConfig: {
-        values: { 'instantly-api-key': 'old-saved-key' },
-        env: { SENDLENS_INSTANTLY_API_KEY: 'old-saved-key' },
-      },
-      env: { SENDLENS_INSTANTLY_API_KEY: 'fresh-env-key' },
-    })
+    const platforms: TargetPlatform[] = ['claude-code', 'cursor', 'codex', 'opencode']
 
-    expect(run.status).toBe(0)
-    expect(run.stderr).toBe('')
-    expect(run.stdout).not.toContain('Found existing plugin config; reusing saved install values.')
-    expect(run.installedUserConfig?.values?.['instantly-api-key']).toBeUndefined()
-    expect(run.installedUserConfig?.env?.SENDLENS_INSTANTLY_API_KEY).toBeUndefined()
-    expect(run.installedUserConfig?.envRefs?.SENDLENS_INSTANTLY_API_KEY).toBe('SENDLENS_INSTANTLY_API_KEY')
+    for (const platform of platforms) {
+      const run = runGeneratedInstaller(platform, {
+        existingUserConfig: {
+          values: { 'instantly-api-key': 'old-saved-key' },
+          env: { SENDLENS_INSTANTLY_API_KEY: 'old-saved-key' },
+        },
+        env: { SENDLENS_INSTANTLY_API_KEY: 'fresh-env-key' },
+      })
+
+      expect(run.status).toBe(0)
+      expect(run.stderr).toBe('')
+      expect(run.stdout).not.toContain('reusing saved install values')
+      if (platform === 'codex') {
+        expect(run.installedUserConfig?.values?.['instantly-api-key']).toBeUndefined()
+        expect(run.installedUserConfig?.env?.SENDLENS_INSTANTLY_API_KEY).toBeUndefined()
+        expect(run.installedUserConfig?.envRefs?.SENDLENS_INSTANTLY_API_KEY).toBe('SENDLENS_INSTANTLY_API_KEY')
+      } else {
+        expect(run.installedUserConfig?.values?.['instantly-api-key']).toBe('fresh-env-key')
+        expect(run.installedUserConfig?.env?.SENDLENS_INSTANTLY_API_KEY).toBe('fresh-env-key')
+      }
+    }
   })
 
   it('lets PLUXX_RECONFIGURE skip saved generated-installer user config', () => {
@@ -676,7 +685,7 @@ describe('runPublish', () => {
 
     expect(run.status).toBe(0)
     expect(run.stderr).toBe('')
-    expect(run.stdout).not.toContain('Found existing plugin config; reusing saved install values.')
+    expect(run.stdout).not.toContain('reusing saved install values')
     expect(run.installerContent).toContain('PLUXX_RECONFIGURE')
     expect(run.installedUserConfig?.values?.['instantly-api-key']).toBeUndefined()
     expect(run.installedUserConfig?.env?.SENDLENS_INSTANTLY_API_KEY).toBeUndefined()
@@ -745,11 +754,30 @@ describe('runPublish', () => {
 
     expect(secondRun.status).toBe(0)
     expect(secondRun.stderr).toBe('')
-    expect(secondRun.stdout).toContain('Found existing plugin config; reusing saved install values.')
+    expect(secondRun.stdout).toContain('Found existing publish-plugin config; reusing saved install values.')
     expect(reinstalledMcp).toContain(SECRET_REFERENCE_ENV_VAR)
     expect(reinstalledMcp).toContain(SECRET_REFERENCE_WORKSPACE_ENV_VAR)
     expect(reinstalledMcp).not.toContain(SECRET_REFERENCE_SENTINEL)
     expect(reinstalledMcp).not.toContain(SECRET_REFERENCE_WORKSPACE_SENTINEL)
+  })
+
+  it('rejects required placeholder-looking saved generated-installer secret values', () => {
+    const platforms: TargetPlatform[] = ['claude-code', 'cursor', 'codex', 'opencode']
+
+    for (const platform of platforms) {
+      const run = runGeneratedInstaller(platform, {
+        existingUserConfig: {
+          values: { 'instantly-api-key': 'your api key here' },
+          env: { SENDLENS_INSTANTLY_API_KEY: 'your api key here' },
+        },
+      })
+
+      expect(run.status).toBe(1)
+      expect(run.stdout).not.toContain('reusing saved install values')
+      expect(run.stderr).toContain('Ignoring placeholder-looking saved config for SENDLENS_INSTANTLY_API_KEY.')
+      expect(run.stderr).toContain('Refusing placeholder-looking saved config for SENDLENS_INSTANTLY_API_KEY.')
+      expect(run.installedUserConfig).toBeUndefined()
+    }
   })
 
   it('ignores placeholder-looking saved generated-installer secret values', () => {
@@ -762,7 +790,7 @@ describe('runPublish', () => {
     })
 
     expect(run.status).toBe(0)
-    expect(run.stdout).not.toContain('Found existing plugin config; reusing saved install values.')
+    expect(run.stdout).not.toContain('reusing saved install values')
     expect(run.stderr).toContain('Ignoring placeholder-looking saved config for SENDLENS_INSTANTLY_API_KEY.')
     expect(run.installedUserConfig?.values?.['instantly-api-key']).toBeUndefined()
     expect(run.installedUserConfig?.env?.SENDLENS_INSTANTLY_API_KEY).toBeUndefined()


### PR DESCRIPTION
## Summary
- reuse valid saved .pluxx-user.json values in generated Claude Code, Cursor, Codex, and OpenCode installers before replacing install dirs
- keep explicit env vars ahead of saved config, reject placeholder-looking saved required secrets with a clear error, and print a plugin-scoped non-secret reuse message
- expand generated-installer coverage for saved reuse, env override precedence, and placeholder rejection across owned host installers

Closes #257

## Validation
- npm run build
- node node_modules/vitest/vitest.mjs run tests/publish.test.ts
- node node_modules/vitest/vitest.mjs run tests/install.test.ts
- npm run typecheck
- npm test