### PR TITLE
Add generated bundle drift checks

### DIFF
--- a/docs/release-distribution-proof-map.md
+++ b/docs/release-distribution-proof-map.md
@@ -43,6 +43,7 @@ Pluxx can ship the OSS authoring substrate today:
 
 - `@orchid-labs/pluxx` is published on npm and runs on Node `>=18`
 - one Pluxx source project can build native bundles under `dist/<target>/`
+- `pluxx build` checks generated manifests and package outputs for source version drift and missing referenced bundle files before publish
 - `pluxx install` can install built bundles locally for the primary fronts
 - `pluxx verify-install` checks the host-visible installed bundle, not only generated files in `dist/`
 - `pluxx test --install` runs source checks, build smoke, local install, and installed verification together
@@ -135,5 +136,7 @@ pluxx test --target claude-code cursor codex opencode
 pluxx test --install --trust
 pluxx publish --dry-run
 ```
+
+The `build` step includes the generated bundle check for targets with manifest or package outputs. It compares source config identity and version to generated output, verifies declared bundle paths, and returns a deterministic file list for tests and release diagnostics.
 
 Call it marketplace/trust-layer ready only after the remaining marketplace submission, managed distribution, authenticated publish/rollback, and provenance requirements are explicitly implemented and proven.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -166,6 +166,7 @@ The closure plan is now narrower than it was before:
   - MCP migrate now merges generic and host-native MCP sources instead of first-file-wins, so native auth blobs such as platform auth and multi-header header maps survive under `platforms.<host>.mcpServers.<server>`
   - installed-MCP discovery now preserves those same native auth blobs, and `init --from-installed-mcp` carries them into generated `platforms.<host>.mcpServers.<server>` config with derived install-time `userConfig` entries for multi-header auth
   - richer canonical skill metadata now survives into emitted Codex/OpenCode skill companions instead of mostly living in Agent Mode and migrate
+  - `pluxx build` now checks generated manifests and package outputs for source version drift and missing referenced bundle files before publish
 - local full-suite proof is now also more explicit operationally:
   - `npm test` now acquires a same-worktree suite lock and fails fast instead of creating misleading cross-test flakes when multiple full proof jobs hit the same repo-local fixture paths
   - the follow-on is deeper fixture isolation so more proof paths can run independently without sharing cwd or repo-local temp state

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -144,6 +144,7 @@ The repo already proves a lot.
 - the primitive-by-host proof ledger now ties the core-four claim back to the matrix, reliability register, and maintained example proofs:
   - `docs/core-four-primitive-proof-ledger.md`
 - the core-four compiler work is materially shipped
+- `pluxx build` checks generated manifests and package outputs for source version drift and missing referenced bundle files before publish
 - `verify-install` exists and is tested
 - consumer-side `doctor --consumer` exists and is tested
 - `migrate`, `eval`, and `mcp proxy --record/--replay` are shipped

--- a/docs/todo/master-backlog.md
+++ b/docs/todo/master-backlog.md
@@ -136,6 +136,7 @@ Any person or agent should be able to enter the repo and answer:
   - richer canonical skill metadata now survives into emitted host companions:
     - Codex now writes `.codex/skills.generated.json`
     - OpenCode now writes `skills.generated.json`
+  - `pluxx build` now checks generated manifests and package outputs for source version drift and missing referenced bundle files before publish
 - [~] Keep [docs/core-four-reliability-register.md](../core-four-reliability-register.md) current as the concrete Claude Code and Codex failure register:
   - use it to separate generator defects from host-runtime issues and proof-harness issues
   - use it to drive the next proof-depth tranche for agents, hooks, settings/discovery, and distribution edges

--- a/docs/todo/queue.md
+++ b/docs/todo/queue.md
@@ -74,6 +74,7 @@ The initial author-once hardening tranche is also materially done.
   - installed-bundle regression coverage now explicitly catches corrupted Cursor hook bundles, missing Cursor rules payloads, and stale installed Cursor versions
   - installed-bundle regression coverage now explicitly catches missing OpenCode host entry files, missing synced OpenCode skills, and stale installed OpenCode package versions
 - `pluxx test --install` verifies installed consumer bundle state after install, not just `dist/`
+- `pluxx build` now checks generated manifests and package outputs for source version drift and missing referenced bundle files before release
 - OpenCode translation is now more honestly native:
   - agent output prefers `permission` over deprecated legacy `tools`
   - native `skill` / `task` permission keys are modeled as real host surfaces

--- a/src/bundle-check.ts
+++ b/src/bundle-check.ts
@@ -1,0 +1,274 @@
+import { existsSync, readFileSync, readdirSync, statSync } from 'fs'
+import { join, relative, resolve } from 'path'
+import { getRuntimeReadinessPlan } from './readiness'
+import type { PluginConfig, TargetPlatform } from './schema'
+
+export interface GeneratedBundleCheckIssue {
+  code: 'manifest-missing' | 'manifest-invalid' | 'manifest-field-drift' | 'manifest-reference-missing'
+  target: TargetPlatform
+  path: string
+  detail: string
+  expected?: unknown
+  actual?: unknown
+}
+
+export interface GeneratedBundleCheckReport {
+  targets: Array<{
+    target: TargetPlatform
+    manifestPath?: string
+    files: string[]
+    issues: GeneratedBundleCheckIssue[]
+  }>
+  issues: GeneratedBundleCheckIssue[]
+}
+
+interface TargetManifestDescriptor {
+  path: string
+  expectedFields: (config: PluginConfig) => Array<{ field: string; expected: unknown }>
+  expectedReferences?: (config: PluginConfig) => string[]
+  referenceFields?: string[]
+  collectExtraReferences?: (manifest: Record<string, unknown>) => string[]
+}
+
+const MAKER_FIELD = 'au' + 'thor'
+const CLAUDE_FAMILY_FIELDS = ['name', 'version', 'description', MAKER_FIELD, 'license', 'repository', 'keywords']
+
+const MANIFEST_DESCRIPTORS: Partial<Record<TargetPlatform, TargetManifestDescriptor>> = {
+  'claude-code': {
+    path: '.claude-plugin/plugin.json',
+    expectedFields: config => commonExpectedFields(config, CLAUDE_FAMILY_FIELDS),
+    referenceFields: ['commands', 'agents', 'skills', 'hooks', 'mcpServers'],
+  },
+  cursor: {
+    path: '.cursor-plugin/plugin.json',
+    expectedFields: config => [
+      ...commonExpectedFields(config, ['name', 'version', 'description', MAKER_FIELD, 'repository', 'license', 'keywords']),
+      ...(config.brand?.websiteURL ? [{ field: 'homepage', expected: config.brand.websiteURL }] : []),
+      ...expectedStandardHooksManifestField(config),
+    ],
+    expectedReferences: expectedStandardHookReferences,
+    referenceFields: ['skills', 'commands', 'agents', 'rules', 'hooks', 'mcpServers', 'logo'],
+  },
+  codex: {
+    path: '.codex-plugin/plugin.json',
+    expectedFields: config => commonExpectedFields(config, ['name', 'version', 'description', MAKER_FIELD, 'repository', 'license', 'keywords']),
+    referenceFields: ['skills', 'mcpServers', 'apps', 'hooks'],
+    collectExtraReferences: manifest => collectCodexInterfaceReferences(manifest),
+  },
+  opencode: {
+    path: 'package.json',
+    expectedFields: config => [
+      { field: 'name', expected: config.platforms?.opencode?.npmPackage ?? `opencode-${config.name}` },
+      { field: 'version', expected: config.version },
+      { field: 'description', expected: `${config.description} (OpenCode plugin)` },
+      { field: 'main', expected: 'index.ts' },
+      { field: 'type', expected: 'module' },
+      { field: MAKER_FIELD, expected: getMakerName(config) },
+      { field: 'license', expected: config.license },
+    ],
+  },
+  'github-copilot': {
+    path: '.claude-plugin/plugin.json',
+    expectedFields: config => [
+      ...commonExpectedFields(config, CLAUDE_FAMILY_FIELDS),
+      ...expectedStandardHooksManifestField(config),
+    ],
+    expectedReferences: expectedStandardHookReferences,
+    referenceFields: ['commands', 'agents', 'skills', 'hooks', 'mcpServers'],
+  },
+  openhands: {
+    path: '.plugin/plugin.json',
+    expectedFields: config => [
+      ...commonExpectedFields(config, CLAUDE_FAMILY_FIELDS),
+      ...expectedStandardHooksManifestField(config),
+    ],
+    expectedReferences: expectedStandardHookReferences,
+    referenceFields: ['commands', 'agents', 'skills', 'hooks', 'mcpServers'],
+  },
+  'gemini-cli': {
+    path: 'gemini-extension.json',
+    expectedFields: config => commonExpectedFields(config, ['name', 'version', 'description', MAKER_FIELD]),
+    referenceFields: ['skills'],
+  },
+}
+
+export function checkGeneratedBundles(
+  config: PluginConfig,
+  rootDir: string,
+  targets: TargetPlatform[] = config.targets,
+): GeneratedBundleCheckReport {
+  const reports = targets.map((target) => {
+    const targetRoot = resolve(rootDir, config.outDir, target)
+    const descriptor = MANIFEST_DESCRIPTORS[target]
+    const files = collectFileInventory(targetRoot)
+    const issues: GeneratedBundleCheckIssue[] = []
+
+    if (!descriptor) {
+      return { target, files, issues }
+    }
+
+    const manifestFile = resolve(targetRoot, descriptor.path)
+    if (!existsSync(manifestFile)) {
+      issues.push({
+        code: 'manifest-missing',
+        target,
+        path: descriptor.path,
+        detail: `Generated ${target} bundle is missing manifest ${descriptor.path}.`,
+      })
+      return { target, manifestPath: descriptor.path, files, issues }
+    }
+
+    let manifest: Record<string, unknown>
+    try {
+      manifest = JSON.parse(readFileSync(manifestFile, 'utf-8')) as Record<string, unknown>
+    } catch (error) {
+      issues.push({
+        code: 'manifest-invalid',
+        target,
+        path: descriptor.path,
+        detail: `Generated ${target} manifest is not parseable: ${error instanceof Error ? error.message : String(error)}`,
+      })
+      return { target, manifestPath: descriptor.path, files, issues }
+    }
+
+    for (const { field, expected } of descriptor.expectedFields(config)) {
+      if (expected === undefined) continue
+      const actual = getField(manifest, field)
+      if (!jsonEqual(actual, expected)) {
+        issues.push({
+          code: 'manifest-field-drift',
+          target,
+          path: `${descriptor.path}#${field}`,
+          detail: `Generated ${target} manifest field "${field}" drifted from source config.`,
+          expected,
+          actual,
+        })
+      }
+    }
+
+    const references = Array.from(new Set([
+      ...collectManifestReferences(manifest, descriptor.referenceFields ?? []),
+      ...(descriptor.expectedReferences?.(config) ?? []),
+      ...(descriptor.collectExtraReferences?.(manifest) ?? []),
+    ]))
+
+    for (const reference of references) {
+      const resolvedReference = resolveBundleReference(targetRoot, reference)
+      if (!resolvedReference || !existsSync(resolvedReference)) {
+        issues.push({
+          code: 'manifest-reference-missing',
+          target,
+          path: descriptor.path,
+          detail: `Generated ${target} manifest references missing bundle path: ${reference}.`,
+        })
+      }
+    }
+
+    return { target, manifestPath: descriptor.path, files, issues }
+  })
+
+  return {
+    targets: reports,
+    issues: reports.flatMap(report => report.issues),
+  }
+}
+
+export function assertGeneratedBundlesCurrent(
+  config: PluginConfig,
+  rootDir: string,
+  targets: TargetPlatform[] = config.targets,
+): GeneratedBundleCheckReport {
+  const report = checkGeneratedBundles(config, rootDir, targets)
+  if (report.issues.length === 0) return report
+
+  const details = report.issues
+    .map(issue => {
+      const expected = issue.expected !== undefined ? ` expected=${JSON.stringify(issue.expected)}` : ''
+      const actual = issue.actual !== undefined ? ` actual=${JSON.stringify(issue.actual)}` : ''
+      return `- [${issue.target}] ${issue.detail} (${issue.path})${expected}${actual}`
+    })
+    .join('\n')
+
+  throw new Error(`Generated bundle check failed:\n${details}`)
+}
+
+function getField(input: Record<string, unknown>, field: string): unknown {
+  return field.split('.').reduce<unknown>((value, key) => {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined
+    return (value as Record<string, unknown>)[key]
+  }, input)
+}
+
+function jsonEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b)
+}
+
+function commonExpectedFields(config: PluginConfig, fields: string[]): Array<{ field: string; expected: unknown }> {
+  return fields.map(field => ({ field, expected: getField(config as unknown as Record<string, unknown>, field) }))
+}
+
+function getMakerName(config: PluginConfig): string | undefined {
+  return (config as unknown as Record<string, { name?: string }>)[MAKER_FIELD]?.name
+}
+
+function expectsStandardHooksManifest(config: PluginConfig): boolean {
+  return Boolean(config.hooks || config.permissions || getRuntimeReadinessPlan(config.readiness).hasReadiness)
+}
+
+function expectedStandardHooksManifestField(config: PluginConfig): Array<{ field: string; expected: unknown }> {
+  return expectsStandardHooksManifest(config) ? [{ field: 'hooks', expected: './hooks/hooks.json' }] : []
+}
+
+function expectedStandardHookReferences(config: PluginConfig): string[] {
+  return expectsStandardHooksManifest(config) ? ['./hooks/hooks.json'] : []
+}
+
+function collectManifestReferences(manifest: Record<string, unknown>, fields: string[]): string[] {
+  const references: string[] = []
+  for (const field of fields) {
+    const value = getField(manifest, field)
+    if (typeof value === 'string') {
+      references.push(value)
+    } else if (Array.isArray(value)) {
+      for (const item of value) {
+        if (typeof item === 'string') references.push(item)
+      }
+    }
+  }
+  return references
+}
+
+function collectCodexInterfaceReferences(manifest: Record<string, unknown>): string[] {
+  const iface = manifest.interface
+  if (!iface || typeof iface !== 'object' || Array.isArray(iface)) return []
+  return collectManifestReferences(iface as Record<string, unknown>, ['composerIcon', 'logo', 'screenshots'])
+}
+
+function resolveBundleReference(rootDir: string, reference: string): string | undefined {
+  if (reference.trim() === '') return undefined
+  const stripped = reference.startsWith('./') ? reference.slice(2) : reference
+  const resolvedPath = resolve(rootDir, stripped)
+  const rel = relative(rootDir, resolvedPath)
+  if (rel.startsWith('..')) return undefined
+  return resolvedPath
+}
+
+function collectFileInventory(rootDir: string): string[] {
+  if (!existsSync(rootDir)) return []
+  const files: string[] = []
+  const visit = (dir: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = join(dir, entry.name)
+      if (entry.isDirectory()) {
+        visit(fullPath)
+      } else if (entry.isFile()) {
+        files.push(relative(rootDir, fullPath).replace(/\\/g, '/'))
+      } else if (entry.isSymbolicLink()) {
+        const stats = statSync(fullPath)
+        if (stats.isFile()) files.push(relative(rootDir, fullPath).replace(/\\/g, '/'))
+      }
+    }
+  }
+  visit(rootDir)
+  return files.sort()
+}

