### PR TITLE
Harden MCP sync metadata validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.22",
       "license": "MIT",
       "dependencies": {
-        "@clack/prompts": "^1.2.0",
+        "@clack/prompts": "1.2.0",
         "jiti": "^2.6.1",
         "zod": "^3.24.0"
       },

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
-    "@clack/prompts": "^1.2.0",
+    "@clack/prompts": "1.2.0",
     "jiti": "^2.6.1",
     "zod": "^3.24.0"
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1600,6 +1600,7 @@ Example prompt or command here
   } catch (error) {
     if (error instanceof PromptCancelledError) {
       console.log('Init cancelled')
+      process.exitCode = 1
       return
     }
 
@@ -2058,6 +2059,7 @@ ${formatAuthRequiredMessage('init', retryError, source)}`)
       if (!options.jsonOutput && !runtime.quiet) {
         clack.cancel(error.message)
       }
+      process.exitCode = 1
       return
     }
 

--- a/src/cli/init-from-mcp.ts
+++ b/src/cli/init-from-mcp.ts
@@ -299,7 +299,7 @@ export function parseMcpSourceInput(input: string, transportOverride?: string): 
   }
 
   if (transportOverride && transportOverride !== 'http' && transportOverride !== 'sse') {
-    throw new Error('Transport must be one of: http, sse')
+    throw new Error('Transport must be one of: http, sse. Try: use "--transport http" or "--transport sse".')
   }
 
   try {

--- a/src/cli/sync-from-mcp.ts
+++ b/src/cli/sync-from-mcp.ts
@@ -1,11 +1,15 @@
 import { cpSync, existsSync, mkdtempSync, readFileSync, rmSync, readdirSync, rmdirSync, writeFileSync } from 'fs'
 import { dirname, isAbsolute, relative, resolve } from 'path'
+import { z } from 'zod'
 import { tmpdir } from 'os'
 import { loadConfig } from '../config/load'
 import { introspectMcpServer, type IntrospectedMcpTool } from '../mcp/introspect'
-import type { McpServer } from '../schema'
+import { McpServerSchema, UserConfigEntrySchema, type McpServer } from '../schema'
 import {
   MCP_SCAFFOLD_METADATA_PATH,
+  MCP_HOOK_MODES,
+  MCP_RUNTIME_AUTH_MODES,
+  MCP_SKILL_GROUPINGS,
   MCP_TAXONOMY_PATH,
   PLUXX_CUSTOM_START,
   PLUXX_CUSTOM_END,
@@ -39,8 +43,97 @@ export async function readMcpScaffoldMetadata(rootDir: string): Promise<McpScaff
     )
   }
 
-  return JSON.parse(readFileSync(filepath, 'utf-8')) as McpScaffoldMetadata
+  const raw = JSON.parse(readFileSync(filepath, 'utf-8'))
+  const result = McpScaffoldMetadataSchema.safeParse(raw)
+  if (!result.success) {
+    const details = result.error.issues
+      .map((issue) => {
+        const path = issue.path.length > 0 ? issue.path.join('.') : '<root>'
+        return `${path}: ${issue.message}`
+      })
+      .slice(0, 5)
+      .join('; ')
+    throw new Error(
+      `Invalid MCP scaffold metadata at ${MCP_SCAFFOLD_METADATA_PATH}: ${details}. `
+      + `Fix: rerun "pluxx init --from-mcp" or restore a valid ${MCP_SCAFFOLD_METADATA_PATH} before syncing.`,
+    )
+  }
+
+  return result.data as McpScaffoldMetadata
 }
+
+const IntrospectedServerInfoSchema = z.object({
+  name: z.string(),
+  title: z.string().optional(),
+  version: z.string().optional(),
+  description: z.string().optional(),
+  websiteUrl: z.string().optional(),
+}).passthrough()
+
+const IntrospectedToolSchema = z.object({
+  name: z.string(),
+  title: z.string().optional(),
+  description: z.string().optional(),
+  inputSchema: z.record(z.string(), z.unknown()).optional(),
+}).passthrough()
+
+const IntrospectedResourceSchema = z.object({
+  uri: z.string(),
+  name: z.string().optional(),
+  title: z.string().optional(),
+  description: z.string().optional(),
+  mimeType: z.string().optional(),
+}).passthrough()
+
+const IntrospectedResourceTemplateSchema = z.object({
+  uriTemplate: z.string(),
+  name: z.string(),
+  title: z.string().optional(),
+  description: z.string().optional(),
+  mimeType: z.string().optional(),
+}).passthrough()
+
+const IntrospectedPromptSchema = z.object({
+  name: z.string(),
+  title: z.string().optional(),
+  description: z.string().optional(),
+  arguments: z.array(z.object({
+    name: z.string(),
+    description: z.string().optional(),
+    required: z.boolean().optional(),
+  }).passthrough()).optional(),
+}).passthrough()
+
+const McpScaffoldMetadataSchema = z.object({
+  version: z.literal(1),
+  source: McpServerSchema,
+  serverInfo: IntrospectedServerInfoSchema,
+  settings: z.object({
+    pluginName: z.string(),
+    displayName: z.string(),
+    description: z.string().optional(),
+    skillGrouping: z.enum(MCP_SKILL_GROUPINGS),
+    requestedHookMode: z.enum(MCP_HOOK_MODES),
+    generatedHookMode: z.enum(MCP_HOOK_MODES),
+    generatedHookEvents: z.array(z.string()),
+    runtimeAuthMode: z.enum(MCP_RUNTIME_AUTH_MODES),
+  }).strict(),
+  userConfig: z.array(UserConfigEntrySchema),
+  tools: z.array(IntrospectedToolSchema),
+  resources: z.array(IntrospectedResourceSchema).optional(),
+  resourceTemplates: z.array(IntrospectedResourceTemplateSchema).optional(),
+  prompts: z.array(IntrospectedPromptSchema).optional(),
+  skills: z.array(z.object({
+    dirName: z.string(),
+    title: z.string(),
+    description: z.string().optional(),
+    toolNames: z.array(z.string()),
+    resourceUris: z.array(z.string()).optional(),
+    resourceTemplateUris: z.array(z.string()).optional(),
+    promptNames: z.array(z.string()).optional(),
+  }).strict()),
+  managedFiles: z.array(z.string()),
+}).strict()
 
 export async function syncFromMcp(options: SyncFromMcpOptions): Promise<SyncFromMcpResult> {
   const metadata = await readMcpScaffoldMetadata(options.rootDir)

--- a/tests/helpers/cli-init-from-mcp-runner.ts
+++ b/tests/helpers/cli-init-from-mcp-runner.ts
@@ -18,6 +18,7 @@ const SYNC_PATH = resolve(import.meta.dir, '../../src/cli/sync-from-mcp.ts')
 const originalStdinIsTTY = process.stdin.isTTY
 const originalStdoutIsTTY = process.stdout.isTTY
 const originalCI = process.env.CI
+const originalExitCode = process.exitCode
 
 type Issue = {
   level: 'error' | 'warning'
@@ -283,11 +284,12 @@ afterEach(() => {
   } else {
     process.env.CI = originalCI
   }
+  process.exitCode = originalExitCode
   mock.restore()
 })
 
 describe('isolated init --from-mcp CLI checks', () => {
-  it('treats clack cancellation as a clean exit', async () => {
+  it('treats clack cancellation as a failed init exit', async () => {
     const cwd = mkdtempSync(resolve(tmpdir(), 'pluxx-init-cancel-'))
 
     try {
@@ -309,6 +311,7 @@ describe('isolated init --from-mcp CLI checks', () => {
       expect(calls.cancel).toEqual(['Init cancelled'])
       expect(calls.error).toEqual([])
       expect(calls.warn).toEqual([])
+      expect(process.exitCode).toBe(1)
     } finally {
       rmSync(cwd, { recursive: true, force: true })
     }

--- a/tests/init-from-mcp.test.ts
+++ b/tests/init-from-mcp.test.ts
@@ -151,7 +151,7 @@ describe('init-from-mcp scaffold', () => {
 
   it('rejects invalid transport overrides', () => {
     expect(() => parseMcpSourceInput('https://mcp.example.com/v1', 'websocket')).toThrow(
-      'Transport must be one of: http, sse',
+      'Transport must be one of: http, sse. Try: use "--transport http" or "--transport sse".',
     )
   })
 

--- a/tests/sync-from-mcp.test.ts
+++ b/tests/sync-from-mcp.test.ts
@@ -2,8 +2,8 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { resolve } from 'path'
 import { introspectMcpServer } from '../src/mcp/introspect'
-import { applyPersistedTaxonomy, detectSkillRenames, detectToolRenames, syncFromMcp } from '../src/cli/sync-from-mcp'
-import { writeMcpScaffold } from '../src/cli/init-from-mcp'
+import { applyPersistedTaxonomy, detectSkillRenames, detectToolRenames, readMcpScaffoldMetadata, syncFromMcp } from '../src/cli/sync-from-mcp'
+import { MCP_SCAFFOLD_METADATA_PATH, writeMcpScaffold } from '../src/cli/init-from-mcp'
 import { AGENT_CONTEXT_PATH, AGENT_PLAN_PATH } from '../src/cli/agent'
 
 const TEST_DIR = resolve(import.meta.dir, '.sync-from-mcp')
@@ -66,6 +66,62 @@ afterEach(() => {
 })
 
 describe('sync-from-mcp', () => {
+  it('rejects incomplete MCP scaffold metadata before syncing', async () => {
+    mkdirSync(resolve(TEST_DIR, '.pluxx'), { recursive: true })
+    writeFileSync(
+      resolve(TEST_DIR, MCP_SCAFFOLD_METADATA_PATH),
+      JSON.stringify({
+        version: 1,
+        source: {
+          transport: 'http',
+          url: 'https://mcp.example.com/mcp',
+        },
+        managedFiles: ['skills/example/SKILL.md'],
+      }, null, 2),
+    )
+
+    await expect(readMcpScaffoldMetadata(TEST_DIR)).rejects.toThrow(
+      'Invalid MCP scaffold metadata at .pluxx/mcp.json',
+    )
+    await expect(readMcpScaffoldMetadata(TEST_DIR)).rejects.toThrow(
+      'Fix: rerun "pluxx init --from-mcp"',
+    )
+  })
+
+  it('rejects corrupted managed file metadata before file operations', async () => {
+    mkdirSync(resolve(TEST_DIR, '.pluxx'), { recursive: true })
+    writeFileSync(
+      resolve(TEST_DIR, MCP_SCAFFOLD_METADATA_PATH),
+      JSON.stringify({
+        version: 1,
+        source: {
+          transport: 'http',
+          url: 'https://mcp.example.com/mcp',
+        },
+        serverInfo: {
+          name: 'stub-server',
+        },
+        settings: {
+          pluginName: 'stub-server',
+          displayName: 'Stub Server',
+          skillGrouping: 'workflow',
+          requestedHookMode: 'none',
+          generatedHookMode: 'none',
+          generatedHookEvents: [],
+          runtimeAuthMode: 'inline',
+        },
+        userConfig: [],
+        tools: [],
+        skills: [],
+        managedFiles: [42],
+      }, null, 2),
+    )
+
+    await expect(readMcpScaffoldMetadata(TEST_DIR)).rejects.toThrow(
+      'managedFiles.0: Expected string',
+    )
+  })
+
   it('does not treat identical descriptions as a rename without corroborating evidence', () => {
     const renames = detectToolRenames(
       [


### PR DESCRIPTION
## Summary
- validate .pluxx/mcp.json with Zod before sync trusts managed file metadata
- pin @clack/prompts to exact 1.2.0 and preserve a helpful --transport error
- make init cancellation set a failing process exit status

## Validation
- npm run typecheck
- bun test tests/sync-from-mcp.test.ts tests/init-from-mcp.test.ts tests/helpers/cli-init-from-mcp-runner.ts
- npm run build
- npm test (passes after build; initial unbuilt run failed because bin/pluxx.js could not find dist/)

Closes #63.
Closes #64.

Notes:
- #59 is only touched narrowly via the transport hint; this PR does not claim the full error-message audit.
- #237 appears already shipped in main and was not reimplemented here.