### PR TITLE
Harden generated hook portability

### DIFF
--- a/docs/core-four-install-update-lifecycle.md
+++ b/docs/core-four-install-update-lifecycle.md
@@ -72,6 +72,8 @@ Generated `pluxx publish --github-release` Codex curl installers also handle thi
 
 Those consumer checks now also warn when the checked project is not trusted in the user Codex config, because Codex can keep project-local hooks disabled until that trust entry exists. `verify-install` now carries those `doctor --consumer` issue details through directly, so operators see the specific warning code, explanation, and fix instead of only a warning count.
 
+Generated command-hook wrappers are now Node launchers at `hooks/pluxx-hook-command-*.mjs`, not shell-invoked wrapper scripts. They quote plugin-root paths, preserve LF line endings, and discover Bash before running Bash-style hook bodies. On Windows, Git Bash or another `bash` on `PATH` is still required for Bash command hooks; when it is missing, the wrapper prints an explicit Pluxx diagnostic that names the missing Bash requirement and the hook command.
+
 If the installed Codex bundle also includes `.codex/config.generated.toml`, `doctor --consumer` and `verify-install` now inspect the checked project and user `config.toml` layers for matching per-tool `approval_mode = "approve"` stanzas. When those generated approvals have not been merged yet, Pluxx warns explicitly instead of assuming the companion file was actually applied. This is still an external merge step, not plugin-bundled enforcement.
 
 The newest live Codex proof on 2026-05-13 narrowed the remaining gap further:

--- a/docs/practical-handbook.md
+++ b/docs/practical-handbook.md
@@ -296,6 +296,12 @@ Use `--trust` if the plugin includes command hooks and you have already reviewed
 
 Use `--dry-run` to preview local install locations and trust implications.
 
+### Hook portability notes
+
+Generated Claude Code, Cursor, and Codex command hooks run through Pluxx-owned `hooks/pluxx-hook-command-*.mjs` launchers. The launcher resolves the installed plugin root, hydrates install-time user config, keeps generated files LF-terminated, and quotes plugin-root command paths so installs under directories with spaces keep working.
+
+Command hook bodies still run through Bash so existing Bash-style hooks behave consistently on macOS, Linux, and Git Bash for Windows. On Windows, install Git Bash or put `bash` on `PATH`; if Bash is unavailable, the generated launcher exits with an explicit Pluxx diagnostic instead of failing as an opaque host shell error.
+
 ### Manual sharing
 
 If you are not relying on `pluxx install`, the thing you share is the platform bundle inside the matching `dist/<platform>/` directory.

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -991,8 +991,22 @@ function findHookWrapperPaths(rootDir: string, command: string): string[] {
       if (!target) return false
       return existsSync(target)
         && basename(target).startsWith('pluxx-hook-command-')
-        && target.endsWith('.sh')
+        && (target.endsWith('.sh') || target.endsWith('.mjs'))
     })
