### PR TITLE
Document Pluxx runtime contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,12 +232,14 @@ Pluxx owns the deterministic scaffold, validation, and host compilation layer. Y
 - upgrade the active global CLI with: `pluxx upgrade`
 - published CLI runtime: Node `>=18`
 - source builds and maintainer workflows also run on Node `>=18`
+- runtime contract: [docs/runtime-contract.md](./docs/runtime-contract.md)
 
 ## Read Next
 
 - [Getting started](./docs/getting-started.md)
 - [Create a Pluxx plugin](./docs/create-a-pluxx-plugin.md)
 - [How it works](./docs/how-it-works.md)
+- [Runtime contract](./docs/runtime-contract.md)
 - [Self-hosted core-four proof](./docs/pluxx-self-hosted-core-four-proof.md)
 - [Docs Ops core-four proof](./docs/docs-ops-core-four-proof.md)
 - [Proof and install guide](./docs/proof-and-install.md)

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -110,6 +110,8 @@ Those should be documented and revisited later, not treated as the core product 
 
 Pluxx is published on npm as `@orchid-labs/pluxx`, and both the published CLI and normal maintainer flows now run on Node `>=18`.
 
+The package-level source of truth is [docs/runtime-contract.md](./runtime-contract.md).
+
 The important practical distinction is:
 
 - the CLI is the real execution engine
@@ -126,6 +128,7 @@ What is **not** true yet:
 
 - `npx pluxx ...` is not the public install path, because the published package name is scoped as `@orchid-labs/pluxx`
 - `node ./bin/pluxx.js ...` from this repo still expects a prior `npm run build`
+- old proof notes that mention `bun scripts/...` are historical probe receipts, not a current end-user runtime requirement
 
 ## How Pluxx Works Today
 

--- a/docs/proof-and-install.md
+++ b/docs/proof-and-install.md
@@ -203,8 +203,9 @@ curl -fsSL https://raw.githubusercontent.com/orchidautomation/pluxx/main/example
 
 Current release note:
 
-- the latest published npm package is `@orchid-labs/pluxx@0.1.21`
-- the published npm package now includes the Claude plugin-agent manifest fix
+- the latest published npm package is `@orchid-labs/pluxx@0.1.22`
+- the published CLI runtime is Node `>=18`; see [runtime contract](./runtime-contract.md)
+- the published package includes the Claude plugin-agent manifest fix and packaged Node runtime verification
 - the public `pluxx test --install --trust --behavioral` path now matches the repo-local Exa proof state
 
 ## Best Demo Flow

--- a/docs/releasing-pluxx.md
+++ b/docs/releasing-pluxx.md
@@ -102,6 +102,7 @@ The workflow intentionally fails if:
 - The published package is scoped: `@orchid-labs/pluxx`
 - The public invocation path is `npx @orchid-labs/pluxx ...`
 - The published CLI runtime is Node `>=18`
+- The package-level runtime source of truth is [docs/runtime-contract.md](./runtime-contract.md)
 - Release automation uses GitHub Actions Node 24 and `softprops/action-gh-release@v3` so the GitHub release step stays off the Node 20 action runtime path
 
 ## References

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -16,6 +16,7 @@ Last updated: 2026-06-24
   - [docs/docs-ops-core-four-proof.md](./docs-ops-core-four-proof.md)
   - [docs/exa-research-example.md](./exa-research-example.md)
   - [docs/release-distribution-proof-map.md](./release-distribution-proof-map.md)
+  - [docs/runtime-contract.md](./runtime-contract.md)
   - [docs/core-four-primitive-proof-ledger.md](./core-four-primitive-proof-ledger.md)
   - [docs/pluxx-plugin-surface-audit.md](./pluxx-plugin-surface-audit.md)
   - [docs/pluxx-self-hosted-core-four-proof.md](./pluxx-self-hosted-core-four-proof.md)
