### PR TITLE
Improve local docs ingestion cleanup

### DIFF
--- a/docs/strategy/docs-url-ingestion.md
+++ b/docs/strategy/docs-url-ingestion.md
@@ -224,6 +224,7 @@ Current behavior:
 - `auto` prefers Firecrawl when configured and otherwise keeps the local OSS path.
 - `firecrawl` is an explicit opt-in that fails fast when no Firecrawl key is configured.
 - `local` forces the built-in fetch + extraction path even if Firecrawl is available.
+- The local path now parses HTML with Cheerio, strips docs-site chrome before extraction, and converts the cleaned main-content fragment to Markdown with Turndown before structured signal extraction.
 - If `--docs` points at a deep page like `https://docs.firecrawl.dev/mcp-server`, Pluxx keeps that exact page and also infers the broader docs root when it can.
 - If only `--website` is provided, Pluxx probes a small set of likely docs roots such as `docs.<host>`, `/docs`, `/developers`, `/api`, and `/reference`.
 - Pluxx writes provenance to `.pluxx/sources.json`, including provider resolution.
@@ -251,6 +252,6 @@ The current snapshot is useful enough to steer product work already:
   - `docs/strategy/docs-ingestion-fixture-eval.md`
 - the scaffold-quality before/after demo is now also captured:
   - `docs/strategy/docs-ingestion-scaffold-before-after.md`
-- Firecrawl remains the clearest weak case for the local fallback because the JS-heavy surface still leaks noisy setup/workflow signals
+- In the latest committed fixture snapshot, Firecrawl remains the clearest weak case for the local fallback because the JS-heavy surface still leaks noisy setup/workflow signals; rerun the fixture comparison after the Cheerio/Turndown local cleanup slice before treating that old local score as current.
 - PlayKit shows the local path can work well when the docs root exposes strong setup and product language in server-rendered HTML
 - Sumble shows that even when docs detail is light, website + docs seeds can still recover useful product truth like product name and positioning

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "1.2.0",
+        "cheerio": "1.0.0-rc.12",
         "jiti": "^2.6.1",
+        "turndown": "^7.2.4",
         "zod": "^3.24.0"
       },
       "bin": {
@@ -18,6 +20,7 @@
       },
       "devDependencies": {
         "@types/node": "^22.15.23",
+        "@types/turndown": "^5.0.6",
         "esbuild": "^0.25.4",
         "tsx": "^4.20.3",
         "typescript": "^5.7.0",
@@ -494,6 +497,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
@@ -879,6 +888,13 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/turndown": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.6.tgz",
+      "integrity": "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -1004,6 +1020,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -1041,6 +1063,72 @@
         "node": ">= 16"
       }
     },
+    "node_modules/cheerio": {
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
+      "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "htmlparser2": "^8.0.1",
+        "parse5": "^7.0.0",
+        "parse5-htmlparser2-tree-adapter": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1067,6 +1155,73 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-module-lexer": {
@@ -1202,6 +1357,25 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "license": "MIT",
@@ -1257,6 +1431,55 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/pathe": {
@@ -1991,6 +2214,19 @@
         "@esbuild/win32-arm64": "0.27.7",
         "@esbuild/win32-ia32": "0.27.7",
         "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/turndown": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz",
+      "integrity": "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.15.23",
+    "@types/turndown": "^5.0.6",
     "esbuild": "^0.25.4",
     "tsx": "^4.20.3",
     "typescript": "^5.7.0",
@@ -73,7 +74,9 @@
   },
   "dependencies": {
     "@clack/prompts": "1.2.0",
+    "cheerio": "1.0.0-rc.12",
     "jiti": "^2.6.1",
+    "turndown": "^7.2.4",
     "zod": "^3.24.0"
   }
 }

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -3,6 +3,8 @@ import { chmod, copyFile, mkdir, mkdtemp, readFile, rm } from 'fs/promises'
 import { homedir, tmpdir } from 'os'
 import { relative, resolve } from 'path'
 import { spawn } from 'child_process'
