### PR TITLE
Centralize host install and discovery truth

### DIFF
--- a/docs/core-four-install-update-lifecycle.md
+++ b/docs/core-four-install-update-lifecycle.md
@@ -1,6 +1,6 @@
 # Core-Four Install And Update Lifecycle
 
-Last updated: 2026-06-24
+Last updated: 2026-06-25
 
 This doc explains the practical install, update, and reload behavior for the four primary Pluxx targets:
 
@@ -19,6 +19,19 @@ Use this doc when the question is not “what files does the host support?” bu
 For the official-doc-backed host capability audit, use [Core-Four Provider Docs Audit](./core-four-provider-docs-audit.md).
 
 For the current release/distribution/proof boundary, use [Release Distribution Proof Map](./release-distribution-proof-map.md).
+
+## Host Install And Discovery Capability Matrix
+
+This is the code-owned source of truth for issue #306: install method, local path, reload behavior, cache semantics, discovery surface, and brand/listing support per primary host.
+
+<!-- BEGIN GENERATED HOST INSTALL DISCOVERY CAPABILITIES -->
+| Host | Install method | Local install path | Reload / update pickup | Cache semantics | Discovery surface | Brand / listing support |
+|---|---|---|---|---|---|---|
+| Claude Code | Native Claude plugin install from a generated local marketplace, or the generated release installer. | ~/.claude/plugins/cache/pluxx-local-<plugin>/<plugin>/<version> after native install; legacy direct installs may still appear at ~/.claude/plugins/<plugin>. | Run /reload-plugins in the active Claude window. | Claude copies the selected marketplace plugin into a versioned plugin cache. Pluxx verifies that cache path rather than assuming the source bundle is live. | Claude plugin marketplace/listing commands and the active Claude plugin list after reload. | No shared manifest-backed brand fields from Pluxx brand today; instructions, skills, commands, and assets still ship inside the bundle. |
+| Cursor | Local plugin install or generated release installer that replaces the local bundle. | ~/.cursor/plugins/local/<plugin> | Use Developer: Reload Window or restart Cursor. | Pluxx installs the local bundle path directly; no separate Pluxx-managed active cache is modeled. | Cursor local plugin directory and host plugin UI after reload or restart. | Narrow shared-brand translation: homepage and logo can be emitted; richer listing copy is not a shared Cursor surface today. |
+| Codex | Local plugin install plus a local marketplace catalog entry, or the generated release installer. | ~/.codex/plugins/<plugin> plus a local marketplace catalog entry. | Use Plugins > Refresh when that UI action is available, otherwise restart Codex. | Codex may load a separate active cache under ~/.codex/plugins/cache/local-plugins/<plugin>/<version>. Pluxx clears local cache on install/uninstall and verify-install detects stale cache contents. | Codex Plugins view and plugin detail page. Plugin-bundled MCP servers may appear on the plugin detail page without appearing in the global MCP servers settings page. | Richest current shared-brand target: display name, descriptions, category, color, icon/logo, screenshots, default prompt, website, and policy links can be emitted into .codex-plugin/plugin.json interface metadata. |
+| OpenCode | Local plugin directory plus generated entry wrapper, generated release installer, or npm-backed wrapper package path. | ~/.config/opencode/plugins/<plugin> plus ~/.config/opencode/plugins/<plugin>.ts and synced skills under ~/.config/opencode/skills/<plugin>-<skill>. | Restart or reload OpenCode. | Pluxx writes the local plugin wrapper and synced skill files directly; no separate Pluxx-managed active cache is modeled. | OpenCode plugin loader, plugin wrapper file, and synced skill namespace. | No shared manifest-backed brand fields from Pluxx brand today; OpenCode receives functional plugin module, instructions, skills, and package metadata. |
+<!-- END GENERATED HOST INSTALL DISCOVERY CAPABILITIES -->
 
 ## Lifecycle Matrix
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -493,7 +493,7 @@ $ npx @orchid-labs/pluxx install --target claude-code
   claude-code -> claude plugin install my-plugin@pluxx-local-my-plugin
 
 Installed 1 plugin(s). Reload or restart your tools to pick them up.