@@ -198,7 +199,7 @@ The closure plan is now narrower than it was before:
 - the release gate is green again as of 2026-05-19:
   - `npm test` passed
   - `npm run release:check` passed
-- the latest published npm package is `@orchid-labs/pluxx@0.1.21`
+- the latest published npm package is `@orchid-labs/pluxx@0.1.22`
 - the release/distribution/proof boundary is now explicit:
   - [docs/release-distribution-proof-map.md](./release-distribution-proof-map.md)
   - [docs/core-four-primitive-proof-ledger.md](./core-four-primitive-proof-ledger.md)
@@ -355,11 +356,11 @@ This is for learning and proof, not for prematurely building the full trust laye
 
 ### 6. Next release
 
-The current public npm cut is `0.1.21`.
+The current public npm cut is `0.1.22`.
 
 The next npm cut should stay primarily an operations step rather than a code-confidence rescue step.
 
-- start from `0.1.21`
+- start from `0.1.22`
 - rerun `npm run release:check`
 - bump `package.json` and `package-lock.json` to the next version
 - commit and push release-prep fixes and source-of-truth updates

--- a/docs/runtime-contract.md
+++ b/docs/runtime-contract.md
@@ -1,0 +1,65 @@
+# Runtime Contract
+
+Last updated: 2026-06-24
+
+## Doc Links
+
+- Role: package runtime source of truth
+- Related:
+  - [README.md](../README.md)
+  - [docs/how-it-works.md](./how-it-works.md)
+  - [docs/proof-and-install.md](./proof-and-install.md)
+  - [docs/releasing-pluxx.md](./releasing-pluxx.md)
+  - [docs/start-here.md](./start-here.md)
+  - [docs/todo/queue.md](./todo/queue.md)
+  - [docs/todo/master-backlog.md](./todo/master-backlog.md)
+  - [docs/roadmap.md](./roadmap.md)
+- Update together:
+  - [README.md](../README.md)
+  - [docs/how-it-works.md](./how-it-works.md)
+  - [docs/proof-and-install.md](./proof-and-install.md)
+
+This is the current runtime contract for `@orchid-labs/pluxx`.
+
+## Published CLI Runtime
+
+The published Pluxx CLI runs on Node `>=18`.
+
+Node is sufficient for end users running the npm package.
+
+Supported consumer invocation paths:
+
+- `npx @orchid-labs/pluxx ...`
+- `npm install -g @orchid-labs/pluxx` followed by `pluxx ...`
+- `node ./bin/pluxx.js ...` from this repo after `npm run build`
+
+The published package ships the Node launcher in `bin/` and the compiled runtime in `dist/`.
+
+## Config Loading
+
+`pluxx.config.ts` and `pluxx.config.js` are loaded under Node through `jiti`.
+
+Config imports of `pluxx` or `@orchid-labs/pluxx` are rewritten to the package runtime entry so fixture projects and installed packages do not need a separate local package alias.
+
+## Contributor Tooling
+
+Normal contributor workflows run through Node and npm:
+
+- `npm run build`
+- `npm run typecheck`
+- `npm test`
+- `node scripts/verify-node-package-runtime.mjs`
+- `npm run release:check`
+
+The test suite still carries compatibility shims for older `bun:test` imports and `Bun.*` helper calls. Those shims run under Vitest's Node environment and are not a consumer Bun dependency.
+
+Historical host probe commands may still mention `bun scripts/...` in dated proof notes. Treat those as dated probe receipts, not the published CLI runtime contract.
+
+## Release Proof
+
+The release gate includes `node scripts/verify-node-package-runtime.mjs`, which packs the npm artifact and verifies:
+
+- installed package execution through `node node_modules/@orchid-labs/pluxx/bin/pluxx.js`
+- `npm exec --package <tarball> -- pluxx ...`
+- TypeScript config loading
+- `doctor`, `validate`, and `build` on a clean fixture project

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -17,6 +17,7 @@ Last updated: 2026-06-24
   - [docs/docs-ops-authenticated-publish-path.md](./docs-ops-authenticated-publish-path.md)
   - [docs/exa-research-example.md](./exa-research-example.md)
   - [docs/release-distribution-proof-map.md](./release-distribution-proof-map.md)