+}
+
+function extractGeneratedHookWrapperCommand(wrapper: string): string {
+  const shellAssignment = wrapper.match(/^PLUXX_HOOK_COMMAND=(.*)$/m)?.[1]
+  if (shellAssignment) return shellAssignment
+
+  const nodeAssignment = wrapper.match(/^const COMMAND = (.*)$/m)?.[1]
+  if (!nodeAssignment) return ''
+
+  try {
+    return JSON.parse(nodeAssignment) as string
+  } catch {
+    return nodeAssignment
+  }
 }
 
 function findCodexCwdUnsafeHookCommands(rootDir: string, commands: string[]): string[] {
@@ -1006,7 +1020,7 @@ function findCodexCwdUnsafeHookCommands(rootDir: string, commands: string[]): st
 
     for (const wrapperPath of findHookWrapperPaths(rootDir, command)) {
       const wrapper = readFileSync(wrapperPath, 'utf-8')
-      const hookCommand = wrapper.match(/^PLUXX_HOOK_COMMAND=(.*)$/m)?.[1] ?? ''
+      const hookCommand = extractGeneratedHookWrapperCommand(wrapper)
       const wrapperRelativeTargets = extractRelativeBundleCommandTargets(hookCommand)
       if (wrapperRelativeTargets.length > 0 && !commandChangesToKnownPluginRoot(wrapper)) {
         issues.add(`${formatBundleRelativePath(rootDir, wrapperPath)} evaluates cwd-relative bundle target(s): ${wrapperRelativeTargets.join(', ')}`)

--- a/src/generators/codex/index.ts
+++ b/src/generators/codex/index.ts
@@ -339,7 +339,7 @@ export class CodexGenerator extends Generator {
         if (!entry.command) continue
 
         nextWrapperIndex += 1
-        const relativePath = `hooks/pluxx-hook-command-${nextWrapperIndex}.sh`
+        const relativePath = `hooks/pluxx-hook-command-${nextWrapperIndex}.mjs`
         await this.writeFile(
           relativePath,
           buildHookCommandWrapperScript(entry.command.replace('${PLUGIN_ROOT}', '${PLUXX_PLUGIN_ROOT}'), 'CODEX_PLUGIN_ROOT'),
@@ -351,7 +351,7 @@ export class CodexGenerator extends Generator {
 
         mappedEntries.push(this.buildCodexCommandHookGroup(
           codexEvent,
-          `bash "\${CODEX_PLUGIN_ROOT}/${relativePath}"`,
+          `node "\${CODEX_PLUGIN_ROOT}/${relativePath}"`,
           matcher,
           entry.timeout,
         ))

--- a/src/generators/cursor/index.ts
+++ b/src/generators/cursor/index.ts
@@ -148,12 +148,12 @@ export class CursorGenerator extends Generator {
           if (entry.model) hookDef.model = entry.model
         } else if (entry.command) {
           nextWrapperIndex += 1
-          const relativePath = `hooks/pluxx-hook-command-${nextWrapperIndex}.sh`
+          const relativePath = `hooks/pluxx-hook-command-${nextWrapperIndex}.mjs`
           await this.writeFile(
             relativePath,
             buildHookCommandWrapperScript(entry.command.replace('${PLUGIN_ROOT}', '.'), 'CURSOR_PLUGIN_ROOT'),
           )
-          hookDef.command = `bash ./${relativePath}`
+          hookDef.command = `node ./${relativePath}`
         }
         if (entry.timeout) hookDef.timeout = entry.timeout
         if (entry.matcher) hookDef.matcher = entry.matcher

--- a/src/generators/shared/claude-family.ts
+++ b/src/generators/shared/claude-family.ts
@@ -289,9 +289,9 @@ async function mapClaudeHookEntry(args: {
     const command = entry.command.replace('${PLUGIN_ROOT}', `\${${options.pluginRootVar}}`)
     const finalCommand = shouldWrapClaudeHookCommands
       ? await (async () => {
-        const relativePath = `hooks/pluxx-hook-command-${nextWrapperIndex()}.sh`
+        const relativePath = `hooks/pluxx-hook-command-${nextWrapperIndex()}.mjs`
         await writeFile(relativePath, buildHookCommandWrapperScript(command, options.pluginRootVar, 'CLAUDE_ENV_FILE'))
-        return `bash "\${${options.pluginRootVar}}/${relativePath}"`
+        return `node "\${${options.pluginRootVar}}/${relativePath}"`
       })()
       : command
 

--- a/src/hook-command-env.ts
+++ b/src/hook-command-env.ts
@@ -1,5 +1,11 @@
-function shellSingleQuote(value: string): string {
-  return `'${value.replace(/'/g, `'\"'\"'`)}'`
+const PLUGIN_ROOT_REFERENCE_PATTERN = /\$\{(?:PLUGIN_ROOT|PLUXX_PLUGIN_ROOT|CLAUDE_PLUGIN_ROOT|CURSOR_PLUGIN_ROOT|CODEX_PLUGIN_ROOT|OPENCODE_PLUGIN_ROOT)\}(?:[\\/][^\s"'`;$|&<>)]*)?/g
+
+export function quotePluginRootCommandReferences(command: string): string {
+  return command.replace(PLUGIN_ROOT_REFERENCE_PATTERN, (match, offset) => {
+    const previous = command[offset - 1]
+    if (previous === '"' || previous === "'") return match
+    return `"${match}"`
+  })
 }
 
 export function buildHookCommandWrapperScript(command: string, pluginRootVar: string, envFileVar?: string): string {
@@ -7,64 +13,101 @@ export function buildHookCommandWrapperScript(command: string, pluginRootVar: st
     throw new Error(`Invalid plugin root environment variable name: ${pluginRootVar}`)
   }
 
-  const serializedCommand = shellSingleQuote(command)
-  const exportLoader = [
-    'import { readFileSync } from "node:fs"',
-    '',
-    'const shellSingleQuote = (input) => `\'${String(input ?? "").replace(/\'/g, `\'"\'"\'`)}\'`',
-    '',
-    'const filepath = process.argv[1]',
-    'if (!filepath) process.exit(0)',
-    'const payload = JSON.parse(readFileSync(filepath, "utf8"))',
-    'const env = payload && typeof payload === "object" && payload.env && typeof payload.env === "object"',
-    '  ? payload.env',
-    '  : {}',
-    'const envRefs = payload && typeof payload === "object" && payload.envRefs && typeof payload.envRefs === "object"',
-    '  ? payload.envRefs',
-    '  : {}',
-    '',
-    'for (const [key, value] of Object.entries(env)) {',
-    '  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue',
-    '  process.stdout.write(`export ${key}=${shellSingleQuote(value)}\\0`)',
-    '}',
-    'for (const [key, envVar] of Object.entries(envRefs)) {',
-    '  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue',
-    '  if (typeof envVar !== "string" || !/^[A-Za-z_][A-Za-z0-9_]*$/.test(envVar)) continue',
-    '  if (!(envVar in process.env)) continue',
-    '  process.stdout.write(`export ${key}=${shellSingleQuote(process.env[envVar])}\\0`)',
-    '}',
-  ].join('\n')
-
-  const maybeAppendEnvFile = envFileVar
-    ? [
-        `      if [ -n "\${${envFileVar}:-}" ]; then`,
-        `        printf '%s\\n' "$pluxx_export" >> "\${${envFileVar}}"`,
-        '      fi',
-      ]
-    : []
+  const serializedCommand = JSON.stringify(quotePluginRootCommandReferences(command))
+  const serializedPluginRootVar = JSON.stringify(pluginRootVar)
+  const serializedEnvFileVar = JSON.stringify(envFileVar ?? null)
 
   return [
-    '#!/usr/bin/env bash',
-    'set -euo pipefail',
+    '#!/usr/bin/env node',
+    'import { appendFileSync, existsSync, readFileSync } from "node:fs"',
+    'import { dirname, resolve } from "node:path"',
+    'import { fileURLToPath } from "node:url"',
+    'import { spawnSync } from "node:child_process"',
     '',
-    `PLUXX_PLUGIN_ROOT="\${${pluginRootVar}:-$(cd "$(dirname "$0")/.." && pwd)}"`,
-    `export ${pluginRootVar}="$PLUXX_PLUGIN_ROOT"`,
-    'export PLUGIN_ROOT="$PLUXX_PLUGIN_ROOT"',
-    'PLUXX_USER_CONFIG_PATH="$PLUXX_PLUGIN_ROOT/.pluxx-user.json"',
+    'const shellSingleQuote = (input) => `\'${String(input ?? "").replace(/\'/g, `\'"\'"\'`)}\'`',
+    `const PLUGIN_ROOT_VAR = ${serializedPluginRootVar}`,
+    `const ENV_FILE_VAR = ${serializedEnvFileVar}`,
+    `const COMMAND = ${serializedCommand}`,
     '',
-    'if [ -f "$PLUXX_USER_CONFIG_PATH" ]; then',
-    '  while IFS= read -r -d \'\' pluxx_export; do',
-    '    if [ -n "$pluxx_export" ]; then',
-    '      eval "$pluxx_export"',
-    ...maybeAppendEnvFile,
-    '    fi',
-    '  done < <(',
-    `    node --input-type=module -e ${shellSingleQuote(exportLoader)} "$PLUXX_USER_CONFIG_PATH"`,
-    '  )',
-    'fi',
+    'const scriptPath = fileURLToPath(import.meta.url)',
+    'const pluginRoot = resolve(process.env[PLUGIN_ROOT_VAR] || dirname(scriptPath) + "/..")',
+    'process.env[PLUGIN_ROOT_VAR] = pluginRoot',
+    'process.env.PLUGIN_ROOT = pluginRoot',
+    'process.env.PLUXX_PLUGIN_ROOT = pluginRoot',
     '',
-    `PLUXX_HOOK_COMMAND=${serializedCommand}`,
-    'eval "$PLUXX_HOOK_COMMAND"',
+    'const userConfigPath = resolve(pluginRoot, ".pluxx-user.json")',
+    'if (existsSync(userConfigPath)) {',
+    '  const payload = JSON.parse(readFileSync(userConfigPath, "utf8"))',
+    '  const env = payload && typeof payload === "object" && payload.env && typeof payload.env === "object"',
+    '    ? payload.env',
+    '    : {}',
+    '  const envRefs = payload && typeof payload === "object" && payload.envRefs && typeof payload.envRefs === "object"',
+    '    ? payload.envRefs',
+    '    : {}',
+    '',
+    '  for (const [key, value] of Object.entries(env)) {',
+    '    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue',
+    '    process.env[key] = String(value)',
+    '    if (ENV_FILE_VAR && process.env[ENV_FILE_VAR]) {',
+    '      appendFileSync(process.env[ENV_FILE_VAR], `export ${key}=${shellSingleQuote(String(value))}\\n`)',
+    '    }',
+    '  }',
+    '  for (const [key, envVar] of Object.entries(envRefs)) {',
+    '    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue',
+    '    if (typeof envVar !== "string" || !/^[A-Za-z_][A-Za-z0-9_]*$/.test(envVar)) continue',
+    '    if (!(envVar in process.env)) continue',
+    '    const value = String(process.env[envVar])',
+    '    process.env[key] = value',
+    '    if (ENV_FILE_VAR && process.env[ENV_FILE_VAR]) {',
+    '      appendFileSync(process.env[ENV_FILE_VAR], `export ${key}=${shellSingleQuote(value)}\\n`)',
+    '    }',
+    '  }',
+    '}',
+    '',
+    'function canRun(command) {',
+    '  const result = spawnSync(command, ["--version"], { stdio: "ignore" })',
+    '  return !result.error && result.status === 0',
+    '}',
+    '',
+    'function findBash() {',
+    '  const candidates = ["bash"]',
+    '  if (process.platform === "win32") {',
+    '    for (const value of [process.env.GIT_BASH, process.env.BASH]) {',
+    '      if (value) candidates.push(value)',
+    '    }',
+    '    candidates.push(',
+    '      "C:/Program Files/Git/bin/bash.exe",',
+    '      "C:/Program Files/Git/usr/bin/bash.exe",',
+    '      "C:/Program Files (x86)/Git/bin/bash.exe",',
+    '      "C:/Program Files (x86)/Git/usr/bin/bash.exe",',
+    '    )',
+    '  }',
+    '  for (const candidate of candidates) {',
+    '    if (canRun(candidate)) return candidate',
+    '  }',
+    '  return null',
+    '}',
+    '',
+    'const bash = findBash()',
+    'if (!bash) {',
+    '  console.error("[pluxx] Cannot run generated hook command because bash was not found.")',
+    '  console.error("[pluxx] Install Git Bash on Windows or make bash available on PATH, then rebuild/reinstall the plugin.")',
+    '  console.error("[pluxx] Hook command: " + COMMAND)',
+    '  process.exit(127)',
+    '}',
+    '',
+    'const result = spawnSync(bash, ["-lc", COMMAND], {',
+    '  cwd: pluginRoot,',
+    '  env: process.env,',
+    '  stdio: "inherit",',
+    '})',
+    '',
+    'if (result.error) {',
+    '  console.error(`[pluxx] Failed to run generated hook command with ${bash}: ${result.error.message}`)',
+    '  process.exit(1)',
+    '}',
+    '',
+    'process.exit(result.status ?? (result.signal ? 128 : 1))',
     '',
   ].join('\n')
 }

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -586,28 +586,32 @@ describe('build', () => {
     const opencodeIndex = readFileSync(resolve(TEST_DIR, 'hook-env-dist/opencode/index.ts'), 'utf-8')
 
     expect(claudeHooks.hooks.SessionStart[0].hooks[0].command).toBe(
-      'bash "${CLAUDE_PLUGIN_ROOT}/hooks/pluxx-hook-command-1.sh"',
+      'node "${CLAUDE_PLUGIN_ROOT}/hooks/pluxx-hook-command-1.mjs"',
     )
-    expect(cursorHooks.hooks.sessionStart[0].command).toBe('bash ./hooks/pluxx-hook-command-1.sh')
+    expect(cursorHooks.hooks.sessionStart[0].command).toBe('node ./hooks/pluxx-hook-command-1.mjs')
     expect(codexHooks.hooks.SessionStart[0].hooks[0].type).toBe('command')
-    expect(codexHooks.hooks.SessionStart[0].hooks[0].command).toBe('bash "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-1.sh"')
+    expect(codexHooks.hooks.SessionStart[0].hooks[0].command).toBe('node "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-1.mjs"')
     expect(opencodeIndex).toContain('const buildHookShellCommand = (rawCommand: string): string => {')
     expect(opencodeIndex).toContain('const userConfig = loadUserConfig(directory)')
     expect(opencodeIndex).toContain('const userEnvRefs = userConfig.envRefs ?? {}')
     expect(opencodeIndex).toContain('Object.entries(userEnvRefs)')
 
-    const wrapperPath = resolve(TEST_DIR, 'hook-env-dist/claude-code/hooks/pluxx-hook-command-1.sh')
+    const wrapperPath = resolve(TEST_DIR, 'hook-env-dist/claude-code/hooks/pluxx-hook-command-1.mjs')
     const wrapper = readFileSync(wrapperPath, 'utf-8')
     expect(wrapper).toContain('.pluxx-user.json')
     expect(wrapper).toContain('CLAUDE_ENV_FILE')
-    expect(wrapper).toContain('PLUXX_HOOK_COMMAND=')
+    expect(wrapper).toContain('const COMMAND =')
+    expect(wrapper).toContain('Cannot run generated hook command because bash was not found.')
+    expect(wrapper).not.toContain('\r\n')
 
-    const cursorWrapper = readFileSync(resolve(TEST_DIR, 'hook-env-dist/cursor/hooks/pluxx-hook-command-1.sh'), 'utf-8')
-    const codexWrapper = readFileSync(resolve(TEST_DIR, 'hook-env-dist/codex/hooks/pluxx-hook-command-1.sh'), 'utf-8')
+    const cursorWrapper = readFileSync(resolve(TEST_DIR, 'hook-env-dist/cursor/hooks/pluxx-hook-command-1.mjs'), 'utf-8')
+    const codexWrapper = readFileSync(resolve(TEST_DIR, 'hook-env-dist/codex/hooks/pluxx-hook-command-1.mjs'), 'utf-8')
     expect(cursorWrapper).toContain('.pluxx-user.json')
-    expect(cursorWrapper).toContain('PLUXX_HOOK_COMMAND=')
+    expect(cursorWrapper).toContain('const COMMAND =')
+    expect(cursorWrapper).not.toContain('\r\n')
     expect(codexWrapper).toContain('.pluxx-user.json')
-    expect(codexWrapper).toContain('PLUXX_HOOK_COMMAND=')
+    expect(codexWrapper).toContain('const COMMAND =')
+    expect(codexWrapper).not.toContain('\r\n')
 
     writeFileSync(
       resolve(TEST_DIR, 'hook-env-dist/claude-code/.pluxx-user.json'),
@@ -622,7 +626,7 @@ describe('build', () => {
     )
     writeFileSync(resolve(TEST_DIR, 'hook-env-dist/claude-code/.claude-env.sh'), '')
 
-    const run = spawnSync('bash', [wrapperPath], {
+    const run = spawnSync('node', [wrapperPath], {
       cwd: resolve(TEST_DIR, 'hook-env-dist/claude-code'),
       encoding: 'utf-8',
       env: {
@@ -664,7 +668,7 @@ describe('build', () => {
         }, null, 2),
       )
 
-      const runWrappedHook = spawnSync('bash', [resolve(TEST_DIR, `hook-env-dist/${platform}/hooks/pluxx-hook-command-1.sh`)], {
+      const runWrappedHook = spawnSync('node', [resolve(TEST_DIR, `hook-env-dist/${platform}/hooks/pluxx-hook-command-1.mjs`)], {
         cwd: platform === 'codex'
           ? TEST_DIR
           : resolve(TEST_DIR, `hook-env-dist/${platform}`),
@@ -680,6 +684,65 @@ describe('build', () => {
       expect(runWrappedHook.status).toBe(0)
       expect(runWrappedHook.stdout).toBe(JSON.stringify(multilineSecret))
     }
+  })
+
+  it('quotes generated hook commands so plugin roots with spaces still execute', async () => {
+    const rootDir = resolve(TEST_DIR, 'hook path with spaces')
+    const outDir = resolve(rootDir, 'dist')
+    rmSync(rootDir, { recursive: true, force: true })
+    mkdirSync(resolve(rootDir, 'skills/basic'), { recursive: true })
+    mkdirSync(resolve(rootDir, 'scripts'), { recursive: true })
+    writeFileSync(resolve(rootDir, 'skills/basic/SKILL.md'), '---\nname: basic\ndescription: Basic skill\n---\n\nBasic skill body.\n')
+    writeFileSync(
+      resolve(rootDir, 'scripts/proof.sh'),
+      '#!/bin/bash\nprintf "%s" "$PLUGIN_ROOT" > ./space-proof.txt\n',
+    )
+
+    const config: PluginConfig = {
+      ...testConfig,
+      name: 'hook-space-plugin',
+      skills: './skills/',
+      hooks: {
+        preToolUse: [{ command: 'bash ${PLUGIN_ROOT}/scripts/proof.sh' }],
+      },
+      commands: undefined,
+      agents: undefined,
+      scripts: './scripts/',
+      assets: undefined,
+      passthrough: undefined,
+      instructions: undefined,
+      targets: ['claude-code', 'cursor', 'codex'],
+      outDir: './dist',
+    }
+
+    await build(config, rootDir)
+
+    const claudeHooks = JSON.parse(readFileSync(resolve(outDir, 'claude-code/hooks/hooks.json'), 'utf-8'))
+    const cursorHooks = JSON.parse(readFileSync(resolve(outDir, 'cursor/hooks/hooks.json'), 'utf-8'))
+    const codexHooks = JSON.parse(readFileSync(resolve(outDir, 'codex/hooks/hooks.json'), 'utf-8'))
+    expect(claudeHooks.hooks.PreToolUse?.[0]?.hooks?.[0]?.command).toBe('node "${CLAUDE_PLUGIN_ROOT}/hooks/pluxx-hook-command-1.mjs"')
+    expect(cursorHooks.hooks.preToolUse?.[0]?.command).toBe('node ./hooks/pluxx-hook-command-1.mjs')
+    expect(codexHooks.hooks.PreToolUse?.[0]?.hooks?.[0]?.command).toBe('node "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-1.mjs"')
+
+    const claudeWrapperPath = resolve(outDir, 'claude-code/hooks/pluxx-hook-command-1.mjs')
+    const cursorWrapperPath = resolve(outDir, 'cursor/hooks/pluxx-hook-command-1.mjs')
+    const codexWrapperPath = resolve(outDir, 'codex/hooks/pluxx-hook-command-1.mjs')
+    for (const wrapperPath of [claudeWrapperPath, cursorWrapperPath, codexWrapperPath]) {
+      const wrapper = readFileSync(wrapperPath, 'utf-8')
+      expect(wrapper).toContain('/scripts/proof.sh')
+      if (wrapperPath !== cursorWrapperPath) {
+        expect(wrapper).toContain('const COMMAND = "bash \\"')
+        expect(wrapper).toContain('/scripts/proof.sh\\""')
+      }
+      expect(wrapper).not.toContain('\r\n')
+    }
+
+    const runClaudeHook = spawnSync('node', [claudeWrapperPath], {
+      cwd: rootDir,
+      encoding: 'utf-8',
+    })
+    expect(runClaudeHook.status).toBe(0)
+    expect(readFileSync(resolve(outDir, 'claude-code/space-proof.txt'), 'utf-8')).toBe(resolve(outDir, 'claude-code'))
   })
 
   it('carries a rich Claude-style skill fixture and supporting files into all core-four outputs', async () => {
@@ -980,10 +1043,10 @@ describe('build', () => {
     expect(cursorManifest.agents).toBe('./agents/')
     expect(cursorManifest.hooks).toBe('./hooks/hooks.json')
     expect(existsSync(resolve(OUT_DIR, 'cursor/commands/pulse.md'))).toBe(true)
-    expect(cursorHooks.hooks.sessionStart?.[0]?.command).toBe('bash ./hooks/pluxx-hook-command-1.sh')
-    expect(cursorHooks.hooks.beforeSubmitPrompt?.[0]?.command).toBe('bash ./hooks/pluxx-hook-command-2.sh')
-    expect(readFileSync(resolve(OUT_DIR, 'cursor/hooks/pluxx-hook-command-1.sh'), 'utf-8')).toContain('./scripts/validate.sh')
-    expect(readFileSync(resolve(OUT_DIR, 'cursor/hooks/pluxx-hook-command-2.sh'), 'utf-8')).toContain('./scripts/check-prompt.sh')
+    expect(cursorHooks.hooks.sessionStart?.[0]?.command).toBe('node ./hooks/pluxx-hook-command-1.mjs')
+    expect(cursorHooks.hooks.beforeSubmitPrompt?.[0]?.command).toBe('node ./hooks/pluxx-hook-command-2.mjs')
+    expect(readFileSync(resolve(OUT_DIR, 'cursor/hooks/pluxx-hook-command-1.mjs'), 'utf-8')).toContain('./scripts/validate.sh')
+    expect(readFileSync(resolve(OUT_DIR, 'cursor/hooks/pluxx-hook-command-2.mjs'), 'utf-8')).toContain('./scripts/check-prompt.sh')
     expect(cursorMcp.mcpServers['test-server'].headers.Authorization).toContain('TEST_API_KEY')
     expect(cursorAgent).toContain('Cursor translation note: stay read-only unless the parent task explicitly asks for file edits.')
     expect(cursorAgent).toContain('Cursor translation note: only delegate further subtasks when the work clearly benefits from another specialist.')
@@ -1019,7 +1082,7 @@ describe('build', () => {
       readFileSync(resolve(outDir, 'cursor/hooks/hooks.json'), 'utf-8')
     )
 
-    expect(cursorHooks.hooks.preToolUse?.[0]?.command).toBe('bash ./hooks/pluxx-hook-command-1.sh')
+    expect(cursorHooks.hooks.preToolUse?.[0]?.command).toBe('node ./hooks/pluxx-hook-command-1.mjs')
     expect(cursorHooks.hooks.unknownEvent).toBeUndefined()
   })
 
@@ -1052,12 +1115,12 @@ describe('build', () => {
     })
     expect(codexManifest.hooks).toBe('./hooks/hooks.json')
     expect(codexBundledHooks.hooks.SessionStart?.[0]?.hooks?.[0]?.type).toBe('command')
-    expect(codexBundledHooks.hooks.SessionStart?.[0]?.hooks?.[0]?.command).toBe('bash "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-1.sh"')
+    expect(codexBundledHooks.hooks.SessionStart?.[0]?.hooks?.[0]?.command).toBe('node "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-1.mjs"')
     expect(codexHooks.pluginBundleFeatureFlag).toBe('hooks')
     expect(codexHooks.generalFeatureFlag).toBe('hooks')
     expect(codexHooks.deprecatedGeneralFeatureFlag).toBe('codex_hooks')
-    expect(codexHooks.hooks.SessionStart?.[0]?.hooks?.[0]?.command).toBe('bash "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-1.sh"')
-    expect(readFileSync(resolve(OUT_DIR, 'codex/hooks/pluxx-hook-command-1.sh'), 'utf-8')).toContain('${PLUXX_PLUGIN_ROOT}/scripts/validate.sh')
+    expect(codexHooks.hooks.SessionStart?.[0]?.hooks?.[0]?.command).toBe('node "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-1.mjs"')
+    expect(readFileSync(resolve(OUT_DIR, 'codex/hooks/pluxx-hook-command-1.mjs'), 'utf-8')).toContain('${PLUXX_PLUGIN_ROOT}/scripts/validate.sh')
     expect(codexCommands.commands[0]?.id).toBe('pulse')
     expect(codexAgent).toContain('name = "escalation"')
     expect(codexAgent).toContain('description = "Escalation specialist."')
@@ -1366,20 +1429,20 @@ describe('build', () => {
 
     expect(codexBundledHooks.hooks.SessionStart?.[0]?.hooks?.[0]).toEqual({
       type: 'command',
-      command: 'bash "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-1.sh"',
+      command: 'node "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-1.mjs"',
     })
     expect(codexBundledHooks.hooks.UserPromptSubmit?.[0]?.hooks?.[0]).toEqual({
       type: 'command',
-      command: 'bash "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-2.sh"',
+      command: 'node "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-2.mjs"',
     })
     expect(codexHooks.model).toBe('pluxx.codex-hooks.v1')
     expect(codexHooks.pluginBundleFeatureFlag).toBe('hooks')
     expect(codexHooks.generalFeatureFlag).toBe('hooks')
     expect(codexHooks.deprecatedGeneralFeatureFlag).toBe('codex_hooks')
-    expect(codexHooks.hooks.SessionStart?.[0]?.hooks?.[0]?.command).toBe('bash "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-1.sh"')
-    expect(codexHooks.hooks.UserPromptSubmit?.[0]?.hooks?.[0]?.command).toBe('bash "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-2.sh"')
-    expect(readFileSync(resolve(OUT_DIR, 'codex/hooks/pluxx-hook-command-1.sh'), 'utf-8')).toContain('${PLUXX_PLUGIN_ROOT}/scripts/validate.sh')
-    expect(readFileSync(resolve(OUT_DIR, 'codex/hooks/pluxx-hook-command-2.sh'), 'utf-8')).toContain('${PLUXX_PLUGIN_ROOT}/scripts/check-prompt.sh')
+    expect(codexHooks.hooks.SessionStart?.[0]?.hooks?.[0]?.command).toBe('node "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-1.mjs"')
+    expect(codexHooks.hooks.UserPromptSubmit?.[0]?.hooks?.[0]?.command).toBe('node "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-2.mjs"')
+    expect(readFileSync(resolve(OUT_DIR, 'codex/hooks/pluxx-hook-command-1.mjs'), 'utf-8')).toContain('${PLUXX_PLUGIN_ROOT}/scripts/validate.sh')
+    expect(readFileSync(resolve(OUT_DIR, 'codex/hooks/pluxx-hook-command-2.mjs'), 'utf-8')).toContain('${PLUXX_PLUGIN_ROOT}/scripts/check-prompt.sh')
   })
 
   it('emits generated Codex hooks for newly documented native events', async () => {
@@ -1410,14 +1473,14 @@ describe('build', () => {
       unsupported?: unknown[]
     }
 
-    expect(codexBundledHooks.hooks.SubagentStart?.[0]?.hooks?.[0]?.command).toBe('bash "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-1.sh"')
-    expect(codexBundledHooks.hooks.PreCompact?.[0]?.hooks?.[0]?.command).toBe('bash "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-2.sh"')
-    expect(codexBundledHooks.hooks.PostCompact?.[0]?.hooks?.[0]?.command).toBe('bash "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-3.sh"')
-    expect(codexBundledHooks.hooks.SubagentStop?.[0]?.hooks?.[0]?.command).toBe('bash "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-4.sh"')
-    expect(codexHooks.hooks.SubagentStart?.[0]?.hooks?.[0]?.command).toBe('bash "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-1.sh"')
-    expect(codexHooks.hooks.PreCompact?.[0]?.hooks?.[0]?.command).toBe('bash "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-2.sh"')
-    expect(codexHooks.hooks.PostCompact?.[0]?.hooks?.[0]?.command).toBe('bash "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-3.sh"')
-    expect(codexHooks.hooks.SubagentStop?.[0]?.hooks?.[0]?.command).toBe('bash "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-4.sh"')
+    expect(codexBundledHooks.hooks.SubagentStart?.[0]?.hooks?.[0]?.command).toBe('node "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-1.mjs"')
+    expect(codexBundledHooks.hooks.PreCompact?.[0]?.hooks?.[0]?.command).toBe('node "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-2.mjs"')
+    expect(codexBundledHooks.hooks.PostCompact?.[0]?.hooks?.[0]?.command).toBe('node "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-3.mjs"')
+    expect(codexBundledHooks.hooks.SubagentStop?.[0]?.hooks?.[0]?.command).toBe('node "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-4.mjs"')
+    expect(codexHooks.hooks.SubagentStart?.[0]?.hooks?.[0]?.command).toBe('node "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-1.mjs"')
+    expect(codexHooks.hooks.PreCompact?.[0]?.hooks?.[0]?.command).toBe('node "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-2.mjs"')
+    expect(codexHooks.hooks.PostCompact?.[0]?.hooks?.[0]?.command).toBe('node "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-3.mjs"')
+    expect(codexHooks.hooks.SubagentStop?.[0]?.hooks?.[0]?.command).toBe('node "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-4.mjs"')
     expect(codexHooks.unsupported).toBeUndefined()
   })
 
@@ -1489,18 +1552,18 @@ describe('build', () => {
     expect(codexBundledHooks.hooks.PreToolUse?.[0]?.matcher).toBe('Bash')
     expect(codexBundledHooks.hooks.PreToolUse?.[0]?.hooks?.[0]).toEqual({
       type: 'command',
-      command: 'bash "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-1.sh"',
+      command: 'node "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-1.mjs"',
     })
     expect(codexBundledHooks.hooks.PermissionRequest?.[0]?.matcher).toBe('Edit')
     expect(codexBundledHooks.hooks.PermissionRequest?.[0]?.hooks?.[0]).toEqual({
       type: 'command',
-      command: 'bash "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-2.sh"',
+      command: 'node "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-2.mjs"',
     })
     expect(codexBundledHooks.hooks.UserPromptSubmit).toBeUndefined()
     expect(codexHooks.hooks.PreToolUse?.[0]?.matcher).toBe('Bash')
-    expect(codexHooks.hooks.PreToolUse?.[0]?.hooks?.[0]?.command).toBe('bash "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-1.sh"')
+    expect(codexHooks.hooks.PreToolUse?.[0]?.hooks?.[0]?.command).toBe('node "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-1.mjs"')
     expect(codexHooks.hooks.PermissionRequest?.[0]?.matcher).toBe('Edit')
-    expect(codexHooks.hooks.PermissionRequest?.[0]?.hooks?.[0]?.command).toBe('bash "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-2.sh"')
+    expect(codexHooks.hooks.PermissionRequest?.[0]?.hooks?.[0]?.command).toBe('node "${CODEX_PLUGIN_ROOT}/hooks/pluxx-hook-command-2.mjs"')
     expect(codexHooks.hooks.PreToolUse?.[0]?.hooks?.[0]?.timeout).toBeUndefined()
     expect(codexHooks.hooks.UserPromptSubmit).toBeUndefined()
     expect(codexHooks.unsupported).toEqual(
@@ -1890,11 +1953,11 @@ describe('build', () => {
     ).toEqual([...linearMatchers])
     expect(
       claudeHooks.hooks.PreToolUse.every((group: { hooks: Array<{ command: string }> }) =>
-        group.hooks[0]?.command.startsWith('bash "${CLAUDE_PLUGIN_ROOT}/hooks/pluxx-hook-command-')
+        group.hooks[0]?.command.startsWith('node "${CLAUDE_PLUGIN_ROOT}/hooks/pluxx-hook-command-')
       )
     ).toBe(true)
     expect(
-      readFileSync(resolve(TEST_DIR, 'matcher-dist/claude-code/hooks/pluxx-hook-command-1.sh'), 'utf-8')
+      readFileSync(resolve(TEST_DIR, 'matcher-dist/claude-code/hooks/pluxx-hook-command-1.mjs'), 'utf-8')
     ).toContain('${CLAUDE_PLUGIN_ROOT}/scripts/confirm-mutation.sh')
 
     expect(cursorHooks.hooks.preToolUse).toHaveLength(linearMatchers.length)
@@ -1903,10 +1966,10 @@ describe('build', () => {
     ).toEqual([...linearMatchers])
     expect(
       cursorHooks.hooks.preToolUse.every((entry: { command: string }) =>
-        entry.command.startsWith('bash ./hooks/pluxx-hook-command-')
+        entry.command.startsWith('node ./hooks/pluxx-hook-command-')
       )
     ).toBe(true)
-    expect(readFileSync(resolve(TEST_DIR, 'matcher-dist/cursor/hooks/pluxx-hook-command-1.sh'), 'utf-8')).toContain('./scripts/confirm-mutation.sh')
+    expect(readFileSync(resolve(TEST_DIR, 'matcher-dist/cursor/hooks/pluxx-hook-command-1.mjs'), 'utf-8')).toContain('./scripts/confirm-mutation.sh')
   })
 
   it('copies skills to all targets', async () => {


### PR DESCRIPTION
## Summary
- Replace generated Claude/Cursor/Codex command-hook shell wrappers with Node launchers that resolve plugin roots, hydrate installed user config, discover Bash/Git Bash, and emit clear missing-Bash diagnostics.
- Quote plugin-root references in generated hook commands so plugin installs under paths with spaces can still execute.
- Extend build coverage for LF line endings, spaces in plugin-root paths, generated wrapper execution, and update install troubleshooting docs.

Closes #341

## Validation
- npm run typecheck
- bun test tests/build.test.ts tests/doctor.test.ts
- npm run build
- npm test