### PR TITLE
refactor: centralize command and agent primitive capability truth

### DIFF
--- a/src/agent-translation-registry.ts
+++ b/src/agent-translation-registry.ts
@@ -1,6 +1,14 @@
 import type { CanonicalAgentMetadata } from './agents'
 
-export type AgentTranslationPlatform = 'cursor' | 'codex' | 'opencode'
+export type AgentTranslationPlatform = 'claude-code' | 'cursor' | 'codex' | 'opencode'
+
+type PrimitiveTranslationMode = 'preserve' | 'translate' | 'degrade' | 'drop'
+
+export interface AgentPrimitiveCapability {
+  mode: PrimitiveTranslationMode
+  nativeSurfaces: string[]
+  notes?: string
+}
 
 interface AgentFieldDescriptor {
   key: string
@@ -15,7 +23,37 @@ interface AgentTranslationProfile {
 
 const HAS_BOOLEAN = (value: boolean | undefined): boolean => typeof value === 'boolean'
 
+const CODEX_AGENT_CAPABILITY_NOTE = 'Codex custom agents and subagents are real native surfaces, but they are not packaged the same way as Claude or Cursor plugin agents. Local May 13, 2026 headless probes now prove explicit invocation, built-in-name override, project-local precedence, and discovered `.agents/skills` inheritance. The same maintained headless suite also showed two config-depth caveats: a parent `[[skills.config]] enabled = false` entry did not disable a discovered project skill, and an agent-local `[[skills.config]]` entry did not preload an undiscovered `skills/` path. The maintained `bun scripts/probe-codex-mcp-runtime.ts --json` headless probe now also shows a more precise MCP approval split: default project-scoped and user-scoped root MCP both emit a real `mcp_tool_call` item but fail it with `user cancelled MCP tool call` before any server-side `tools/call`, while the default inline-agent path reaches startup plus `tools/list` and then falls back to `MCP_PROOF_MARKER_MISSING`. The same maintained suite now also proves five approved allow-paths: explicit `[mcp_servers.<id>.tools.<tool>] approval_mode = "approve"` works for project-scoped root MCP, user-scoped root MCP, agent-local inline `mcp_servers`, and custom agents that inherit an approved project-scoped or user-scoped root MCP server. All three approved custom-agent MCP paths still avoid a root `mcp_tool_call` item in the parent `codex exec --json` stream and instead surface child `agents_states` moving through `pending_init` to `completed`; project-scoped servers still do not appear in `codex mcp list`, and user-scoped servers do appear there. The maintained `bun scripts/probe-codex-agents-interactive-runtime.ts --json` trusted interactive probe also showed the same `sandbox_mode = "read-only"` child agent still wrote to the workspace there too, so these fields are not yet uniformly trustworthy runtime boundaries.'
+
+const AGENT_PRIMITIVE_CAPABILITIES: Record<AgentTranslationPlatform, AgentPrimitiveCapability> = {
+  'claude-code': {
+    mode: 'preserve',
+    nativeSurfaces: ['agents/*.md'],
+    notes: 'Claude plugin agents are a first-class native surface with rich frontmatter.',
+  },
+  cursor: {
+    mode: 'translate',
+    nativeSurfaces: ['agents/', '.cursor/agents/', '~/.cursor/agents/'],
+    notes: 'Cursor specialization and tool access often live more naturally in subagents than in skills.',
+  },
+  codex: {
+    mode: 'translate',
+    nativeSurfaces: ['.codex/agents/*.toml', '~/.codex/agents/*.toml', 'subagent workflows'],
+    notes: CODEX_AGENT_CAPABILITY_NOTE,
+  },
+  opencode: {
+    mode: 'preserve',
+    nativeSurfaces: ['agents/*.md', 'config agent definitions'],
+    notes: 'OpenCode agents are first-class native surfaces. Prefer permission-first agent config for new builds; legacy tools remains compatibility input, not the preferred emitted shape.',
+  },
+}
+
 const AGENT_TRANSLATION_PROFILES: Record<AgentTranslationPlatform, AgentTranslationProfile> = {
+  'claude-code': {
+    degradedFields: [],
+    guidanceSurfaces: ['agents/*.md'],
+    message: () => '',
+  },
   cursor: {
     degradedFields: [
       { key: 'mode', present: (metadata) => !!metadata.mode },
@@ -68,6 +106,10 @@ const AGENT_TRANSLATION_PROFILES: Record<AgentTranslationPlatform, AgentTranslat
     guidanceSurfaces: ['agent config notes', 'runtime/developer guidance'],
     message: (fields) => `Agent fields ${fields.map((field) => `"${field}"`).join(', ')} are not native OpenCode agent config fields today. Pluxx keeps the specialist behavior, but translates that intent through agent config notes and surrounding runtime guidance instead.`,
   },
+}
+
+export function getAgentPrimitiveCapability(platform: AgentTranslationPlatform): AgentPrimitiveCapability {
+  return AGENT_PRIMITIVE_CAPABILITIES[platform]
 }
 
 export function getTranslatedAgentFields(

--- a/src/command-translation-registry.ts
+++ b/src/command-translation-registry.ts
@@ -1,6 +1,15 @@
 import type { CanonicalCommandMetadata } from './commands'
 
-type CommandTranslationPlatform = 'codex'
+export type CommandTranslationPlatform = 'claude-code' | 'cursor' | 'codex' | 'opencode'
+type CommandDegradationPlatform = 'codex'
+
+type PrimitiveTranslationMode = 'preserve' | 'translate' | 'degrade' | 'drop'
+
+export interface CommandPrimitiveCapability {
+  mode: PrimitiveTranslationMode
+  nativeSurfaces: string[]
+  notes?: string
+}
 
 interface CommandFieldDescriptor {
   label: string
@@ -21,13 +30,41 @@ const CODEX_COMMAND_FIELD_DESCRIPTORS: CommandFieldDescriptor[] = [
 ]
 
 export const CODEX_COMMAND_GUIDANCE_SURFACES = ['skills/', 'AGENTS.md', '.codex/commands.generated.json'] as const
+const CODEX_COMMAND_GUIDANCE_NOTE = 'Current Codex docs do not document plugin-packaged slash-command parity, so Pluxx keeps canonical command intent through routing guidance plus a generated companion mirror.'
+
+const COMMAND_PRIMITIVE_CAPABILITIES: Record<CommandTranslationPlatform, CommandPrimitiveCapability> = {
+  'claude-code': {
+    mode: 'preserve',
+    nativeSurfaces: ['commands/*.md', 'skills/<skill>/SKILL.md'],
+    notes: 'Claude still supports command files, but the product is increasingly converging command workflows into skills.',
+  },
+  cursor: {
+    mode: 'preserve',
+    nativeSurfaces: ['commands/*', 'slash commands'],
+  },
+  codex: {
+    mode: 'degrade',
+    nativeSurfaces: [...CODEX_COMMAND_GUIDANCE_SURFACES],
+    notes: CODEX_COMMAND_GUIDANCE_NOTE,
+  },
+  opencode: {
+    mode: 'preserve',
+    nativeSurfaces: ['commands/*.md', 'config command definitions'],
+  },
+}
 
 export function getCodexCommandGuidanceNote(): string {
   return 'Codex does not currently document plugin-packaged slash-command parity. Pluxx keeps canonical command intent through AGENTS.md routing guidance and `.codex/commands.generated.json`.'
 }
 
-export function getTranslatedCommandFields(
+export function getCommandPrimitiveCapability(
   platform: CommandTranslationPlatform,
+): CommandPrimitiveCapability {
+  return COMMAND_PRIMITIVE_CAPABILITIES[platform]
+}
+
+export function getTranslatedCommandFields(
+  platform: CommandDegradationPlatform,
   metadata: CanonicalCommandMetadata,
 ): string[] {
   if (platform !== 'codex') return []
@@ -37,7 +74,7 @@ export function getTranslatedCommandFields(
 }
 
 export function getCommandTranslationMessage(
-  platform: CommandTranslationPlatform,
+  platform: CommandDegradationPlatform,
   degradedFields: string[],
 ): string | undefined {
   if (degradedFields.length === 0) return undefined

--- a/src/validation/platform-rules.ts
+++ b/src/validation/platform-rules.ts
@@ -1,4 +1,6 @@
 import type { PluxxCompilerBucket, TargetPlatform } from '../schema'
+import { getAgentPrimitiveCapability } from '../agent-translation-registry'
+import { getCommandPrimitiveCapability } from '../command-translation-registry'
 import { CODEX_SUPPORTED_HOOK_EVENTS } from '../hook-events'
 import { getRuntimeReadinessExternalConfigNote } from '../runtime-readiness-registry'
 
@@ -795,14 +797,10 @@ export const CORE_FOUR_PRIMITIVE_CAPABILITIES: Record<CoreFourPlatform, CoreFour
         nativeSurfaces: ['skills/<skill>/SKILL.md'],
       },
       commands: {
-        mode: 'preserve',
-        nativeSurfaces: ['commands/*.md', 'skills/<skill>/SKILL.md'],
-        notes: 'Claude still supports command files, but the product is increasingly converging command workflows into skills.',
+        ...getCommandPrimitiveCapability('claude-code'),
       },
       agents: {
-        mode: 'preserve',
-        nativeSurfaces: ['agents/*.md'],
-        notes: 'Claude plugin agents are a first-class native surface with rich frontmatter.',
+        ...getAgentPrimitiveCapability('claude-code'),
       },
       hooks: {
         mode: 'preserve',
@@ -838,13 +836,10 @@ export const CORE_FOUR_PRIMITIVE_CAPABILITIES: Record<CoreFourPlatform, CoreFour
         notes: 'Cursor skills preserve workflow meaning but document a narrower frontmatter set than Claude.',
       },
       commands: {
-        mode: 'preserve',
-        nativeSurfaces: ['commands/*', 'slash commands'],
+        ...getCommandPrimitiveCapability('cursor'),
       },
       agents: {
-        mode: 'translate',
-        nativeSurfaces: ['agents/', '.cursor/agents/', '~/.cursor/agents/'],
-        notes: 'Cursor specialization and tool access often live more naturally in subagents than in skills.',
+        ...getAgentPrimitiveCapability('cursor'),
       },
       hooks: {
         mode: 'preserve',
@@ -878,14 +873,10 @@ export const CORE_FOUR_PRIMITIVE_CAPABILITIES: Record<CoreFourPlatform, CoreFour
         nativeSurfaces: ['skills/<skill>/SKILL.md'],
       },
       commands: {
-        mode: 'degrade',
-        nativeSurfaces: ['skills/', 'AGENTS.md', '.codex/commands.generated.json'],
-        notes: 'Current Codex docs do not document plugin-packaged slash-command parity, so Pluxx keeps canonical command intent through routing guidance plus a generated companion mirror.',
+        ...getCommandPrimitiveCapability('codex'),
       },
       agents: {
-        mode: 'translate',
-        nativeSurfaces: ['.codex/agents/*.toml', '~/.codex/agents/*.toml', 'subagent workflows'],
-        notes: 'Codex custom agents and subagents are real native surfaces, but they are not packaged the same way as Claude or Cursor plugin agents. Local May 13, 2026 headless probes now prove explicit invocation, built-in-name override, project-local precedence, and discovered `.agents/skills` inheritance. The same maintained headless suite also showed two config-depth caveats: a parent `[[skills.config]] enabled = false` entry did not disable a discovered project skill, and an agent-local `[[skills.config]]` entry did not preload an undiscovered `skills/` path. The maintained `bun scripts/probe-codex-mcp-runtime.ts --json` headless probe now also shows a more precise MCP approval split: default project-scoped and user-scoped root MCP both emit a real `mcp_tool_call` item but fail it with `user cancelled MCP tool call` before any server-side `tools/call`, while the default inline-agent path reaches startup plus `tools/list` and then falls back to `MCP_PROOF_MARKER_MISSING`. The same maintained suite now also proves five approved allow-paths: explicit `[mcp_servers.<id>.tools.<tool>] approval_mode = "approve"` works for project-scoped root MCP, user-scoped root MCP, agent-local inline `mcp_servers`, and custom agents that inherit an approved project-scoped or user-scoped root MCP server. All three approved custom-agent MCP paths still avoid a root `mcp_tool_call` item in the parent `codex exec --json` stream and instead surface child `agents_states` moving through `pending_init` to `completed`; project-scoped servers still do not appear in `codex mcp list`, and user-scoped servers do appear there. The maintained `bun scripts/probe-codex-agents-interactive-runtime.ts --json` trusted interactive probe also showed the same `sandbox_mode = "read-only"` child agent still wrote to the workspace there too, so these fields are not yet uniformly trustworthy runtime boundaries.',
+        ...getAgentPrimitiveCapability('codex'),
       },
       hooks: {
         mode: 'translate',
@@ -922,13 +913,10 @@ export const CORE_FOUR_PRIMITIVE_CAPABILITIES: Record<CoreFourPlatform, CoreFour
         nativeSurfaces: ['skills/<skill>/SKILL.md'],
       },
       commands: {
-        mode: 'preserve',
-        nativeSurfaces: ['commands/*.md', 'config command definitions'],
+        ...getCommandPrimitiveCapability('opencode'),
       },
       agents: {
-        mode: 'preserve',
-        nativeSurfaces: ['agents/*.md', 'config agent definitions'],
-        notes: 'OpenCode agents are first-class native surfaces. Prefer permission-first agent config for new builds; legacy tools remains compatibility input, not the preferred emitted shape.',
+        ...getAgentPrimitiveCapability('opencode'),
       },
       hooks: {
         mode: 'translate',

--- a/tests/platform-rules.test.ts
+++ b/tests/platform-rules.test.ts
@@ -9,6 +9,8 @@ import {
   getPlatformRules,
 } from '../src/validation/platform-rules'
 import { PLUXX_COMPILER_BUCKETS } from '../src/schema'
+import { getAgentPrimitiveCapability } from '../src/agent-translation-registry'
+import { getCommandPrimitiveCapability } from '../src/command-translation-registry'
 
 describe('PLATFORM_VALIDATION_RULES', () => {
   it('has entries for all researched platforms', () => {
@@ -74,9 +76,25 @@ describe('CORE_FOUR_PRIMITIVE_CAPABILITIES', () => {
     ])
   })
 
+  it('derives command capability truth from the command translation registry', () => {
+    for (const platform of CORE_FOUR_PLATFORMS) {
+      expect(CORE_FOUR_PRIMITIVE_CAPABILITIES[platform].buckets.commands).toEqual(
+        getCommandPrimitiveCapability(platform),
+      )
+    }
+  })
+
   it('captures cursor agent translation through subagents', () => {
     expect(CORE_FOUR_PRIMITIVE_CAPABILITIES.cursor.buckets.agents.mode).toBe('translate')
     expect(CORE_FOUR_PRIMITIVE_CAPABILITIES.cursor.buckets.agents.nativeSurfaces).toContain('.cursor/agents/')
+  })
+
+  it('derives agent capability truth from the agent translation registry', () => {
+    for (const platform of CORE_FOUR_PLATFORMS) {
+      expect(CORE_FOUR_PRIMITIVE_CAPABILITIES[platform].buckets.agents).toEqual(
+        getAgentPrimitiveCapability(platform),
+      )
+    }
   })
 
   it('getCoreFourPrimitiveCapabilities returns the requested platform', () => {


### PR DESCRIPTION
## Summary

Command and agent primitive parity now has a single compiler-owned source for the core four. Platform rules consume the command and agent registries instead of restating modes, surfaces, and notes, so lint/generator messaging and primitive summaries cannot drift independently.

## Design Notes

- Command registry capability truth now covers Claude Code, Cursor, Codex, and OpenCode while retaining Codex command degradation field checks.
- Agent registry capability truth now covers the same core-four surface, including the existing Codex proof note, while existing per-field degradation warnings remain unchanged.
- Platform-rule tests now assert command and agent buckets derive from the primitive registries.

## Issue Consolidation

This is the focused code slice from the overlapping primitive-compiler issue set:

- Advances orchidautomation/pluxx#265 by moving command and agent bucket truth into compiler-owned primitive registries.
- Narrows orchidautomation/pluxx#283 to a concrete command/agent rollout path instead of a broad all-primitives sweep.
- Partially addresses orchidautomation/pluxx#291 and orchidautomation/pluxx#294 by making command and agent translation capability truth shared by validation and summaries.

The instruction, skill, hook, permission, runtime, distribution, and migrate/import fidelity issues remain intentionally out of scope for follow-up PRs.

## Validation

- `bun test tests/platform-rules.test.ts tests/primitive-summary.test.ts tests/lint.test.ts`
- `npm run typecheck`
- `npm run build`
- `npm test` 46 test files, 528 tests passed

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This is an internal compiler registry refactor with no production service, runtime migration, or hosted surface impact.

Healthy signals:
- PR CI passes the same platform-rules, primitive-summary, lint, build, and package tests.
- Build summaries continue to show command and agent native surfaces unchanged.

Failure signals:
- CI fails in `tests/platform-rules.test.ts`, `tests/primitive-summary.test.ts`, or lint translation explainability tests.
- Generated package declarations fail because registry export types are inconsistent.

Validation window and owner:
- PR author validates through CI before merge; no post-deploy runtime watch is needed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