+  - [docs/runtime-contract.md](./runtime-contract.md)
   - [docs/core-four-primitive-proof-ledger.md](./core-four-primitive-proof-ledger.md)
   - [docs/core-four-provider-docs-audit.md](./core-four-provider-docs-audit.md)
   - [docs/core-four-translation-hit-list.md](./core-four-translation-hit-list.md)
@@ -321,7 +322,7 @@ The repo already proves a lot.
 - the current release gate is green again as of 2026-05-19:
   - `npm test` passed
   - `npm run release:check` passed
-- the latest published npm package is `@orchid-labs/pluxx@0.1.21`
+- the latest published npm package is `@orchid-labs/pluxx@0.1.22`
 - marketplace submission APIs, a managed trust/distribution control plane, automatic rollback/unpublish orchestration, and real authenticated publish plus rollback proof remain explicit release gaps, not hidden shipped capabilities:
   - `docs/release-distribution-proof-map.md`
 - OpenCode-native agent output is now permission-first:
@@ -489,13 +490,13 @@ Run two lanes in parallel:
 
 ### 6. Release State
 
-The current public release is `0.1.21`.
+The current public release is `0.1.22`.
 
 The release checklist for the current cut is complete:
 
-- `package.json` and `package-lock.json` are at `0.1.21`
-- local `main` is tagged `v0.1.21`
-- npm reports `@orchid-labs/pluxx@0.1.21` as latest
+- `package.json` and `package-lock.json` are at `0.1.22`
+- local `main` is tagged `v0.1.22`
+- npm reports `@orchid-labs/pluxx@0.1.22` as latest
 - the GitHub release workflow reran the release gate, including package runtime verification and release tarball pack
 
 For the next release, start from the current version, rerun `npm run release:check`, bump the package version, push `main`, push the matching `vX.Y.Z` tag, and verify npm plus GitHub release artifacts after the workflow completes.

--- a/docs/todo/master-backlog.md
+++ b/docs/todo/master-backlog.md
@@ -29,6 +29,7 @@ This is not the same thing as the short queue.
   - [docs/docs-ops-core-four-proof.md](../docs-ops-core-four-proof.md)
   - [docs/exa-research-example.md](../exa-research-example.md)
   - [docs/release-distribution-proof-map.md](../release-distribution-proof-map.md)
+  - [docs/runtime-contract.md](../runtime-contract.md)
   - [docs/core-four-primitive-proof-ledger.md](../core-four-primitive-proof-ledger.md)
   - [docs/pluxx-plugin-surface-audit.md](../pluxx-plugin-surface-audit.md)
   - [docs/pluxx-self-hosted-core-four-proof.md](../pluxx-self-hosted-core-four-proof.md)
@@ -400,8 +401,8 @@ Open work:
 - [x] Validate the current self-hosting flow end to end
 - [x] Run tests, release smoke, and the packaged-runtime release gate before the next cut
 - [x] Restore example parity for `examples/prospeo-mcp` so release smoke and the real package agree again
-- [x] Publish and verify `@orchid-labs/pluxx@0.1.21`
-- [ ] For the next cut, bump `package.json` from `0.1.21` to the next version
+- [x] Publish and verify `@orchid-labs/pluxx@0.1.22`
+- [ ] For the next cut, bump `package.json` from `0.1.22` to the next version
 - [ ] Rerun `npm run release:check` before tagging
 - [ ] Commit and push release-prep fixes to `main`
 - [ ] Push the matching `vX.Y.Z` tag so the GitHub Actions release workflow publishes to npm

--- a/docs/todo/queue.md
+++ b/docs/todo/queue.md
@@ -16,6 +16,7 @@ Last updated: 2026-06-24
   - [docs/docs-ops-core-four-proof.md](../docs-ops-core-four-proof.md)
   - [docs/exa-research-example.md](../exa-research-example.md)
   - [docs/release-distribution-proof-map.md](../release-distribution-proof-map.md)