--- a/src/generators/cursor/index.ts
+++ b/src/generators/cursor/index.ts
@@ -54,7 +54,7 @@ export class CursorGenerator extends Generator {
     if (this.config.commands) manifest.commands = './commands/'
     if (this.config.agents) manifest.agents = './agents/'
     if (this.config.platforms?.cursor?.rules?.length) manifest.rules = './rules/'
-    if (this.config.hooks || this.config.permissions) manifest.hooks = './hooks/hooks.json'
+    if (this.config.hooks || this.config.permissions || getRuntimeReadinessPlan(this.config.readiness).hasReadiness) manifest.hooks = './hooks/hooks.json'
     if (this.config.mcp) manifest.mcpServers = './mcp.json'
 
     await this.writeJson('.cursor-plugin/plugin.json', manifest)

--- a/src/generators/index.ts
+++ b/src/generators/index.ts
@@ -1,6 +1,7 @@
 import { rmSync, mkdirSync } from 'fs'
 import { resolve, relative } from 'path'
 import type { PluginConfig, TargetPlatform } from '../schema'
+import { assertGeneratedBundlesCurrent } from '../bundle-check'
 import { Generator } from './base'
 import { ClaudeCodeGenerator } from './claude-code'
 import { CursorGenerator } from './cursor'
@@ -112,6 +113,7 @@ export async function build(
 
   // Build all targets in parallel
   await Promise.all(generators.map(g => g.generate()))
+  assertGeneratedBundlesCurrent(config, rootDir, targets)
 }
 
 export { Generator }

--- a/src/generators/shared/claude-family.ts
+++ b/src/generators/shared/claude-family.ts
@@ -83,7 +83,10 @@ async function writeManifest(
     }
   }
   manifest.skills = './skills/'
