### PR TITLE
fix: expand docs locally after Firecrawl fallback

### DIFF
--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -293,9 +293,24 @@ interface AgentOverrides {
   reviewCriteria?: string
 }
 
+interface AgentContextIngestionProvider {
+  name: ResolvedAgentIngestProvider
+  fetchSource(
+    url: string,
+    kind: 'website' | 'docs',
+    role: AgentContextSource['role'],
+    note?: string,
+  ): Promise<AgentContextSource | null>
+  expandSources(
+    sources: AgentContextSource[],
+    seenUrls: Set<string>,
+  ): Promise<AgentContextSource[]>
+}
+
 interface AgentContextFetchStrategy {
   requestedProvider: AgentIngestProvider
   resolvedProvider: ResolvedAgentIngestProvider
+  provider: AgentContextIngestionProvider
   fallbackToLocalOnError: boolean
 }
 
@@ -1056,17 +1071,8 @@ async function collectAgentContextPackInternal(
     }
   }
 
-  const firecrawlExpandedSources = await expandFirecrawlContextSources(sources, seenUrls, ingestStrategy)
-  for (const source of firecrawlExpandedSources) {
-    const identity = normalizeUrlIdentity(source.resolvedUrl ?? source.requestedUrl ?? source.label)
-    if (seenUrls.has(identity)) continue
-    sources.push(source)
-    records.push(buildContextSourceRecord(source, true))
-    seenUrls.add(identity)
-  }
-
-  const localExpandedSources = await expandLocalContextSources(sources, seenUrls, ingestStrategy)
-  for (const source of localExpandedSources) {
+  const expandedSources = await expandContextSources(sources, seenUrls, ingestStrategy)
+  for (const source of expandedSources) {
     const identity = normalizeUrlIdentity(source.resolvedUrl ?? source.requestedUrl ?? source.label)
     if (seenUrls.has(identity)) continue
     sources.push(source)
@@ -1174,20 +1180,27 @@ async function fetchContextSource(
   role: AgentContextSource['role'],
   options: RemoteContextFetchOptions,
 ): Promise<AgentContextSource | null> {
-  if (options.strategy.resolvedProvider === 'firecrawl') {
-    const firecrawlSource = await fetchContextSourceWithFirecrawl(url, kind, role, options.note)
+  if (options.strategy.provider.name === 'firecrawl') {
+    const firecrawlSource = await options.strategy.provider.fetchSource(url, kind, role, options.note)
+    if (!firecrawlSource) {
+      return LOCAL_AGENT_CONTEXT_INGESTION_PROVIDER.fetchSource(url, kind, role, appendAgentContextNote(
+        options.note,
+        'Firecrawl scrape returned no source; fell back to local fetch.',
+      ))
+    }
+
     if (firecrawlSource.status === 'ok' || !options.strategy.fallbackToLocalOnError) {
       return firecrawlSource
     }
 
     const fallbackReason = firecrawlSource.summary.replace(/^Unavailable:\s*/i, '').replace(/\.$/, '')
-    return fetchContextSourceLocally(url, kind, role, appendAgentContextNote(
+    return LOCAL_AGENT_CONTEXT_INGESTION_PROVIDER.fetchSource(url, kind, role, appendAgentContextNote(
       options.note,
       `Firecrawl scrape failed (${fallbackReason}); fell back to local fetch.`,
     ))
   }
 
-  return fetchContextSourceLocally(url, kind, role, options.note)
+  return options.strategy.provider.fetchSource(url, kind, role, options.note)
 }
 
 async function fetchContextSourceLocally(
@@ -1335,15 +1348,30 @@ async function fetchContextSourceWithFirecrawl(
   }
 }
 
-async function expandFirecrawlContextSources(
+async function expandContextSources(
   sources: AgentContextSource[],
   seenUrls: Set<string>,
   ingestStrategy: AgentContextFetchStrategy,
 ): Promise<AgentContextSource[]> {
-  if (ingestStrategy.resolvedProvider !== 'firecrawl') {
-    return []
+  const primarySources = await ingestStrategy.provider.expandSources(sources, seenUrls)
+  if (!ingestStrategy.fallbackToLocalOnError || ingestStrategy.provider.name === 'local') {
+    return primarySources
   }
 
+  const primaryIdentities = primarySources.map((source) => normalizeUrlIdentity(source.resolvedUrl ?? source.requestedUrl ?? source.label))
+  const fallbackSeenUrls = new Set([...seenUrls, ...primaryIdentities])
+  const localFallbackSources = await LOCAL_AGENT_CONTEXT_INGESTION_PROVIDER.expandSources(
+    [...sources, ...primarySources],
+    fallbackSeenUrls,
+  )
+
+  return [...primarySources, ...localFallbackSources]
+}
+
+async function expandFirecrawlContextSources(
+  sources: AgentContextSource[],
+  seenUrls: Set<string>,
+): Promise<AgentContextSource[]> {
   const roots = prioritizeExpansionRoots(sources, 'firecrawl')
   if (roots.length === 0) {
     return []
@@ -1373,12 +1401,7 @@ async function expandFirecrawlContextSources(
 async function expandLocalContextSources(
   sources: AgentContextSource[],
   seenUrls: Set<string>,
-  ingestStrategy: AgentContextFetchStrategy,
 ): Promise<AgentContextSource[]> {
-  if (ingestStrategy.resolvedProvider !== 'local') {
-    return []
-  }
-
   const roots = prioritizeExpansionRoots(sources, 'local')
   if (roots.length === 0) {
     return []
@@ -1861,6 +1884,18 @@ interface FirecrawlBatchData {
   }
 }
 
+const LOCAL_AGENT_CONTEXT_INGESTION_PROVIDER: AgentContextIngestionProvider = {
+  name: 'local',
+  fetchSource: fetchContextSourceLocally,
+  expandSources: expandLocalContextSources,
+}
+
+const FIRECRAWL_AGENT_CONTEXT_INGESTION_PROVIDER: AgentContextIngestionProvider = {
+  name: 'firecrawl',
+  fetchSource: fetchContextSourceWithFirecrawl,
+  expandSources: expandFirecrawlContextSources,
+}
+
 function resolveAgentContextFetchStrategy(
   requestedProvider: AgentIngestProvider | undefined,
 ): AgentContextFetchStrategy {
@@ -1869,6 +1904,7 @@ function resolveAgentContextFetchStrategy(
     return {
       requestedProvider: requested,
       resolvedProvider: 'local',
+      provider: LOCAL_AGENT_CONTEXT_INGESTION_PROVIDER,
       fallbackToLocalOnError: false,
     }
   }
@@ -1880,6 +1916,7 @@ function resolveAgentContextFetchStrategy(
     return {
       requestedProvider: requested,
       resolvedProvider: 'firecrawl',
+      provider: FIRECRAWL_AGENT_CONTEXT_INGESTION_PROVIDER,
       fallbackToLocalOnError: false,
     }
   }
@@ -1888,6 +1925,7 @@ function resolveAgentContextFetchStrategy(
     return {
       requestedProvider: requested,
       resolvedProvider: 'firecrawl',
+      provider: FIRECRAWL_AGENT_CONTEXT_INGESTION_PROVIDER,
       fallbackToLocalOnError: true,
     }
   }
@@ -1895,6 +1933,7 @@ function resolveAgentContextFetchStrategy(
   return {
     requestedProvider: requested,
     resolvedProvider: 'local',
+    provider: LOCAL_AGENT_CONTEXT_INGESTION_PROVIDER,
     fallbackToLocalOnError: false,
   }
 }

--- a/tests/agent-mode.test.ts
+++ b/tests/agent-mode.test.ts
@@ -1752,6 +1752,105 @@ exit 1
     }
   })
 
+  it('uses local link expansion after auto-selected Firecrawl falls back', async () => {
+    const originalFetch = globalThis.fetch
+    const originalFirecrawlKey = process.env.FIRECRAWL_API_KEY
+    process.env.FIRECRAWL_API_KEY = 'fc-test-key'
+
+    globalThis.fetch = (async (input, init) => {
+      const request = new Request(input, init)
+      if (request.url === 'https://api.firecrawl.dev/v2/scrape') {
+        return new Response(JSON.stringify({ success: false, error: 'upstream unavailable' }), {
+          status: 502,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+
+      if (request.url === 'https://playkit.sh/') {
+        return new Response(
+          '<!doctype html><html><head><title>PlayKit</title><meta name="description" content="Clay expertise in every AI conversation."></head><body><main><h1>PlayKit</h1><a href="https://docs.playkit.sh/">Docs</a><p>Clay expertise in every AI conversation.</p></main></body></html>',
+          {
+            status: 200,
+            headers: { 'Content-Type': 'text/html; charset=utf-8' },
+          },
+        )
+      }
+
+      if (request.url === 'https://docs.playkit.sh/' || request.url === 'https://docs.playkit.sh/docs') {
+        return new Response(
+          '<!doctype html><html><head><title>PlayKit Docs</title><meta name="description" content="Clay expertise in every AI conversation."></head><body><main><h1>PlayKit Docs</h1><a href="/docs/authentication">Authentication</a><a href="/docs/quickstart">Quickstart</a><p>Connect Clay before using API tools.</p></main></body></html>',
+          {
+            status: 200,
+            headers: { 'Content-Type': 'text/html; charset=utf-8' },
+          },
+        )
+      }
+
+      if (request.url === 'https://docs.playkit.sh/docs/authentication') {
+        return new Response(
+          '<!doctype html><html><head><title>Authentication</title><meta name="description" content="Set the X-API-Key header before using hosted PlayKit MCP."></head><body><main><h1>Authentication</h1><h2>API Key Header</h2><p>Set the X-API-Key header before using hosted PlayKit MCP.</p></main></body></html>',
+          {
+            status: 200,
+            headers: { 'Content-Type': 'text/html; charset=utf-8' },
+          },
+        )
+      }
+
+      if (request.url === 'https://docs.playkit.sh/docs/quickstart') {
+        return new Response(
+          '<!doctype html><html><head><title>Quickstart</title><meta name="description" content="Install PlayKit MCP and connect Clay in a few minutes."></head><body><main><h1>Quickstart</h1><h2>Quick Setup</h2><p>Install PlayKit MCP and connect Clay in a few minutes.</p></main></body></html>',
+          {
+            status: 200,
+            headers: { 'Content-Type': 'text/html; charset=utf-8' },
+          },
+        )
+      }
+
+      throw new Error(`Unexpected fetch to ${request.url}`)
+    }) as typeof fetch
+
+    try {
+      const plan = await planAgentPrepare(TEST_DIR, {
+        websiteUrl: 'https://playkit.sh/',
+        ingestProvider: 'auto',
+      })
+      await applyAgentPreparePlan(TEST_DIR, plan)
+
+      const context = readFileSync(resolve(TEST_DIR, AGENT_CONTEXT_PATH), 'utf-8')
+      const sources = JSON.parse(readFileSync(resolve(TEST_DIR, AGENT_SOURCES_PATH), 'utf-8')) as {
+        ingestion?: {
+          requestedProvider: string
+          resolvedProvider: string
+          fallbackToLocalOnError: boolean
+        }
+        sources: Array<{ label: string; role: string; provider?: string; note?: string }>
+      }
+      const docsContext = JSON.parse(readFileSync(resolve(TEST_DIR, AGENT_DOCS_CONTEXT_PATH), 'utf-8')) as {
+        authHints: string[]
+        setupHints: string[]
+      }
+
+      expect(sources.ingestion).toEqual({
+        requestedProvider: 'auto',
+        resolvedProvider: 'firecrawl',
+        fallbackToLocalOnError: true,
+      })
+      expect(sources.sources.some((source) => source.role === 'discovered-page' && source.label === 'https://docs.playkit.sh/docs/authentication')).toBe(true)
+      expect(sources.sources.some((source) => source.role === 'discovered-page' && source.provider === 'local' && source.note === 'Discovered via local link expansion.')).toBe(true)
+      expect(docsContext.authHints.some((hint) => hint.includes('X-API-Key'))).toBe(true)
+      expect(docsContext.setupHints.some((hint) => /Install Play ?Kit MCP/.test(hint) || hint.includes('Connect Clay before using API tools'))).toBe(true)
+      expect(context).toContain('https://docs.playkit.sh/docs/authentication')
+      expect(context).toContain('Discovered via local link expansion.')
+    } finally {
+      globalThis.fetch = originalFetch
+      if (originalFirecrawlKey === undefined) {
+        delete process.env.FIRECRAWL_API_KEY
+      } else {
+        process.env.FIRECRAWL_API_KEY = originalFirecrawlKey
+      }
+    }
+  })
+
   it('fails fast when firecrawl is explicitly requested without a key', async () => {
     const originalFirecrawlKey = process.env.FIRECRAWL_API_KEY
     delete process.env.FIRECRAWL_API_KEY


### PR DESCRIPTION
## Summary

Docs ingestion now keeps the OSS fallback path first-class even when `auto` initially selects Firecrawl. If Firecrawl scraping fails, local ingestion handles both the seed fetches and follow-on link expansion, so discovered docs pages still land in `.pluxx/sources.json` and `.pluxx/docs-context.json` with local provenance.

The ingestion code now has an internal provider contract for fetch and expansion behavior. That keeps the local and Firecrawl paths behind the same shape, which makes the later `init`/`autopilot` reuse work less likely to duplicate provider logic.

## Validation

- `npm run build`
- `npm run typecheck`
- `npx vitest run tests/agent-mode.test.ts`
- `npm test` (46 files, 527 tests)

## Related Issues

Partial slice of orchidautomation/pluxx#197 and orchidautomation/pluxx#200.

Related follow-on context: orchidautomation/pluxx#199, orchidautomation/pluxx#201, orchidautomation/pluxx#202, orchidautomation/pluxx#223, orchidautomation/pluxx#310, orchidautomation/pluxx#65, orchidautomation/pluxx#66, orchidautomation/pluxx#74.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
