### PR TITLE
feat(codex): apply generated companions to active config

### DIFF
--- a/docs/core-four-install-update-lifecycle.md
+++ b/docs/core-four-install-update-lifecycle.md
@@ -89,6 +89,8 @@ Generated command-hook wrappers are now Node launchers at `hooks/pluxx-hook-comm
 
 If the installed Codex bundle also includes `.codex/config.generated.toml`, `doctor --consumer` and `verify-install` now inspect the checked project and user `config.toml` layers for matching per-tool `approval_mode = "approve"` stanzas. When those generated approvals have not been merged yet, Pluxx warns explicitly instead of assuming the companion file was actually applied. This is still an external merge step, not plugin-bundled enforcement.
 
+Use `pluxx codex apply --consumer <installed-codex-bundle> --project-root <project>` to make that external merge step explicit. The command applies the canonical `[features].hooks = true` prerequisite for hook-bearing bundles and merges generated MCP approval stanzas from `.codex/config.generated.toml` into the selected active Codex config. Use `--dry-run` first to preview the target config path and planned changes, then reload Codex and rerun `pluxx verify-install --target codex`.
+
 The newest live Codex proof on 2026-05-13 narrowed the remaining gap further:
 
 - Pluxx now emits the official nested Codex hook shape at `hooks/hooks.json`

--- a/src/cli/codex-apply.ts
+++ b/src/cli/codex-apply.ts
@@ -1,0 +1,431 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { homedir } from 'os'
+import { dirname, resolve } from 'path'
+import {
+  parseCodexApprovedMcpToolsFromToml,
+  type CodexMcpApprovalEntry,
+} from '../codex-permissions-companion'
+import { RECOMMENDED_CODEX_HOOKS_FEATURE_FLAG } from '../codex-hooks-feature'
+import { parseTomlValue, splitTomlList, stripTomlComment } from '../toml-lite'
+
+export interface CodexCompanionApplyOptions {
+  consumerRoot: string
+  configPath?: string
+  projectRoot?: string
+  userConfig?: boolean
+  includeHooks?: boolean
+  includeMcpApprovals?: boolean
+  dryRun?: boolean
+}
+
+export interface CodexCompanionApplyAction {
+  kind: 'hooks-feature' | 'mcp-approval'
+  status: 'added' | 'already-present' | 'skipped'
+  detail: string
+}
+
+export interface CodexCompanionApplyResult {
+  ok: boolean
+  dryRun: boolean
+  consumerRoot: string
+  configPath: string
+  changed: boolean
+  actions: CodexCompanionApplyAction[]
+}
+
+interface MergeResult {
+  text: string
+  changed: boolean
+  addedCount?: number
+  updatedCount?: number
+}
+
+interface InternalCodexCompanionApplyResult extends CodexCompanionApplyResult {
+  nextText?: string
+}
+
+export function resolveCodexApplyConfigPath(options: Pick<CodexCompanionApplyOptions, 'configPath' | 'projectRoot' | 'userConfig'>): string {
+  if (options.configPath) return resolve(options.configPath)
+  if (options.userConfig) {
+    const homeDir = process.env.HOME?.trim() || homedir()
+    const codexHome = process.env.CODEX_HOME?.trim() || resolve(homeDir, '.codex')
+    return resolve(codexHome, 'config.toml')
+  }
+  return resolve(options.projectRoot ?? process.cwd(), '.codex/config.toml')
+}
+
+export function planCodexCompanionApply(options: CodexCompanionApplyOptions): CodexCompanionApplyResult {
+  return stripInternalApplyResult(buildCodexCompanionApplyPlan(options))
+}
+
+function buildCodexCompanionApplyPlan(options: CodexCompanionApplyOptions): InternalCodexCompanionApplyResult {
+  const consumerRoot = resolve(options.consumerRoot)
+  const configPath = resolveCodexApplyConfigPath(options)
+  const includeHooks = options.includeHooks ?? true
+  const includeMcpApprovals = options.includeMcpApprovals ?? true
+  const actions: CodexCompanionApplyAction[] = []
+  const manifestPath = resolve(consumerRoot, '.codex-plugin/plugin.json')
+  const companionPath = resolve(consumerRoot, '.codex/config.generated.toml')
+
+  if (!existsSync(manifestPath) && !existsSync(companionPath)) {
+    throw new Error(`No Codex plugin manifest or generated config companion found under ${consumerRoot}.`)
+  }
+
+  let configText = existsSync(configPath) ? readFileSync(configPath, 'utf-8') : ''
+  let changed = false
+
+  if (includeHooks) {
+    if (codexBundleDeclaresHooks(consumerRoot)) {
+      const hookMerge = ensureCodexHooksFeature(configText)
+      configText = hookMerge.text
+      changed ||= hookMerge.changed
+      actions.push({
+        kind: 'hooks-feature',
+        status: hookMerge.changed ? 'added' : 'already-present',
+        detail: hookMerge.changed
+          ? `Added [features].${RECOMMENDED_CODEX_HOOKS_FEATURE_FLAG} = true for plugin-bundled Codex hooks.`
+          : `[features].${RECOMMENDED_CODEX_HOOKS_FEATURE_FLAG} = true is already present.`,
+      })
+    } else {
+      actions.push({
+        kind: 'hooks-feature',
+        status: 'skipped',
+        detail: 'Installed Codex bundle does not declare plugin-bundled hooks.',
+      })
+    }
+  }
+
+  if (includeMcpApprovals) {
+    if (!existsSync(companionPath)) {
+      actions.push({
+        kind: 'mcp-approval',
+        status: 'skipped',
+        detail: 'No .codex/config.generated.toml companion was found in the installed Codex bundle.',
+      })
+    } else {
+      const approvals = parseCodexApprovedMcpToolsFromToml(readFileSync(companionPath, 'utf-8'))
+      const approvalMerge = ensureCodexMcpApprovals(configText, approvals)
+      configText = approvalMerge.text
+      changed ||= approvalMerge.changed
+      actions.push({
+        kind: 'mcp-approval',
+        status: approvalMerge.changed ? 'added' : 'already-present',
+        detail: approvalMerge.changed
+          ? `Applied ${approvalMerge.addedCount ?? 0} generated MCP approval stanza(s) and updated ${approvalMerge.updatedCount ?? 0} existing stanza(s) from .codex/config.generated.toml.`
+          : 'Generated MCP approval stanzas are already present in active Codex config.',
+      })
+    }
+  }
+
+  return {
+    ok: true,
+    dryRun: options.dryRun ?? false,
+    consumerRoot,
+    configPath,
+    changed,
+    actions,
+    ...(changed ? { nextText: configText } : {}),
+  }
+}
+
+export function applyCodexCompanion(options: CodexCompanionApplyOptions): CodexCompanionApplyResult {
+  const planned = buildCodexCompanionApplyPlan(options)
+  if (planned.changed && !options.dryRun && planned.nextText !== undefined) {
+    mkdirSync(dirname(planned.configPath), { recursive: true })
+    writeFileSync(planned.configPath, planned.nextText)
+  }
+
+  return stripInternalApplyResult(planned)
+}
+
+export function ensureCodexHooksFeature(source: string): MergeResult {
+  if (readFeatureFlag(source) === true) return { text: source, changed: false }
+
+  const lines = source.split(/\r?\n/)
+  if (lines.length === 1 && lines[0] === '') lines.pop()
+
+  let inFeaturesTable = false
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = stripTomlComment(lines[index]).trim()
+    const sectionMatch = line.match(/^\[(.+)\]$/)
+    if (sectionMatch) {
+      inFeaturesTable = sectionMatch[1].trim() === 'features'
+      continue
+    }
+
+    const dottedMatch = line.match(/^features\.hooks\s*=\s*(.+)$/)
+    if (dottedMatch) {
+      lines[index] = `${lines[index].slice(0, lines[index].indexOf('='))}= true`
+      return { text: finishToml(lines), changed: true }
+    }
+
+    const inlineMatch = line.match(/^features\s*=\s*(\{.+\})$/)
+    if (inlineMatch) {
+      const updated = mergeInlineFeatures(inlineMatch[1])
+      if (updated) {
+        lines[index] = `${lines[index].slice(0, lines[index].indexOf('='))}= ${updated}`
+        return { text: finishToml(lines), changed: true }
+      }
+    }
+
+    if (inFeaturesTable) {
+      const tableMatch = line.match(/^hooks\s*=\s*(.+)$/)
+      if (tableMatch) {
+        lines[index] = `${lines[index].slice(0, lines[index].indexOf('='))}= true`
+        return { text: finishToml(lines), changed: true }
+      }
+    }
+  }
+
+  const table = findTableRange(lines, 'features')
+  if (table) {
+    lines.splice(table.end, 0, `${RECOMMENDED_CODEX_HOOKS_FEATURE_FLAG} = true`)
+    return { text: finishToml(lines), changed: true }
+  }
+
+  if (lines.length > 0 && lines[lines.length - 1].trim() !== '') lines.push('')
+  lines.push('[features]', `${RECOMMENDED_CODEX_HOOKS_FEATURE_FLAG} = true`)
+  return { text: finishToml(lines), changed: true }
+}
+
+export function ensureCodexMcpApprovals(source: string, approvals: CodexMcpApprovalEntry[]): MergeResult {
+  if (approvals.length === 0) return { text: source, changed: false }
+
+  const lines = source.split(/\r?\n/)
+  if (lines.length === 1 && lines[0] === '') lines.pop()
+
+  let updatedCount = 0
+  const missing: CodexMcpApprovalEntry[] = []
+  for (const entry of approvals) {
+    const existing = updateExistingCodexMcpApproval(lines, entry)
+    if (!existing.found) {
+      missing.push(entry)
+      continue
+    }
+    if (existing.changed) updatedCount += 1
+  }
+
+  if (missing.length === 0 && updatedCount === 0) {
+    return { text: source, changed: false }
+  }
+
+  if (lines.length > 0 && lines[lines.length - 1].trim() !== '') lines.push('')
+
+  if (missing.length > 0) {
+    lines.push('# Applied by Pluxx from .codex/config.generated.toml.')
+    for (const entry of missing) {
+      lines.push('')
+      lines.push(`[mcp_servers.${toQuotedTomlKey(entry.serverName)}.tools.${toQuotedTomlKey(entry.toolName)}]`)
+      lines.push('approval_mode = "approve"')
+    }
+  }
+
+  return { text: finishToml(lines), changed: true, addedCount: missing.length, updatedCount }
+}
+
+function codexBundleDeclaresHooks(rootDir: string): boolean {
+  const manifestPath = resolve(rootDir, '.codex-plugin/plugin.json')
+  if (!existsSync(manifestPath)) return false
+
+  try {
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8')) as { hooks?: unknown }
+    const hooksPath = typeof manifest.hooks === 'string' ? manifest.hooks : 'hooks/hooks.json'
+    return existsSync(resolve(rootDir, hooksPath))
+  } catch {
+    return false
+  }
+}
+
+function readFeatureFlag(source: string): boolean | undefined {
+  let inFeaturesTable = false
+  for (const rawLine of source.split(/\r?\n/)) {
+    const line = stripTomlComment(rawLine).trim()
+    if (!line) continue
+
+    const sectionMatch = line.match(/^\[(.+)\]$/)
+    if (sectionMatch) {
+      inFeaturesTable = sectionMatch[1].trim() === 'features'
+      continue
+    }
+
+    const dottedMatch = line.match(/^features\.hooks\s*=\s*(.+)$/)
+    if (dottedMatch) return parseTomlValue(dottedMatch[1].trim()) === true
+
+    const inlineMatch = line.match(/^features\s*=\s*(.+)$/)
+    if (inlineMatch) {
+      const parsed = parseTomlValue(inlineMatch[1].trim())
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return (parsed as Record<string, unknown>).hooks === true
+      }
+    }
+
+    if (!inFeaturesTable) continue
+    const tableMatch = line.match(/^hooks\s*=\s*(.+)$/)
+    if (tableMatch) return parseTomlValue(tableMatch[1].trim()) === true
+  }
+
+  return undefined
+}
+
+function mergeInlineFeatures(value: string): string | null {
+  const inner = value.slice(1, -1).trim()
+  const parts = inner ? splitTomlList(inner).map((part) => part.trim()).filter(Boolean) : []
+  let replaced = false
+  const nextParts = parts.map((part) => {
+    if (!/^hooks\s*=/.test(part)) return part
+    replaced = true
+    return 'hooks = true'
+  })
+  if (!replaced) nextParts.push('hooks = true')
+  return `{ ${nextParts.join(', ')} }`
+}
+
+function findTableRange(lines: string[], tableName: string): { start: number; end: number } | null {
+  let start = -1
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = stripTomlComment(lines[index]).trim()
+    const sectionMatch = line.match(/^\[(.+)\]$/)
+    if (!sectionMatch) continue
+    if (start < 0) {
+      if (sectionMatch[1].trim() === tableName) start = index
+      continue
+    }
+    return { start, end: index }
+  }
+  return start < 0 ? null : { start, end: lines.length }
+}
+
+function sameApprovalEntry(a: CodexMcpApprovalEntry, b: CodexMcpApprovalEntry): boolean {
+  return a.serverName === b.serverName && a.toolName === b.toolName
+}
+
+function updateExistingCodexMcpApproval(
+  lines: string[],
+  expected: CodexMcpApprovalEntry,
+): { found: boolean; changed: boolean } {
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = stripTomlComment(lines[index]).trim()
+    if (!line) continue
+
+    const sectionMatch = line.match(/^\[(.+)\]$/)
+    if (sectionMatch) {
+      const section = parseCodexApprovalSection(sectionMatch[1].trim())
+      if (!section || !sameApprovalEntry(section, expected)) continue
+
+      const end = findNextTableIndex(lines, index + 1)
+      for (let assignmentIndex = index + 1; assignmentIndex < end; assignmentIndex += 1) {
+        const assignmentLine = stripTomlComment(lines[assignmentIndex]).trim()
+        const assignmentMatch = assignmentLine.match(/^approval_mode\s*=\s*(.+)$/)
+        if (!assignmentMatch) continue
+
+        const approvalMode = parseTomlValue(assignmentMatch[1].trim())
+        if (approvalMode === 'approve') {
+          return { found: true, changed: false }
+        }
+        throw new Error(formatApprovalConflict(expected, approvalMode))
+      }
+
+      lines.splice(end, 0, 'approval_mode = "approve"')
+      return { found: true, changed: true }
+    }
+
+    const assignmentMatch = line.match(/^([^=]+?)\s*=\s*(.+)$/)
+    if (!assignmentMatch) continue
+    const assignment = parseCodexApprovalAssignmentKey(assignmentMatch[1].trim())
+    if (!assignment || !sameApprovalEntry(assignment, expected)) continue
+
+    const approvalMode = parseTomlValue(assignmentMatch[2].trim())
+    if (approvalMode === 'approve') {
+      return { found: true, changed: false }
+    }
+    throw new Error(formatApprovalConflict(expected, approvalMode))
+  }
+
+  return { found: false, changed: false }
+}
+
+function findNextTableIndex(lines: string[], start: number): number {
+  for (let index = start; index < lines.length; index += 1) {
+    if (/^\[.+\]$/.test(stripTomlComment(lines[index]).trim())) return index
+  }
+  return lines.length
+}
+
+function parseCodexApprovalSection(sectionName: string): CodexMcpApprovalEntry | null {
+  const tokens = splitTomlDottedPath(sectionName)
+  if (tokens.length !== 4) return null
+  if (tokens[0] !== 'mcp_servers' || tokens[2] !== 'tools') return null
+
+  return {
+    serverName: tokens[1],
+    toolName: tokens[3],
+  }
+}
+
+function parseCodexApprovalAssignmentKey(key: string): CodexMcpApprovalEntry | null {
+  const tokens = splitTomlDottedPath(key)
+  if (tokens.length !== 5) return null
+  if (tokens[0] !== 'mcp_servers' || tokens[2] !== 'tools' || tokens[4] !== 'approval_mode') return null
+
+  return {
+    serverName: tokens[1],
+    toolName: tokens[3],
+  }
+}
+
+function formatApprovalConflict(entry: CodexMcpApprovalEntry, approvalMode: unknown): string {
+  const renderedMode = typeof approvalMode === 'string' ? `"${approvalMode}"` : JSON.stringify(approvalMode)
+  return `Codex MCP approval conflict for ${entry.serverName}.${entry.toolName}: active config already sets approval_mode = ${renderedMode}. Pluxx will not override an explicit local security decision; edit the active Codex config manually if you want approval_mode = "approve".`
+}
+
+function splitTomlDottedPath(value: string): string[] {
+  const parts: string[] = []
+  let current = ''
+  let inString = false
+  let quote = ''
+
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index]
+    if ((char === '"' || char === "'") && value[index - 1] !== '\\') {
+      if (!inString) {
+        inString = true
+        quote = char
+      } else if (quote === char) {
+        inString = false
+        quote = ''
+      }
+      current += char
+      continue
+    }
+
+    if (!inString && char === '.') {
+      const trimmed = current.trim()
+      if (trimmed) parts.push(trimmed)
+      current = ''
+      continue
+    }
+
+    current += char
+  }
+
+  const trimmed = current.trim()
+  if (trimmed) parts.push(trimmed)
+
+  return parts.map((part) => {
+    const parsed = parseTomlValue(part)
+    return typeof parsed === 'string' ? parsed : part
+  })
+}
+
+function finishToml(lines: string[]): string {
+  return `${lines.join('\n').replace(/\s+$/u, '')}\n`
+}
+
+function toQuotedTomlKey(value: string): string {
+  return JSON.stringify(value)
+}
+
+function stripInternalApplyResult(result: InternalCodexCompanionApplyResult): CodexCompanionApplyResult {
+  const { nextText: _nextText, ...publicResult } = result
+  return publicResult
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -79,6 +79,7 @@ import { printVerifyInstallResult, verifyInstall } from './verify-install'
 import { runBehavioralSuite } from './behavioral'
 import type { BehavioralSuiteResult } from './behavioral'
 import { planTextFileAction, writeTextFile } from '../text-files'
+import { applyCodexCompanion } from './codex-apply'
 import {
   discoverInstalledMcpServers,
   formatInstalledMcpSource,
@@ -273,6 +274,9 @@ export async function main() {
       break
     case 'discover-mcp':
       await runDiscoverMcp()
+      break
+    case 'codex':
+      await runCodex()
       break
     case 'autopilot':
       await runAutopilot()
@@ -3393,6 +3397,54 @@ async function runVerifyInstall() {
   }
 }
 
+async function runCodex() {
+  const subcommand = args[1]
+  if (subcommand === 'apply') {
+    const consumerRoot = readOption(args, '--consumer') ?? args[2]
+    if (!consumerRoot || consumerRoot.startsWith('-')) {
+      console.error('Usage: pluxx codex apply --consumer <installed-codex-bundle> [--config <config.toml>|--project-root <path>|--user] [--hooks-only|--mcp-approvals-only] [--dry-run] [--json]')
+      process.exit(1)
+    }
+
+    const hooksOnly = readFlag(args, '--hooks-only')
+    const approvalsOnly = readFlag(args, '--mcp-approvals-only')
+    if (hooksOnly && approvalsOnly) {
+      throw new Error('Use either --hooks-only or --mcp-approvals-only, not both.')
+    }
+
+    const result = applyCodexCompanion({
+      consumerRoot,
+      configPath: readOption(args, '--config'),
+      projectRoot: readOption(args, '--project-root'),
+      userConfig: readFlag(args, '--user'),
+      includeHooks: !approvalsOnly,
+      includeMcpApprovals: !hooksOnly,
+      dryRun: runtime.dryRun,
+    })
+
+    if (runtime.jsonOutput) {
+      printJson(result)
+      return
+    }
+
+    if (!runtime.quiet) {
+      console.log(`${runtime.dryRun ? 'Dry run: ' : ''}${result.changed ? 'Codex config changes planned' : 'Codex config already up to date'}: ${result.configPath}`)
+      for (const action of result.actions) {
+        console.log(`  [${action.status}] ${action.detail}`)
+      }
+      if (result.changed && runtime.dryRun) {
+        console.log('Run without --dry-run to apply these changes, then rerun `pluxx verify-install --target codex`.')
+      } else if (result.changed) {
+        console.log('Applied. Reload Codex, then rerun `pluxx verify-install --target codex`.')
+      }
+    }
+    return
+  }
+
+  console.error('Usage: pluxx codex apply --consumer <installed-codex-bundle> [--config <config.toml>|--project-root <path>|--user] [--hooks-only|--mcp-approvals-only] [--dry-run] [--json]')
+  process.exit(1)
+}
+
 async function runUninstall() {
   const targets = parseTargetFlagValues(args)
 
@@ -3450,6 +3502,7 @@ Usage:
   pluxx agent prepare                     Generate agent context + boundary files for host agents
   pluxx agent prompt <kind>               Generate a prompt pack (taxonomy, instructions, review)
   pluxx agent run <kind> --runner <id>    Execute a prompt pack via Claude, Cursor, Codex, or OpenCode headlessly
+  pluxx codex apply --consumer <path>     Apply generated Codex hook/config companions to active config
   pluxx discover-mcp [--host <hosts...>] List installed MCP servers from local host configs
   pluxx mcp proxy ...                     Run a local MCP proxy with optional record/replay tapes
   pluxx autopilot --from-mcp ...          Run import + agent refinement + verification in one command
@@ -3513,6 +3566,7 @@ Examples:
   pluxx agent run taxonomy --runner codex
   pluxx agent run taxonomy --runner codex --verbose-runner
   pluxx agent run review --runner opencode --attach http://localhost:4096 --no-verify
+  pluxx codex apply --consumer ./dist/codex --project-root . --dry-run
   pluxx autopilot --from-mcp https://example.com/mcp --runner codex --website https://example.com --docs https://docs.example.com --ingest-provider auto
   pluxx mcp proxy --from-mcp "node ./server.js" --record .pluxx/tapes/dev.json
   pluxx mcp proxy --replay .pluxx/tapes/dev.json

--- a/tests/codex-apply.test.ts
+++ b/tests/codex-apply.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'bun:test'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { resolve } from 'path'
+import {
+  planCodexCompanionApply,
+  ensureCodexHooksFeature,
+  ensureCodexMcpApprovals,
+} from '../src/cli/codex-apply'
+
+describe('codex companion apply helpers', () => {
+  it('adds the canonical Codex hook feature flag without replacing deprecated compatibility context', () => {
+    const result = ensureCodexHooksFeature('[features]\ncodex_hooks = true\n')
+
+    expect(result.changed).toBe(true)
+    expect(result.text).toContain('[features]\n')
+    expect(result.text).toContain('hooks = true')
+    expect(result.text).toContain('codex_hooks = true')
+  })
+
+  it('updates inline feature tables without introducing codex_hooks as guidance', () => {
+    const result = ensureCodexHooksFeature('features = { codex_hooks = true }\n')
+
+    expect(result.changed).toBe(true)
+    expect(result.text).toContain('features = { codex_hooks = true, hooks = true }')
+  })
+
+  it('updates an existing disabled hook feature flag instead of duplicating it', () => {
+    const result = ensureCodexHooksFeature('[features]\nhooks = false\n')
+
+    expect(result.changed).toBe(true)
+    expect(result.text).toBe('[features]\nhooks = true\n')
+  })
+
+  it('merges missing generated MCP approval stanzas without duplicating existing entries', () => {
+    const result = ensureCodexMcpApprovals(
+      '[mcp_servers."hosted".tools."search"]\napproval_mode = "approve"\n',
+      [
+        { serverName: 'hosted', toolName: 'search' },
+        { serverName: 'hosted', toolName: 'summarize' },
+      ],
+    )
+
+    expect(result.changed).toBe(true)
+    expect(result.addedCount).toBe(1)
+    expect(result.text.match(/hosted"\.tools\."search/g)?.length).toBe(1)
+    expect(result.text).toContain('[mcp_servers."hosted".tools."summarize"]')
+  })
+
+  it('fails on an existing ask approval table instead of widening it', () => {
+    expect(() => ensureCodexMcpApprovals(
+      '[mcp_servers."hosted".tools."search"]\napproval_mode = "ask"\n',
+      [{ serverName: 'hosted', toolName: 'search' }],
+    )).toThrow('already sets approval_mode = "ask"')
+  })
+
+  it('fails on an existing deny approval assignment instead of widening it', () => {
+    expect(() => ensureCodexMcpApprovals(
+      'mcp_servers."hosted".tools."search".approval_mode = "deny"\n',
+      [{ serverName: 'hosted', toolName: 'search' }],
+    )).toThrow('already sets approval_mode = "deny"')
+  })
+
+  it('fails clearly when apply is pointed at a non-Codex bundle path', () => {
+    const dir = mkdtempSync(resolve(tmpdir(), 'pluxx-codex-apply-empty-'))
+
+    try {
+      expect(() => planCodexCompanionApply({ consumerRoot: dir })).toThrow('No Codex plugin manifest')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Codex users now have an explicit apply step for generated companion config instead of manually copying snippets out of installed bundles. `pluxx codex apply --consumer <bundle> --project-root <project>` merges the canonical `[features].hooks = true` prerequisite for hook-bearing bundles and generated MCP approval stanzas from `.codex/config.generated.toml` into the selected active Codex config, with `--dry-run` available before writing.

This keeps the runtime boundary honest: the command applies known prerequisites and companion config, while `verify-install` remains the proof step and Codex hook execution is still documented as a runtime activation caveat. `codex_hooks` stays deprecated compatibility context only; the apply path writes `[features].hooks = true`.

## Issue Links

Advances orchidautomation/pluxx#276, orchidautomation/pluxx#298, and orchidautomation/pluxx#314. Provides supporting implementation context for orchidautomation/pluxx#326.

PR orchidautomation/pluxx#327 is classified as superseded source material: current `main` already contains the bundled Codex hook direction from that branch, and this PR builds on the current verifier/apply gap instead of rebasing the stale conflicting branch.

## Validation

- `npm run typecheck`
- `bun test tests/codex-apply.test.ts tests/doctor.test.ts`
- `npm run build`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