+import * as cheerio from 'cheerio/lib/slim'
+import TurndownService from 'turndown'
 import { planTextFileAction, readTextFile, writeTextFile } from '../text-files'
 import { loadConfig } from '../config/load'
 import { getCanonicalCommandMetadata, readCanonicalCommandFiles } from '../commands'
@@ -34,6 +36,9 @@ export type AgentRunner = typeof AGENT_RUNNERS[number]
 export type AgentIngestProvider = typeof AGENT_INGEST_PROVIDERS[number]
 export type ResolvedAgentIngestProvider = Exclude<AgentIngestProvider, 'auto'>
 
+type CheerioRoot = cheerio.CheerioAPI
+type CheerioSelection = cheerio.Cheerio<any>
+
 const AGENT_PROMPT_PATHS: Record<AgentPromptKind, string> = {
   taxonomy: '.pluxx/agent/taxonomy-prompt.md',
   instructions: '.pluxx/agent/instructions-prompt.md',
@@ -48,6 +53,35 @@ const AGENT_RUNNER_BINARIES: Record<AgentRunner, string> = {
 }
 
 const CURSOR_RUNNER_BINARIES = ['agent', 'cursor-agent'] as const
+const LOCAL_HTML_TURNDOWN = new TurndownService({
+  headingStyle: 'atx',
+  codeBlockStyle: 'fenced',
+  bulletListMarker: '-',
+})
+
+const LOCAL_HTML_NOISE_SELECTORS = [
+  'script',
+  'style',
+  'noscript',
+  'svg',
+  'template',
+  'iframe',
+  'canvas',
+  'header',
+  'nav',
+  'footer',
+  'aside',
+  'form',
+  'button',
+  'input',
+  'select',
+  'textarea',
+  '[hidden]',
+  '[aria-hidden="true"]',
+  '[role="navigation"]',
+  '[role="search"]',
+  '[data-pagefind-ignore]',
+].join(',')
 
 export interface AgentPreparePlannedFile {
   relativePath: string
@@ -1524,38 +1558,38 @@ function extractLocalMappedLinks(
   html: string,
   kind: 'website' | 'docs',
 ): FirecrawlMappedLink[] {
-  const cleanedHtml = stripNonContentHtml(html)
-  const primaryHtml = selectPrimaryHtmlFragment(cleanedHtml)
-  const matches = primaryHtml.matchAll(/<a\b[^>]*href=(["'])(.*?)\1[^>]*>([\s\S]*?)<\/a>/gi)
   const base = safeParseUrl(baseUrl)
   if (!base) return []
 
+  const $ = cheerio.load(html)
+  const primary = selectLocalMainContent($)
+  cleanLocalHtmlSelection($, primary)
   const links: FirecrawlMappedLink[] = []
-  for (const match of matches) {
-    const rawHref = match[2]?.trim()
+  primary.find('a[href]').each((_, element) => {
+    const rawHref = $(element).attr('href')?.trim()
     if (!rawHref || rawHref.startsWith('#') || rawHref.startsWith('javascript:') || rawHref.startsWith('mailto:') || rawHref.startsWith('tel:')) {
-      continue
+      return
     }
 
     const resolved = safeParseUrl(new URL(rawHref, baseUrl).toString())
     if (!resolved || !['http:', 'https:'].includes(resolved.protocol)) {
-      continue
+      return
     }
 
     if (kind === 'docs' && resolved.host !== base.host) {
-      continue
+      return
     }
     if (kind === 'website' && resolved.host !== base.host && !resolved.host.startsWith('docs.')) {
-      continue
+      return
     }
 
     resolved.hash = ''
-    const title = cleanHtmlText(match[3] ?? '')
+    const title = normalizeHtmlText($(element).text())
     links.push({
       url: resolved.toString(),
       title: title || undefined,
     })
-  }
+  })
 
   return normalizeFirecrawlMappedLinks(
     uniqueStrings(links.map((link) => JSON.stringify(link))).map((entry) => JSON.parse(entry) as FirecrawlMappedLink),
@@ -2123,80 +2157,108 @@ function summarizeHtml(html: string): {
   headings: string[]
   paragraphs: string[]
 } {
-  const cleanedHtml = stripNonContentHtml(html)
-  const primaryHtml = selectPrimaryHtmlFragment(cleanedHtml)
-  const title = matchHtmlTag(html, 'title')
-  const description = matchMetaDescription(html)
-  const headings = matchHtmlTags(primaryHtml, ['h1', 'h2', 'h3'])
-    .filter((value) => !isLikelyChromeHeading(value))
-    .slice(0, 5)
-  const paragraphs = filterLikelyContentText(matchHtmlTags(primaryHtml, ['p']))
-    .slice(0, 3)
-  const lines: string[] = []
+  const artifact = extractLocalHtmlMarkdownArtifact(html)
+  return summarizeMarkdownArtifact(artifact.markdown, {
+    title: artifact.title,
+    description: artifact.description,
+  })
+}
 
-  if (title) {
-    lines.push(`Title: ${title}`)
-  }
-  if (description) {
-    lines.push(`Description: ${description}`)
-  }
-  if (headings.length > 0) {
-    lines.push(`Headings: ${headings.join(' | ')}`)
-  }
-  if (paragraphs.length > 0) {
-    lines.push(`Excerpt: ${paragraphs.join(' ').slice(0, 900)}`)
-  }
+function extractLocalHtmlMarkdownArtifact(html: string): {
+  markdown: string
+  title?: string
+  description?: string
+} {
+  const $ = cheerio.load(html)
+  const title = normalizeHtmlText($('title').first().text()) || undefined
+  const description = normalizeHtmlText(
+    $('meta[name="description" i]').first().attr('content')
+    ?? $('meta[property="og:description" i]').first().attr('content')
+    ?? '',
+  ) || undefined
+  const primary = selectLocalMainContent($).clone()
+  cleanLocalHtmlSelection($, primary)
+  const primaryHtml = primary.html() ?? ''
+  const markdown = LOCAL_HTML_TURNDOWN.turndown(primaryHtml || normalizeHtmlText(primary.text()))
 
   return {
-    summary: lines.join('\n'),
-    title: title ?? undefined,
-    description: description ?? undefined,
-    headings,
-    paragraphs,
+    markdown,
+    title,
+    description,
   }
 }
 
-function stripNonContentHtml(html: string): string {
-  return html
-    .replace(/<!--[\s\S]*?-->/g, ' ')
-    .replace(/<(script|style|noscript|svg|template)[^>]*>[\s\S]*?<\/\1>/gi, ' ')
-}
-
-function selectPrimaryHtmlFragment(html: string): string {
-  const preferredPatterns = [
-    /<main\b[^>]*>([\s\S]*?)<\/main>/gi,
-    /<article\b[^>]*>([\s\S]*?)<\/article>/gi,
-    /<([a-z0-9:-]+)\b[^>]*\brole=["']main["'][^>]*>([\s\S]*?)<\/\1>/gi,
-    /<([a-z0-9:-]+)\b[^>]*\b(?:id|class)=["'][^"']*(?:content|docs|doc-content|article|main|prose)[^"']*["'][^>]*>([\s\S]*?)<\/\1>/gi,
+function selectLocalMainContent($: CheerioRoot): CheerioSelection {
+  const selectors = [
+    'main',
+    'article',
+    '[role="main"]',
+    '[data-mdx-content]',
+    '[data-docs-content]',
+    '.markdown-body',
+    '.prose',
+    '.doc-content',
+    '.docs-content',
+    '.documentation',
+    '#content',
+    '#docs-content',
+    '#main-content',
+    '[class*="main-content"]',
+    '[class*="docs-content"]',
+    '[class*="doc-content"]',
+    '[class*="markdown"]',
+    '[class*="prose"]',
   ]
 
-  let bestFragment = ''
+  let best: CheerioSelection = $('body').first()
   let bestScore = Number.NEGATIVE_INFINITY
 
-  for (const pattern of preferredPatterns) {
-    const matches = html.matchAll(pattern)
-    for (const match of matches) {
-      const fragment = match[2] ?? match[1] ?? ''
-      const score = scoreHtmlFragment(fragment)
+  for (const selector of selectors) {
+    $(selector).each((_, element) => {
+      const candidate = $(element)
+      const score = scoreLocalHtmlCandidate(candidate)
       if (score > bestScore) {
         bestScore = score
-        bestFragment = fragment
+        best = candidate
       }
-    }
+    })
   }
 
-  if (bestFragment) return bestFragment
-
-  const body = html.match(/<body\b[^>]*>([\s\S]*?)<\/body>/i)?.[1]
-  return body || html
+  return best.length > 0 ? best : $.root()
 }
 
-function scoreHtmlFragment(fragment: string): number {
-  const text = cleanHtmlText(fragment)
-  const paragraphCount = (fragment.match(/<p\b/gi) ?? []).length
-  const headingCount = (fragment.match(/<h[1-3]\b/gi) ?? []).length
-  const chromePenalty = isLikelyChromeText(text) ? 120 : 0
-  return text.length + paragraphCount * 120 + headingCount * 80 - chromePenalty
+function cleanLocalHtmlSelection($: CheerioRoot, selection: CheerioSelection): void {
+  selection.find(LOCAL_HTML_NOISE_SELECTORS).remove()
+  selection.find('[class], [id], [aria-label], [data-testid]').each((_, element) => {
+    const marker = [
+      $(element).attr('id'),
+      $(element).attr('class'),
+      $(element).attr('aria-label'),
+      $(element).attr('data-testid'),
+    ]
+      .filter(Boolean)
+      .join(' ')
+      .toLowerCase()
+
+    if (/(^|\b)(sidebar|side-nav|sidenav|toc|table-of-contents|breadcrumb|pagination|prev-next|navbar|nav-menu|cookie|banner|announcement|promo|search)(\b|$)/.test(marker)) {
+      $(element).remove()
+    }
+  })
+}
+
+function scoreLocalHtmlCandidate(selection: CheerioSelection): number {
+  const text = normalizeHtmlText(selection.text())
+  if (!text) return Number.NEGATIVE_INFINITY
+
+  const paragraphCount = selection.find('p,li').length
+  const headingCount = selection.find('h1,h2,h3').length
+  const codeCount = selection.find('pre,code').length
+  const linkCount = selection.find('a').length
+  const wordCount = text.split(/\s+/).length
+  const chromePenalty = isLikelyChromeText(text) ? 400 : 0
+  const linkPenalty = linkCount > paragraphCount + headingCount + codeCount + 6 ? 150 : 0
+
+  return wordCount * 8 + paragraphCount * 120 + headingCount * 90 + codeCount * 100 - chromePenalty - linkPenalty
 }
 
 function filterLikelyContentText(values: string[]): string[] {
@@ -2642,33 +2704,8 @@ function uniqueStrings<T extends string>(values: T[]): T[] {
   return [...new Set(values.map((value) => value.trim()).filter(Boolean) as T[])]
 }
 
-function matchHtmlTag(html: string, tag: string): string | null {
-  const match = html.match(new RegExp(`<${tag}[^>]*>([\\s\\S]*?)</${tag}>`, 'i'))
-  return match ? cleanHtmlText(match[1]) : null
-}
-
-function matchMetaDescription(html: string): string | null {
-  const match = html.match(/<meta[^>]+name=["']description["'][^>]+content=["']([^"']+)["'][^>]*>/i)
-  return match ? cleanHtmlText(match[1]) : null
-}
-
-function matchHtmlTags(html: string, tags: string[]): string[] {
-  const pattern = new RegExp(`<(?:${tags.join('|')})[^>]*>([\\s\\S]*?)</(?:${tags.join('|')})>`, 'ig')
-  const values: string[] = []
-  for (const match of html.matchAll(pattern)) {
-    const value = cleanHtmlText(match[1])
-    if (value) values.push(value)
-  }
-  return values
-}
-
-function cleanHtmlText(value: string): string {
-  return value
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
+function normalizeHtmlText(value: string | undefined): string {
+  return (value ?? '')
     .replace(/\s+/g, ' ')
     .trim()
 }

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -1562,8 +1562,9 @@ function extractLocalMappedLinks(
   if (!base) return []
 
   const $ = cheerio.load(html)
+  // Docs sites often place valid follow-up pages in sidebars inside <main>.
+  // Keep pruning limited to text summarization so expansion does not lose them.
   const primary = selectLocalMainContent($)
-  cleanLocalHtmlSelection($, primary)
   const links: FirecrawlMappedLink[] = []
   primary.find('a[href]').each((_, element) => {
     const rawHref = $(element).attr('href')?.trim()

--- a/src/cli/agent.ts
+++ b/src/cli/agent.ts
@@ -1564,7 +1564,7 @@ function extractLocalMappedLinks(
   const $ = cheerio.load(html)
   // Docs sites often place valid follow-up pages in sidebars inside <main>.
   // Keep pruning limited to text summarization so expansion does not lose them.
-  const primary = selectLocalMainContent($)
+  const primary = selectLocalLinkDiscoveryContent($)
   const links: FirecrawlMappedLink[] = []
   primary.find('a[href]').each((_, element) => {
     const rawHref = $(element).attr('href')?.trim()
@@ -1595,6 +1595,11 @@ function extractLocalMappedLinks(
   return normalizeFirecrawlMappedLinks(
     uniqueStrings(links.map((link) => JSON.stringify(link))).map((entry) => JSON.parse(entry) as FirecrawlMappedLink),
   )
+}
+
+function selectLocalLinkDiscoveryContent($: CheerioRoot): CheerioSelection {
+  const main = $('main, [role="main"]').first()
+  return main.length > 0 ? main : selectLocalMainContent($)
 }
 
 function normalizeFirecrawlMappedLinks(

--- a/tests/agent-mode.test.ts
+++ b/tests/agent-mode.test.ts
@@ -1274,11 +1274,21 @@ exit 1
                     <a href="/docs/authentication">Authentication</a>
                     <a href="/docs/quickstart">Quickstart</a>
                     <a href="/docs/knowledge-tools">Knowledge Tools</a>
+                    <a href="/docs/overview">Overview</a>
+                    <a href="/docs/guides">Guides</a>
+                    <a href="/docs/tables">Tables</a>
+                    <a href="/docs/actions">Actions</a>
+                    <a href="/docs/admin">Admin</a>
+                    <a href="/docs/billing">Billing</a>
+                    <a href="/docs/settings">Settings</a>
+                    <a href="/docs/support">Support</a>
                   </nav>
                 </aside>
-                <article>
+                <article class="prose">
                   <h1>PlayKit Docs</h1>
-                  <p>Choose a guide from the docs navigation.</p>
+                  <p>Choose a guide from the docs navigation after reviewing the product overview and workflow model.</p>
+                  <p>PlayKit helps operators answer Clay questions, plan enrichments, and inspect table workflows before they spend credits.</p>
+                  <p>The primary docs content is intentionally longer than the short sidebar labels so text scoring prefers this nested prose container.</p>
                 </article>
               </main>
             </body>

--- a/tests/agent-mode.test.ts
+++ b/tests/agent-mode.test.ts
@@ -1189,11 +1189,15 @@ exit 1
                   <p>Search docs</p>
                 </nav>
               </header>
+              <aside class="table-of-contents">
+                <a href="/pricing">API key sidebar teaser</a>
+              </aside>
               <main>
                 <h1>Firecrawl MCP</h1>
                 <h2>Scrape pages</h2>
                 <p>Set the Firecrawl API key before using the hosted endpoint.</p>
                 <p>Use onlyMainContent when you want cleaner page bodies.</p>
+                <pre><code>env FIRECRAWL_API_KEY=fc-YOUR_API_KEY npx -y firecrawl-mcp</code></pre>
               </main>
               <footer>
                 <p>Privacy Policy</p>
@@ -1234,9 +1238,11 @@ exit 1
       expect(docsContext.workflowHints).toContain('Scrape pages')
       expect(docsContext.authHints).toContain('Set the Firecrawl API key before using the hosted endpoint.')
       expect(docsContext.setupHints.some((hint) => hint.includes('onlyMainContent') || hint.includes('only Main Content'))).toBe(true)
+      expect(docsContext.setupHints.some((hint) => hint.includes('npx -y firecrawl-mcp'))).toBe(true)
       expect(context).not.toContain('Pricing')
       expect(context).not.toContain('Privacy Policy')
       expect(context).not.toContain('Search docs')
+      expect(context).not.toContain('API key sidebar teaser')
     } finally {
       globalThis.fetch = originalFetch
     }

--- a/tests/agent-mode.test.ts
+++ b/tests/agent-mode.test.ts
@@ -1269,10 +1269,17 @@ exit 1
                 </nav>
               </header>
               <main>
-                <h1>PlayKit Docs</h1>
-                <a href="/docs/authentication">Authentication</a>
-                <a href="/docs/quickstart">Quickstart</a>
-                <a href="/docs/knowledge-tools">Knowledge Tools</a>
+                <aside class="docs-sidebar" aria-label="Docs navigation">
+                  <nav>
+                    <a href="/docs/authentication">Authentication</a>
+                    <a href="/docs/quickstart">Quickstart</a>
+                    <a href="/docs/knowledge-tools">Knowledge Tools</a>
+                  </nav>
+                </aside>
+                <article>
+                  <h1>PlayKit Docs</h1>
+                  <p>Choose a guide from the docs navigation.</p>
+                </article>
               </main>
             </body>
           </html>`,


### PR DESCRIPTION
## Summary
- Improves local docs ingestion by parsing HTML with Cheerio, selecting/cleaning the main content region, and converting the cleaned fragment to Markdown with Turndown before summarization.
- Preserves local URL/link provenance while avoiding docs-site chrome and sidebar noise in generated context.
- Keeps local expansion credible for docs sites by collecting follow-up links from an unpruned link-discovery subtree before summary cleanup removes sidebars/navigation.
- Keeps the public runtime contract at Node >=18 by exact-pinning cheerio to 1.0.0-rc.12, whose package engine is Node >= 6; turndown is compatible with Node >=18.

## Blocks PR Review Fixes
- Rebased onto current origin/main at 187be49 after #373 merged.
- Addressed the package.json engine blocker by pinning cheerio to 1.0.0-rc.12 instead of raising the package engine floor.
- Addressed the first src/cli/agent.ts local expansion blocker by keeping aggressive pruning limited to text summarization.
- Addressed the nested-prose/sidebar blocker by making link discovery prefer the outer main or role=main subtree before falling back to the text-scored content selector.
- Strengthened the regression fixture so sidebar docs links live inside main while a nested article.prose has enough text to beat outer main under the summary scorer.

## Validation
- Orchid repo preflight
- npm run build
- npm run typecheck
- npx vitest run tests/agent-mode.test.ts -t "local link discovery"
- npx vitest run tests/agent-mode.test.ts -t ingestion
- npm test: 48 files passed, 550 tests passed

Closes #200.
Advances #197 by preserving cleaner local provenance artifacts.
Follow-up evidence remains in #202. #199 and #201 are unchanged by this slice.