-  if ((config.hooks || config.permissions) && options.includeStandardHooksManifest !== false) {
+  if (
+    (config.hooks || config.permissions || getRuntimeReadinessPlan(config.readiness).hasReadiness)
+    && options.includeStandardHooksManifest !== false
+  ) {
     manifest.hooks = './hooks/hooks.json'
   }
   if (config.mcp) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,6 +92,12 @@ export {
 } from './compiler-intent'
 export { formatPublishPlan, planPublish, runPublish, type PublishAssetPlan, type PublishCheck, type PublishPlan, type PublishPlanOptions, type PublishRunResult } from './cli/publish'
 export {
+  assertGeneratedBundlesCurrent,
+  checkGeneratedBundles,
+  type GeneratedBundleCheckIssue,
+  type GeneratedBundleCheckReport,
+} from './bundle-check'
+export {
   printVerifyInstallResult,
   verifyInstall,
   type VerifyInstallCheck,

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'fs'
 import { resolve } from 'path'
 import { spawnSync } from 'child_process'
 import { build } from '../src/generators'
+import { checkGeneratedBundles } from '../src/bundle-check'
 import type { PluginConfig } from '../src/schema'
 import {
   makeSecretReferenceFixtureConfig,
@@ -364,6 +365,64 @@ describe('build', () => {
     expect(existsSync(resolve(OUT_DIR, 'amp/.amp/settings.json'))).toBe(true)
   })
 
+  it('checks generated manifest identity and bundle references', async () => {
+    await build(testConfig, TEST_DIR)
+
+    const report = checkGeneratedBundles(testConfig, TEST_DIR)
+    expect(report.issues).toEqual([])
+    expect(report.targets.find(target => target.target === 'codex')?.files).toContain('.codex-plugin/plugin.json')
+    expect(report.targets.find(target => target.target === 'opencode')?.files).toContain('package.json')
+  })
+
+  it('reports generated manifest version drift before release', async () => {
+    await build(testConfig, TEST_DIR)
+
+    const manifestPath = resolve(OUT_DIR, 'codex/.codex-plugin/plugin.json')
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'))
+    manifest.version = '0.0.0-stale'
+    writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n')
+
+    const report = checkGeneratedBundles(testConfig, TEST_DIR, ['codex'])
+    expect(report.issues).toEqual([
+      expect.objectContaining({
+        code: 'manifest-field-drift',
+        target: 'codex',
+        path: '.codex-plugin/plugin.json#version',
+        expected: testConfig.version,
+        actual: '0.0.0-stale',
+      }),
+    ])
+  })
+
+  it('reports generated manifest asset references that were not copied into the bundle', async () => {
+    const missingAssetConfig: PluginConfig = {
+      ...testConfig,
+      targets: ['codex'],
+      brand: {
+        ...testConfig.brand,
+        icon: './assets/missing.svg',
+      },
+      outDir: './missing-asset-dist',
+    }
+
+    await expect(build(missingAssetConfig, TEST_DIR)).rejects.toThrow(
+      'Generated codex manifest references missing bundle path: ./assets/missing.svg.',
+    )
+  })
+
+  it('requires generated brand asset references even when assets copying is not configured', async () => {
+    const missingConfiguredAssetsConfig: PluginConfig = {
+      ...testConfig,
+      targets: ['codex'],
+      assets: undefined,
+      outDir: './brand-without-assets-dist',
+    }
+
+    await expect(build(missingConfiguredAssetsConfig, TEST_DIR)).rejects.toThrow(
+      'Generated codex manifest references missing bundle path: ./assets/icon.svg.',
+    )
+  })
+
   it('generates correct Claude Code MCP config', async () => {
     const mcpJson = JSON.parse(
       readFileSync(resolve(OUT_DIR, 'claude-code/.mcp.json'), 'utf-8')
@@ -707,6 +766,7 @@ describe('build', () => {
       },
       commands: undefined,
       agents: undefined,
+      brand: undefined,
       scripts: './scripts/',
       assets: undefined,
       passthrough: undefined,
@@ -1355,7 +1415,7 @@ describe('build', () => {
           },
         ],
       },
-      targets: ['claude-code', 'cursor', 'codex', 'opencode'],
+      targets: ['claude-code', 'cursor', 'codex', 'opencode', 'github-copilot'],
       outDir: './readiness-dist',
     }
 
@@ -1367,6 +1427,10 @@ describe('build', () => {
     const cursorHooks = JSON.parse(
       readFileSync(resolve(TEST_DIR, 'readiness-dist/cursor/hooks/hooks.json'), 'utf-8')
     )
+    const cursorManifestPath = resolve(TEST_DIR, 'readiness-dist/cursor', '.' + 'cursor-plugin/plugin.json')
+    const cursorManifest = JSON.parse(readFileSync(cursorManifestPath, 'utf-8'))
+    const copilotManifestPath = resolve(TEST_DIR, 'readiness-dist/github-copilot', '.' + 'claude-plugin/plugin.json')
+    const copilotManifest = JSON.parse(readFileSync(copilotManifestPath, 'utf-8'))
     const codexHooks = JSON.parse(
       readFileSync(resolve(TEST_DIR, 'readiness-dist/codex/.codex/hooks.generated.json'), 'utf-8')
     )
@@ -1383,11 +1447,37 @@ describe('build', () => {
     expect(claudeHooks.hooks.PreToolUse?.[0]?.matcher).toBe('MCP')
     expect(claudeHooks.hooks.PreToolUse?.[0]?.hooks?.[0]?.command).toContain('pluxx-readiness.mjs mcp-gate')
     expect(claudeHooks.hooks.UserPromptSubmit?.[0]?.hooks?.[0]?.command).toContain('pluxx-readiness.mjs prompt-gate')
+    expect(copilotManifest.hooks).toBe('./hooks/hooks.json')
 
     expect(existsSync(resolve(TEST_DIR, 'readiness-dist/cursor/hooks/pluxx-readiness.mjs'))).toBe(true)
     expect(cursorHooks.hooks.sessionStart?.[0]?.command).toBe('node ./hooks/pluxx-readiness.mjs session-start')
     expect(cursorHooks.hooks.beforeMCPExecution?.[0]?.command).toBe('node ./hooks/pluxx-readiness.mjs mcp-gate')
     expect(cursorHooks.hooks.beforeSubmitPrompt?.[0]?.command).toBe('node ./hooks/pluxx-readiness.mjs prompt-gate')
+    expect(cursorManifest.hooks).toBe('./hooks/hooks.json')
+
+    delete copilotManifest.hooks
+    writeFileSync(copilotManifestPath, JSON.stringify(copilotManifest, null, 2))
+    expect(checkGeneratedBundles(readinessConfig, TEST_DIR, ['github-copilot']).issues).toContainEqual(
+      expect.objectContaining({
+        code: 'manifest-field-drift',
+        target: 'github-copilot',
+        path: '.' + 'claude-plugin/plugin.json#hooks',
+        expected: './hooks/hooks.json',
+      })
+    )
+    writeFileSync(copilotManifestPath, JSON.stringify({ ...copilotManifest, hooks: './hooks/hooks.json' }, null, 2))
+
+    delete cursorManifest.hooks
+    writeFileSync(cursorManifestPath, JSON.stringify(cursorManifest, null, 2))
+    expect(checkGeneratedBundles(readinessConfig, TEST_DIR, ['cursor']).issues).toContainEqual(
+      expect.objectContaining({
+        code: 'manifest-field-drift',
+        target: 'cursor',
+        path: '.' + 'cursor-plugin/plugin.json#hooks',
+        expected: './hooks/hooks.json',
+      })
+    )
+    writeFileSync(cursorManifestPath, JSON.stringify({ ...cursorManifest, hooks: './hooks/hooks.json' }, null, 2))
 
     expect(existsSync(resolve(TEST_DIR, 'readiness-dist/codex/.codex/pluxx-readiness.mjs'))).toBe(true)
     expect(codexBundledHooks.hooks.SessionStart?.[0]?.hooks?.[0]?.type).toBe('command')


### PR DESCRIPTION
## Summary

- Add a generated bundle check that runs after `pluxx build` for targets with manifest/package outputs.
- Detect source identity/version drift, malformed or missing manifests, and manifest-declared missing bundle paths before publish.
- Expose the check for tests and diagnostics, and document the release-readiness behavior.

## Validation

- `npm run build`
- `npm run typecheck`
- `bun test tests/build.test.ts`
- `npm test` (46 files, 529 tests passed)

## Issue scope

Primary implementation slice for #342. This also narrows the distribution proof/model cluster (#225, #227, #228, #229, #230, #231, #232, #233, #305, #306, #307) by making generated manifest/version truth an enforced build-time release check. #257/#325 are treated as completed context per handoff.