+  - [docs/runtime-contract.md](../runtime-contract.md)
   - [docs/core-four-primitive-proof-ledger.md](../core-four-primitive-proof-ledger.md)
   - [docs/pluxx-plugin-surface-audit.md](../pluxx-plugin-surface-audit.md)
   - [docs/pluxx-self-hosted-core-four-proof.md](../pluxx-self-hosted-core-four-proof.md)
@@ -176,7 +177,7 @@ The initial author-once hardening tranche is also materially done.
 The public baseline is also real.
 
 - npm package is live as `@orchid-labs/pluxx`
-- the latest published npm package is `@orchid-labs/pluxx@0.1.21`
+- the latest published npm package is `@orchid-labs/pluxx@0.1.22`
 - published CLI runtime is Node `>=18`
 - published CLI lifecycle ergonomics are now stronger for global installs:
   - `pluxx --version`
@@ -456,7 +457,7 @@ Open work:
 
 Goal:
 
-- keep the next npm release routine now that `0.1.21` is published and the code path plus packaged tarball pass the release gate
+- keep the next npm release routine now that `0.1.22` is published and the code path plus packaged tarball pass the release gate
 
 Open work:
 
@@ -464,8 +465,8 @@ Open work:
 - [x] run tests and release smoke
 - [x] restore example/release-smoke parity for `examples/prospeo-mcp`
 - [x] rerun the full release gate, including tarball install and `npm exec`
-- [x] publish and verify `@orchid-labs/pluxx@0.1.21`
-- [ ] for the next cut, bump `package.json` from `0.1.21` to the next version
+- [x] publish and verify `@orchid-labs/pluxx@0.1.22`
+- [ ] for the next cut, bump `package.json` from `0.1.22` to the next version
 - [ ] rerun `npm run release:check` before tagging
 - [ ] commit and push release-prep fixes on `main`
 - [ ] push the matching `vX.Y.Z` tag to trigger the GitHub Actions npm publish

--- a/tests/package.test.ts
+++ b/tests/package.test.ts
@@ -40,7 +40,11 @@ describe('package metadata', () => {
     expect(pkg.exports['.'].import).toBe('./dist/index.js')
     expect(pkg.engines.node).toBe('>=18')
     expect(pkg.engines.bun).toBeUndefined()
+    expect(pkg.dependencies.bun).toBeUndefined()
+    expect(pkg.devDependencies.bun).toBeUndefined()
     expect(pkg.scripts.build).toContain('scripts/build.mjs')
+    expect(pkg.scripts.test).toBe('node scripts/run-vitest-exclusive.mjs')
+    expect(pkg.scripts['release:check']).toContain('node scripts/verify-node-package-runtime.mjs')
     expect(pkg.scripts.prepublishOnly).toMatch(/npm run build/)
   })
 


### PR DESCRIPTION
## Summary

- add docs/runtime-contract.md as the package runtime source of truth
- align README/how-it-works/proof/start-here/queue/backlog/roadmap/release docs with the verified 0.1.22 Node runtime state
- pin package metadata tests so the published contract stays Node >=18, has no Bun engine/dependency, and keeps packaged Node runtime verification in the release gate

## Issue audit

- #212 remains open as the umbrella for the full runtime migration history and any future runtime fallout.
- #213, #217, #218, and #219 appear satisfied by v0.1.22 plus this source-of-truth cleanup once merged.

## Verification

- npm test -- tests/package.test.ts
- npm run typecheck
- npm run build
- node scripts/verify-node-package-runtime.mjs
- npm view @orchid-labs/pluxx version -> 0.1.22
- gh release view v0.1.22 -> published 2026-06-24T19:10:48Z
- rg stale runtime/version references: no matches for 0.1.21 or Bun-required guidance

Do not merge yet.