### PR TITLE
Tighten Node runtime launcher contract

### DIFF
--- a/bin/pluxx.js
+++ b/bin/pluxx.js
@@ -6,12 +6,7 @@ import { fileURLToPath, pathToFileURL } from 'url'
 
 const binDir = dirname(fileURLToPath(import.meta.url))
 const distCliPath = resolve(binDir, '..', 'dist', 'cli', 'index.js')
-const sourceCliPath = resolve(binDir, '..', 'src', 'cli', 'index.ts')
-const cliPath = existsSync(distCliPath)
-  ? distCliPath
-  : process.versions.bun
-    ? sourceCliPath
-    : null
+const cliPath = existsSync(distCliPath) ? distCliPath : null
 
 if (!cliPath) {
   console.error('pluxx CLI bundle not found.')

--- a/docs/runtime-contract.md
+++ b/docs/runtime-contract.md
@@ -34,6 +34,7 @@ Supported consumer invocation paths:
 - `node ./bin/pluxx.js ...` from this repo after `npm run build`
 
 The published package ships the Node launcher in `bin/` and the compiled runtime in `dist/`.
+The launcher intentionally does not load TypeScript source files or fall back to Bun at runtime.
 
 ## Config Loading
 
@@ -46,6 +47,7 @@ Config imports of `pluxx` or `@orchid-labs/pluxx` are rewritten to the package r
 Normal contributor workflows run through Node and npm:
 
 - `npm run build`
+- `npm run dev -- ...` for source-mode CLI work
 - `npm run typecheck`
 - `npm test`
 - `node scripts/verify-node-package-runtime.mjs`

--- a/tests/package.test.ts
+++ b/tests/package.test.ts
@@ -1,33 +1,20 @@
-import { afterAll, afterEach, describe, expect, it } from 'bun:test'
+import { describe, expect, it } from 'bun:test'
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { resolve } from 'path'
 
 const ROOT = resolve(import.meta.dir, '..')
 const DIST_CLI_PATH = resolve(ROOT, 'dist/cli/index.js')
-const ORIGINAL_DIST_CLI_CONTENT = existsSync(DIST_CLI_PATH)
-  ? readFileSync(DIST_CLI_PATH, 'utf-8')
-  : null
 
-afterEach(() => {
-  if (ORIGINAL_DIST_CLI_CONTENT === null) {
+function restoreDistCli(snapshot: string | null): void {
+  if (snapshot === null) {
     rmSync(DIST_CLI_PATH, { force: true })
     return
   }
 
   mkdirSync(resolve(ROOT, 'dist/cli'), { recursive: true })
-  writeFileSync(DIST_CLI_PATH, ORIGINAL_DIST_CLI_CONTENT)
-})
-
-afterAll(() => {
-  if (ORIGINAL_DIST_CLI_CONTENT === null) {
-    rmSync(DIST_CLI_PATH, { force: true })
-    return
-  }
-
-  mkdirSync(resolve(ROOT, 'dist/cli'), { recursive: true })
-  writeFileSync(DIST_CLI_PATH, ORIGINAL_DIST_CLI_CONTENT)
-})
+  writeFileSync(DIST_CLI_PATH, snapshot)
+}
 
 describe('package metadata', () => {
   it('publishes a real launcher and compiled CLI entry metadata', () => {
@@ -56,24 +43,33 @@ describe('package metadata', () => {
     expect(launcher).toContain("resolve(binDir, '..', 'dist', 'cli', 'index.js')")
     expect(launcher).toContain('pluxx CLI bundle not found.')
     expect(launcher).toContain("await import(pathToFileURL(cliPath).href)")
+    expect(launcher).not.toContain('process.versions.bun')
+    expect(launcher).not.toContain("resolve(binDir, '..', 'src', 'cli', 'index.ts')")
   })
 
   it('routes execution through the published launcher under Node', async () => {
+    const originalDistCliContent = existsSync(DIST_CLI_PATH)
+      ? readFileSync(DIST_CLI_PATH, 'utf-8')
+      : null
     mkdirSync(resolve(ROOT, 'dist/cli'), { recursive: true })
     writeFileSync(DIST_CLI_PATH, 'export async function main() { console.log("stub cli ok") }\n')
 
-    const proc = Bun.spawn(['node', resolve(ROOT, 'bin/pluxx.js'), 'help'], {
-      stdout: 'pipe',
-      stderr: 'pipe',
-    })
+    try {
+      const proc = Bun.spawn(['node', resolve(ROOT, 'bin/pluxx.js'), 'help'], {
+        stdout: 'pipe',
+        stderr: 'pipe',
+      })
 
-    const stdout = await new Response(proc.stdout).text()
-    const stderr = await new Response(proc.stderr).text()
-    const exitCode = await proc.exited
+      const stdout = await new Response(proc.stdout).text()
+      const stderr = await new Response(proc.stderr).text()
+      const exitCode = await proc.exited
 
-    expect(exitCode).toBe(0)
-    expect(stdout).toContain('stub cli ok')
-    expect(stderr).toBe('')
+      expect(exitCode).toBe(0)
+      expect(stdout).toContain('stub cli ok')
+      expect(stderr).toBe('')
+    } finally {
+      restoreDistCli(originalDistCliContent)
+    }
   })
 
   it('loads a TypeScript pluxx.config.ts through the built Node CLI', async () => {


### PR DESCRIPTION
## Summary
- remove the final Bun-only source fallback from `bin/pluxx.js`, so the launcher only runs the compiled Node CLI bundle
- document that source-mode CLI work uses `npm run dev -- ...`, not a runtime Bun fallback
- fix `tests/package.test.ts` so the stub launcher test restores only its own stub and cannot delete the real `dist/cli/index.js` before package runtime verification

## Validation
- `node scripts/run-vitest-exclusive.mjs tests/package.test.ts`
- `npm run typecheck`
- `node scripts/verify-node-package-runtime.mjs`
- `npm run release:check` (46 files / 538 tests, package runtime verification, pack dry-run)

## Issues
Advances #212.
Closes #213.
Closes #217.
Closes #218 after confirming downstream plugin guidance is already Node 18+ and not Bun-required.
Closes #219.