### PR TITLE
Update release workflow action runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
         run: npm publish --provenance --access public
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           files: ${{ steps.pack.outputs.package_file }}

--- a/docs/releasing-pluxx.md
+++ b/docs/releasing-pluxx.md
@@ -102,7 +102,7 @@ The workflow intentionally fails if:
 - The published package is scoped: `@orchid-labs/pluxx`
 - The public invocation path is `npx @orchid-labs/pluxx ...`
 - The published CLI runtime is Node `>=18`
-- Release automation also uses the Node/npm toolchain
+- Release automation uses GitHub Actions Node 24 and `softprops/action-gh-release@v3` so the GitHub release step stays off the Node 20 action runtime path
 
 ## References
 

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const ROOT = resolve(import.meta.dir, '..')
+const releaseWorkflow = readFileSync(resolve(ROOT, '.github/workflows/release.yml'), 'utf-8')
+
+describe('release workflow', () => {
+  it('uses GitHub Actions runtime versions that avoid the Node 20 deprecation path', () => {
+    expect(releaseWorkflow).toMatch(/uses:\s+actions\/checkout@v5/)
+    expect(releaseWorkflow).toMatch(/uses:\s+actions\/setup-node@v5/)
+    expect(releaseWorkflow).toMatch(/node-version:\s+24/)
+    expect(releaseWorkflow).toMatch(/uses:\s+softprops\/action-gh-release@v3/)
+    expect(releaseWorkflow).not.toMatch(/uses:\s+softprops\/action-gh-release@v2/)
+  })
+})


### PR DESCRIPTION
## Summary

- Update `.github/workflows/release.yml` to use `softprops/action-gh-release@v3`.
- Add a focused release-workflow regression test that pins the release job to checkout/setup-node v5, Node 24, and `softprops/action-gh-release@v3`.
- Document the release automation runtime path in `docs/releasing-pluxx.md`.

## Upstream confirmation

- Confirmed from upstream `softprops/action-gh-release` releases that `v3.0.0` moves the action runtime from Node 20 to Node 24 and recommends using `v3` on runners that support Node 24: https://github.com/softprops/action-gh-release/releases
- Confirmed upstream README/search result states `v3` requires a GitHub Actions runtime that supports Node 24, with `v2.6.2` as the last Node 20-compatible line: https://github.com/softprops/action-gh-release
- Latest upstream release observed during verification: `v3.0.1`.

## Validation

- Orchid repo preflight: `0` failures, `16` warnings for existing optional repo artifact folders / `.agent-artifacts` setup.
- `npm test -- tests/release-workflow.test.ts` passed.
- `npm run release:check` passed end to end:
  - build passed
  - typecheck passed
  - test suite passed: `45` files, `521` tests
  - Node package runtime verification passed
  - npm dry-run pack completed

Note: an initial sandboxed `npm run release:check` run passed the full test suite but stalled during the packaged tarball install step because registry access was unavailable. I stopped that run and reran the same command with network access enabled; the rerun passed end to end.

Closes #325.