-Claude Code note: if Claude is already open, run /reload-plugins in the session to pick up the new install.
+Claude Code note: if Claude is already open, run /reload-plugins to pick up the new install.
 ```
 
 ### Step 6: Sync later

--- a/site/how-it-works/how-it-works.mdx
+++ b/site/how-it-works/how-it-works.mdx
@@ -477,7 +477,7 @@ $ npx @orchid-labs/pluxx install --target claude-code
   claude-code -> claude plugin install my-plugin@pluxx-local-my-plugin
 
 Installed 1 plugin(s). Reload or restart your tools to pick them up.
-Claude Code note: if Claude is already open, run /reload-plugins in the session to pick up the new install.
+Claude Code note: if Claude is already open, run /reload-plugins to pick up the new install.
 ```
 
 After install, verify the host-visible state instead of trusting `dist/` alone:

--- a/src/distribution-lifecycle.ts
+++ b/src/distribution-lifecycle.ts
@@ -1,25 +1,95 @@
 import type { TargetPlatform } from './schema'
 
-const INSTALL_FOLLOWUP_NOTES: Partial<Record<TargetPlatform, string>> = {
-  'claude-code': 'Claude Code note: if Claude is already open, run /reload-plugins in the session to pick up the new install.',
-  cursor: 'Cursor note: if Cursor is already open, use Developer: Reload Window or restart Cursor to pick up the new install.',
-  codex: 'Codex note: if Codex is already open, use Plugins > Refresh if that action is available in your current UI, or restart Codex to pick up the new install. Plugin-bundled MCP servers may appear on the plugin detail page without appearing in the global MCP servers settings page.',
-  opencode: 'OpenCode note: if OpenCode is already open, restart or reload it so the plugin is picked up.',
+export type CoreFourTargetPlatform = Extract<TargetPlatform, 'claude-code' | 'cursor' | 'codex' | 'opencode'>
+
+export interface HostInstallDiscoveryCapability {
+  platform: CoreFourTargetPlatform
+  label: string
+  installMethod: string
+  localInstallPath: string
+  reloadBehavior: string
+  cacheSemantics: string
+  discoverySurface: string
+  brandListingSupport: string
+  installFollowupNote: string
+  publishReloadInstruction: string
+  verifyStaleAction?: string
 }
+
+export const CORE_FOUR_INSTALL_DISCOVERY_CAPABILITIES: readonly HostInstallDiscoveryCapability[] = [
+  {
+    platform: 'claude-code',
+    label: 'Claude Code',
+    installMethod: 'Native Claude plugin install from a generated local marketplace, or the generated release installer.',
+    localInstallPath: '~/.claude/plugins/cache/pluxx-local-<plugin>/<plugin>/<version> after native install; legacy direct installs may still appear at ~/.claude/plugins/<plugin>.',
+    reloadBehavior: 'Run /reload-plugins in the active Claude window.',
+    cacheSemantics: 'Claude copies the selected marketplace plugin into a versioned plugin cache. Pluxx verifies that cache path rather than assuming the source bundle is live.',
+    discoverySurface: 'Claude plugin marketplace/listing commands and the active Claude plugin list after reload.',
+    brandListingSupport: 'No shared manifest-backed brand fields from Pluxx brand today; instructions, skills, commands, and assets still ship inside the bundle.',
+    installFollowupNote: 'Claude Code note: if Claude is already open, run /reload-plugins to pick up the new install.',
+    publishReloadInstruction: 'If Claude is already open, run /reload-plugins.',
+  },
+  {
+    platform: 'cursor',
+    label: 'Cursor',
+    installMethod: 'Local plugin install or generated release installer that replaces the local bundle.',
+    localInstallPath: '~/.cursor/plugins/local/<plugin>',
+    reloadBehavior: 'Use Developer: Reload Window or restart Cursor.',
+    cacheSemantics: 'Pluxx installs the local bundle path directly; no separate Pluxx-managed active cache is modeled.',
+    discoverySurface: 'Cursor local plugin directory and host plugin UI after reload or restart.',
+    brandListingSupport: 'Narrow shared-brand translation: homepage and logo can be emitted; richer listing copy is not a shared Cursor surface today.',
+    installFollowupNote: 'Cursor note: if Cursor is already open, use Developer: Reload Window or restart Cursor to pick up the new install.',
+    publishReloadInstruction: 'If Cursor is already open, use Developer: Reload Window or restart Cursor so the plugin is picked up.',
+  },
+  {
+    platform: 'codex',
+    label: 'Codex',
+    installMethod: 'Local plugin install plus a local marketplace catalog entry, or the generated release installer.',
+    localInstallPath: '~/.codex/plugins/<plugin> plus a local marketplace catalog entry.',
+    reloadBehavior: 'Use Plugins > Refresh when that UI action is available, otherwise restart Codex.',
+    cacheSemantics: 'Codex may load a separate active cache under ~/.codex/plugins/cache/local-plugins/<plugin>/<version>. Pluxx clears local cache on install/uninstall and verify-install detects stale cache contents.',
+    discoverySurface: 'Codex Plugins view and plugin detail page. Plugin-bundled MCP servers may appear on the plugin detail page without appearing in the global MCP servers settings page.',
+    brandListingSupport: 'Richest current shared-brand target: display name, descriptions, category, color, icon/logo, screenshots, default prompt, website, and policy links can be emitted into .codex-plugin/plugin.json interface metadata.',
+    installFollowupNote: 'Codex note: if Codex is already open, use Plugins > Refresh if that action is available in your current UI, or restart Codex to pick up the new install. Plugin-bundled MCP servers may appear on the plugin detail page without appearing in the global MCP servers settings page.',
+    publishReloadInstruction: 'If Codex is already open, use Plugins > Refresh if that action is available in your current UI, or restart Codex so the plugin is picked up.',
+    verifyStaleAction: 'in Codex, use Plugins > Refresh if available, or restart Codex so the plugin cache reloads',
+  },
+  {
+    platform: 'opencode',
+    label: 'OpenCode',
+    installMethod: 'Local plugin directory plus generated entry wrapper, generated release installer, or npm-backed wrapper package path.',
+    localInstallPath: '~/.config/opencode/plugins/<plugin> plus ~/.config/opencode/plugins/<plugin>.ts and synced skills under ~/.config/opencode/skills/<plugin>-<skill>.',
+    reloadBehavior: 'Restart or reload OpenCode.',
+    cacheSemantics: 'Pluxx writes the local plugin wrapper and synced skill files directly; no separate Pluxx-managed active cache is modeled.',
+    discoverySurface: 'OpenCode plugin loader, plugin wrapper file, and synced skill namespace.',
+    brandListingSupport: 'No shared manifest-backed brand fields from Pluxx brand today; OpenCode receives functional plugin module, instructions, skills, and package metadata.',
+    installFollowupNote: 'OpenCode note: if OpenCode is already open, restart or reload it so the plugin is picked up.',
+    publishReloadInstruction: 'If OpenCode is already open, restart or reload it so the plugin is picked up.',
+  },
+] as const
+
+const CORE_FOUR_CAPABILITIES_BY_PLATFORM = Object.fromEntries(
+  CORE_FOUR_INSTALL_DISCOVERY_CAPABILITIES.map((capability) => [capability.platform, capability]),
+) as Record<CoreFourTargetPlatform, HostInstallDiscoveryCapability>
+
+const CORE_FOUR_PLATFORMS = new Set<TargetPlatform>(
+  CORE_FOUR_INSTALL_DISCOVERY_CAPABILITIES.map((capability) => capability.platform),
+)
 
 const VERIFY_STALE_ACTIONS: Partial<Record<TargetPlatform, string>> = {
-  codex: 'in Codex, use Plugins > Refresh if available, or restart Codex so the plugin cache reloads',
+  codex: CORE_FOUR_CAPABILITIES_BY_PLATFORM.codex.verifyStaleAction,
 }
 
-const PUBLISH_RELOAD_INSTRUCTIONS: Partial<Record<TargetPlatform, string>> = {
-  'claude-code': 'If Claude is already open, run /reload-plugins in the active session.',
-  cursor: 'If Cursor is already open, use Developer: Reload Window or restart Cursor so the plugin is picked up.',
-  codex: 'If Codex is already open, use Plugins > Refresh if that action is available in your current UI, or restart Codex so the plugin is picked up.',
-  opencode: 'If OpenCode is already open, restart or reload it so the plugin is picked up.',
+function isCoreFourTarget(target: TargetPlatform): target is CoreFourTargetPlatform {
+  return CORE_FOUR_PLATFORMS.has(target)
+}
+
+export function getHostInstallDiscoveryCapability(target: CoreFourTargetPlatform): HostInstallDiscoveryCapability {
+  return CORE_FOUR_CAPABILITIES_BY_PLATFORM[target]
 }
 
 export function getInstallFollowupNote(target: TargetPlatform): string | undefined {
-  return INSTALL_FOLLOWUP_NOTES[target]
+  return isCoreFourTarget(target) ? getHostInstallDiscoveryCapability(target).installFollowupNote : undefined
 }
 
 export function getInstallFollowupNotes(targets: TargetPlatform[]): string[] {
@@ -33,5 +103,44 @@ export function getVerifyInstallStaleAction(target: TargetPlatform): string | un
 }
 
 export function getPublishReloadInstruction(target: TargetPlatform): string | undefined {
-  return PUBLISH_RELOAD_INSTRUCTIONS[target]
+  return isCoreFourTarget(target) ? getHostInstallDiscoveryCapability(target).publishReloadInstruction : undefined
+}
+
+export function renderHostInstallDiscoveryCapabilitiesMarkdown(): string {
+  const lines = [
+    '| Host | Install method | Local install path | Reload / update pickup | Cache semantics | Discovery surface | Brand / listing support |',
+    '|---|---|---|---|---|---|---|',
+  ]
+
+  for (const capability of CORE_FOUR_INSTALL_DISCOVERY_CAPABILITIES) {
+    lines.push([
+      capability.label,
+      capability.installMethod,
+      capability.localInstallPath,
+      capability.reloadBehavior,
+      capability.cacheSemantics,
+      capability.discoverySurface,
+      capability.brandListingSupport,
+    ].map(escapeMarkdownTableCell).join(' | ').replace(/^/, '| ').replace(/$/, ' |'))
+  }
+
+  return `${lines.join('\n')}\n`
+}
+
+export function replaceGeneratedHostInstallDiscoverySection(markdown: string): string {
+  const start = '<!-- BEGIN GENERATED HOST INSTALL DISCOVERY CAPABILITIES -->'
+  const end = '<!-- END GENERATED HOST INSTALL DISCOVERY CAPABILITIES -->'
+  const startIndex = markdown.indexOf(start)
+  const endIndex = markdown.indexOf(end)
+  if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
+    throw new Error('Missing generated host install discovery capability markers')
+  }
+
+  const before = markdown.slice(0, startIndex + start.length)
+  const after = markdown.slice(endIndex)
+  return `${before}\n${renderHostInstallDiscoveryCapabilitiesMarkdown()}${after}`
+}
+
+function escapeMarkdownTableCell(value: string): string {
+  return value.replace(/\|/g, '\\|')
 }

--- a/tests/distribution-lifecycle.test.ts
+++ b/tests/distribution-lifecycle.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import {
+  CORE_FOUR_INSTALL_DISCOVERY_CAPABILITIES,
+  getHostInstallDiscoveryCapability,
+  getInstallFollowupNote,
+  getPublishReloadInstruction,
+  getVerifyInstallStaleAction,
+  replaceGeneratedHostInstallDiscoverySection,
+} from '../src/distribution-lifecycle'
+
+const ROOT = resolve(import.meta.dir, '..')
+
+describe('distribution lifecycle capabilities', () => {
+  it('centralizes install, reload, cache, discovery, and brand truth for the core four', () => {
+    expect(CORE_FOUR_INSTALL_DISCOVERY_CAPABILITIES.map((capability) => capability.platform)).toEqual([
+      'claude-code',
+      'cursor',
+      'codex',
+      'opencode',
+    ])
+
+    expect(getHostInstallDiscoveryCapability('claude-code').localInstallPath).toContain('~/.claude/plugins/cache/')
+    expect(getHostInstallDiscoveryCapability('cursor').brandListingSupport).toContain('homepage and logo')
+    expect(getHostInstallDiscoveryCapability('codex').cacheSemantics).toContain('stale cache contents')
+    expect(getHostInstallDiscoveryCapability('codex').discoverySurface).toContain('plugin detail page')
+    expect(getHostInstallDiscoveryCapability('opencode').localInstallPath).toContain('synced skills')
+  })
+
+  it('keeps existing CLI reload and stale-cache helpers backed by the registry', () => {
+    expect(getInstallFollowupNote('claude-code')).toBe(
+      getHostInstallDiscoveryCapability('claude-code').installFollowupNote,
+    )
+    expect(getPublishReloadInstruction('codex')).toBe(
+      getHostInstallDiscoveryCapability('codex').publishReloadInstruction,
+    )
+    expect(getVerifyInstallStaleAction('codex')).toBe(
+      getHostInstallDiscoveryCapability('codex').verifyStaleAction,
+    )
+    expect(getInstallFollowupNote('gemini-cli')).toBeUndefined()
+    expect(getPublishReloadInstruction('gemini-cli')).toBeUndefined()
+  })
+
+  it('keeps the lifecycle doc capability table generated from the registry', () => {
+    const checkedIn = readFileSync(resolve(ROOT, 'docs/core-four-install-update-lifecycle.md'), 'utf-8')
+
+    expect(checkedIn).toBe(replaceGeneratedHostInstallDiscoverySection(checkedIn))
+  })
+})

--- a/tests/install.test.ts
+++ b/tests/install.test.ts
@@ -211,7 +211,7 @@ describe('install', () => {
 
   it('reports host-specific reload guidance for the core four install surfaces', () => {
     expect(getInstallFollowupNotes(['claude-code', 'cursor', 'codex', 'opencode'])).toEqual([
-      'Claude Code note: if Claude is already open, run /reload-plugins in the session to pick up the new install.',
+      'Claude Code note: if Claude is already open, run /reload-plugins to pick up the new install.',
       'Cursor note: if Cursor is already open, use Developer: Reload Window or restart Cursor to pick up the new install.',
       'Codex note: if Codex is already open, use Plugins > Refresh if that action is available in your current UI, or restart Codex to pick up the new install. Plugin-bundled MCP servers may appear on the plugin detail page without appearing in the global MCP servers settings page.',
       'OpenCode note: if OpenCode is already open, restart or reload it so the plugin is picked up.',


### PR DESCRIPTION
## Summary
- centralize core-four install/discovery/reload/cache/brand capability truth in src/distribution-lifecycle.ts
- render the lifecycle doc capability table from that registry and pin it with a doc-sync test
- align copied Claude install output docs with the shared helper text

## Scope
Picked the smallest shippable slice from the distribution/install lane: #306. This does not implement the broader DistributionSpec (#305), canonical install references (#227), trust tiers (#229), team/private registry design (#233), or the release UX/component work (#225).

Closes #306.

## Validation
- npm run build
- npm run typecheck
- npx vitest run tests/distribution-lifecycle.test.ts tests/install.test.ts
- npx vitest run tests/publish.test.ts tests/release-smoke.test.ts
- npm test