### PR TITLE
Add install reference syntax parser

### DIFF
--- a/docs/core-four-install-update-lifecycle.md
+++ b/docs/core-four-install-update-lifecycle.md
@@ -20,6 +20,8 @@ For the official-doc-backed host capability audit, use [Core-Four Provider Docs 
 
 For the current release/distribution/proof boundary, use [Release Distribution Proof Map](./release-distribution-proof-map.md).
 
+For the parser-backed reference shape that future install-link and ownership work should reuse, use [Install Reference Syntax](./install-reference-syntax.md).
+
 ## Host Install And Discovery Capability Matrix
 
 This is the code-owned source of truth for issue #306: install method, local path, reload behavior, cache semantics, discovery surface, and brand/listing support per primary host.

--- a/docs/install-reference-syntax.md
+++ b/docs/install-reference-syntax.md
@@ -1,0 +1,71 @@
+# Install Reference Syntax
+
+Last updated: 2026-06-25
+
+This document defines the parser-backed install reference contract for follow-on distribution work.
+
+It does not mean `pluxx install <reference>` is shipped today. Current local installs still run from a Pluxx source project after build:
+
+```bash
+pluxx build
+pluxx install --target codex
+pluxx verify-install --target codex
+```
+
+The goal of install references is to give future install links, release assets, ownership records, and team distribution docs one short, stable identifier shape instead of ad hoc paths or package names.
+
+## Syntax
+
+```text
+<scheme>:<locator>[@<version>][#<target>]
+```
+
+Supported schemes:
+
+| Scheme | Purpose | Example | Current status |
+|---|---|---|---|
+| `local` | Local source or built bundle path | `local:../dist/codex#codex` | Parser-backed contract only; current CLI still uses source-project `pluxx install --target ...` |
+| `github` | GitHub release-backed plugin bundle | `github:acme/docs-ops@v1.2.3#claude-code` | Parser-backed contract for release-link work |
+| `npm` | npm package-backed plugin wrapper | `npm:@acme/docs-ops-opencode@1.2.3#opencode` | Parser-backed contract; closest current shipped lane is npm-backed OpenCode publishing |
+| `team` | Reserved team-scoped distribution namespace | `team:acme/docs-ops@stable#cursor` | Reserved for future team distribution; not a hosted registry claim |
+
+Targets use the normal Pluxx target slugs:
+
+- `claude-code`
+- `cursor`
+- `codex`
+- `opencode`
+- beta target slugs are accepted by the parser, but they do not become release-smoked install fronts by syntax alone
+
+## Rules
+
+- The scheme is required.
+- The locator is required.
+- `github` and `team` locators use `<owner-or-team>/<plugin-or-repo>`.
+- `npm` locators use npm package syntax, including scoped packages such as `@scope/name`.
+- Version targeting is optional and uses the final `@`.
+- Target selection is optional and uses `#<target>`.
+- Scoped npm packages do not treat the leading `@scope` as a version.
+- `team:` references are intentionally parseable but not installable until a later team distribution surface exists.
+
+## Examples
+
+```text
+local:../dist/codex#codex
+github:orchidautomation/docs-ops@v1.2.3#claude-code
+npm:@orchid-labs/docs-ops-opencode@1.2.3#opencode
+team:orchid/docs-ops@stable#cursor
+```
+
+## Non-Goals
+
+This contract does not ship:
+
+- marketplace submission APIs
+- a private or paid registry
+- team install authorization
+- fleet rollout
+- automatic rollback or prune behavior
+- `pluxx install <reference>` as an executable install flow
+
+Those are separate implementation slices. The reference parser only creates a shared, validated string contract they can build on.

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,17 @@ export {
   type GeneratedBundleCheckReport,
 } from './bundle-check'
 export {
+  INSTALL_REFERENCE_SCHEMES,
+  formatInstallReference,
+  parseInstallReference,
+  type GitHubInstallReference,
+  type InstallReferenceScheme,
+  type LocalInstallReference,
+  type NpmInstallReference,
+  type ParsedInstallReference,
+  type TeamInstallReference,
+} from './install-reference'
+export {
   printVerifyInstallResult,
   verifyInstall,
   type VerifyInstallCheck,

--- a/src/install-reference.ts
+++ b/src/install-reference.ts
@@ -1,0 +1,230 @@
+import { TargetPlatform as TargetPlatformSchema, type TargetPlatform } from './schema'
+
+export const INSTALL_REFERENCE_SCHEMES = ['local', 'github', 'npm', 'team'] as const
+
+export type InstallReferenceScheme = typeof INSTALL_REFERENCE_SCHEMES[number]
+
+interface BaseInstallReference {
+  raw: string
+  scheme: InstallReferenceScheme
+  locator: string
+  version?: string
+  target?: TargetPlatform
+  normalized: string
+}
+
+export interface LocalInstallReference extends BaseInstallReference {
+  scheme: 'local'
+  path: string
+}
+
+export interface GitHubInstallReference extends BaseInstallReference {
+  scheme: 'github'
+  owner: string
+  repo: string
+}
+
+export interface NpmInstallReference extends BaseInstallReference {
+  scheme: 'npm'
+  packageName: string
+}
+
+export interface TeamInstallReference extends BaseInstallReference {
+  scheme: 'team'
+  team: string
+  plugin: string
+}
+
+export type ParsedInstallReference =
+  | LocalInstallReference
+  | GitHubInstallReference
+  | NpmInstallReference
+  | TeamInstallReference
+
+const INSTALL_REFERENCE_HELP =
+  'Install references must use <scheme>:<locator>[@<version>][#<target>] with scheme local, github, npm, or team.'
+
+const OWNER_PAIR_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/
+const NPM_PACKAGE_PATTERN = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/
+const VERSION_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._+:/-]*$/
+
+export function parseInstallReference(rawReference: string): ParsedInstallReference {
+  const raw = rawReference.trim()
+  if (!raw) {
+    throw installReferenceError('Provide an install reference.')
+  }
+
+  const schemeSeparator = raw.indexOf(':')
+  if (schemeSeparator <= 0) {
+    throw installReferenceError('Install reference is missing a scheme.')
+  }
+
+  const rawScheme = raw.slice(0, schemeSeparator)
+  if (!isInstallReferenceScheme(rawScheme)) {
+    throw installReferenceError(`Unsupported install reference scheme "${rawScheme}".`)
+  }
+
+  const rest = raw.slice(schemeSeparator + 1)
+  const { body, target } = splitInstallReferenceTarget(rest)
+  if (!body) {
+    throw installReferenceError(`Install reference "${rawScheme}:" is missing a locator.`)
+  }
+
+  if (rawScheme === 'local') {
+    return buildLocalInstallReference(raw, body, target)
+  }
+
+  const { locator, version } = splitInstallReferenceVersion(body)
+  if (!locator) {
+    throw installReferenceError(`Install reference "${rawScheme}:" is missing a locator before the version.`)
+  }
+  validateInstallReferenceVersion(version)
+
+  switch (rawScheme) {
+    case 'github':
+      return buildGitHubInstallReference(raw, locator, version, target)
+    case 'npm':
+      return buildNpmInstallReference(raw, locator, version, target)
+    case 'team':
+      return buildTeamInstallReference(raw, locator, version, target)
+  }
+}
+
+export function formatInstallReference(reference: ParsedInstallReference): string {
+  return reference.normalized
+}
+
+function buildLocalInstallReference(raw: string, locator: string, target?: TargetPlatform): LocalInstallReference {
+  return {
+    raw,
+    scheme: 'local',
+    locator,
+    path: locator,
+    ...(target ? { target } : {}),
+    normalized: normalizeInstallReference('local', locator, undefined, target),
+  }
+}
+
+function buildGitHubInstallReference(
+  raw: string,
+  locator: string,
+  version?: string,
+  target?: TargetPlatform,
+): GitHubInstallReference {
+  if (!OWNER_PAIR_PATTERN.test(locator)) {
+    throw installReferenceError('GitHub install references must look like github:<owner>/<repo>[@<version>][#<target>].')
+  }
+
+  const [owner, repo] = locator.split('/') as [string, string]
+  return {
+    raw,
+    scheme: 'github',
+    locator,
+    owner,
+    repo,
+    ...(version ? { version } : {}),
+    ...(target ? { target } : {}),
+    normalized: normalizeInstallReference('github', locator, version, target),
+  }
+}
+
+function buildNpmInstallReference(
+  raw: string,
+  locator: string,
+  version?: string,
+  target?: TargetPlatform,
+): NpmInstallReference {
+  if (!NPM_PACKAGE_PATTERN.test(locator)) {
+    throw installReferenceError('npm install references must look like npm:<package>[@<version>][#<target>].')
+  }
+
+  return {
+    raw,
+    scheme: 'npm',
+    locator,
+    packageName: locator,
+    ...(version ? { version } : {}),
+    ...(target ? { target } : {}),
+    normalized: normalizeInstallReference('npm', locator, version, target),
+  }
+}
+
+function buildTeamInstallReference(
+  raw: string,
+  locator: string,
+  version?: string,
+  target?: TargetPlatform,
+): TeamInstallReference {
+  if (!OWNER_PAIR_PATTERN.test(locator)) {
+    throw installReferenceError('Team install references must look like team:<team>/<plugin>[@<version>][#<target>].')
+  }
+
+  const [team, plugin] = locator.split('/') as [string, string]
+  return {
+    raw,
+    scheme: 'team',
+    locator,
+    team,
+    plugin,
+    ...(version ? { version } : {}),
+    ...(target ? { target } : {}),
+    normalized: normalizeInstallReference('team', locator, version, target),
+  }
+}
+
+function splitInstallReferenceTarget(input: string): { body: string; target?: TargetPlatform } {
+  const targetSeparator = input.lastIndexOf('#')
+  if (targetSeparator === -1) return { body: input }
+
+  const body = input.slice(0, targetSeparator).trim()
+  const rawTarget = input.slice(targetSeparator + 1).trim()
+  if (!rawTarget) {
+    throw installReferenceError('Install reference target cannot be empty after "#".')
+  }
+
+  const parsedTarget = TargetPlatformSchema.safeParse(rawTarget)
+  if (!parsedTarget.success) {
+    throw installReferenceError(`Unknown install reference target "${rawTarget}".`)
+  }
+
+  return { body, target: parsedTarget.data }
+}
+
+function splitInstallReferenceVersion(input: string): { locator: string; version?: string } {
+  const versionSeparator = input.lastIndexOf('@')
+  if (versionSeparator <= 0) {
+    return { locator: input.trim() }
+  }
+
+  const locator = input.slice(0, versionSeparator).trim()
+  const version = input.slice(versionSeparator + 1).trim()
+  if (!version) {
+    throw installReferenceError('Install reference version cannot be empty after "@".')
+  }
+
+  return { locator, version }
+}
+
+function validateInstallReferenceVersion(version?: string): void {
+  if (!version) return
+  if (!VERSION_PATTERN.test(version)) {
+    throw installReferenceError(`Install reference version "${version}" is not valid.`)
+  }
+}
+
+function normalizeInstallReference(
+  scheme: InstallReferenceScheme,
+  locator: string,
+  version?: string,
+  target?: TargetPlatform,
+): string {
+  return `${scheme}:${locator}${version ? `@${version}` : ''}${target ? `#${target}` : ''}`
+}
+
+function isInstallReferenceScheme(value: string): value is InstallReferenceScheme {
+  return (INSTALL_REFERENCE_SCHEMES as readonly string[]).includes(value)
+}
+
+function installReferenceError(message: string): Error {
+  return new Error(`${message} ${INSTALL_REFERENCE_HELP}`)
+}

--- a/tests/install-reference.test.ts
+++ b/tests/install-reference.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'bun:test'
+import { formatInstallReference, parseInstallReference } from '../src/install-reference'
+
+describe('install references', () => {
+  it('parses local source bundle references with an optional target', () => {
+    const reference = parseInstallReference('local:../dist/codex#codex')
+
+    expect(reference).toEqual({
+      raw: 'local:../dist/codex#codex',
+      scheme: 'local',
+      locator: '../dist/codex',
+      path: '../dist/codex',
+      target: 'codex',
+      normalized: 'local:../dist/codex#codex',
+    })
+    expect(formatInstallReference(reference)).toBe('local:../dist/codex#codex')
+  })
+
+  it('parses GitHub release references with version targeting', () => {
+    const reference = parseInstallReference('github:orchidautomation/pluxx-example@v1.2.3#claude-code')
+
+    expect(reference.scheme).toBe('github')
+    expect(reference.locator).toBe('orchidautomation/pluxx-example')
+    expect(reference.version).toBe('v1.2.3')
+    expect(reference.target).toBe('claude-code')
+    if (reference.scheme === 'github') {
+      expect(reference.owner).toBe('orchidautomation')
+      expect(reference.repo).toBe('pluxx-example')
+    }
+  })
+
+  it('parses scoped npm package references without confusing scope for version', () => {
+    const packageOnly = parseInstallReference('npm:@orchid-labs/pluxx-opencode#opencode')
+    expect(packageOnly.scheme).toBe('npm')
+    expect(packageOnly.locator).toBe('@orchid-labs/pluxx-opencode')
+    expect(packageOnly.version).toBeUndefined()
+    expect(packageOnly.target).toBe('opencode')
+
+    const packageWithVersion = parseInstallReference('npm:@orchid-labs/pluxx-opencode@0.1.22#opencode')
+    expect(packageWithVersion.scheme).toBe('npm')
+    expect(packageWithVersion.locator).toBe('@orchid-labs/pluxx-opencode')
+    expect(packageWithVersion.version).toBe('0.1.22')
+  })
+
+  it('parses reserved team-scoped references without treating them as shipped installs', () => {
+    const reference = parseInstallReference('team:acme/docs-ops@stable#cursor')
+
+    expect(reference.scheme).toBe('team')
+    expect(reference.locator).toBe('acme/docs-ops')
+    expect(reference.version).toBe('stable')
+    expect(reference.target).toBe('cursor')
+    if (reference.scheme === 'team') {
+      expect(reference.team).toBe('acme')
+      expect(reference.plugin).toBe('docs-ops')
+    }
+  })
+
+  it('rejects unsupported schemes and malformed locators', () => {
+    expect(() => parseInstallReference('registry:acme/docs-ops')).toThrow('Unsupported install reference scheme "registry"')
+    expect(() => parseInstallReference('github:only-owner#codex')).toThrow('GitHub install references must look like')
+    expect(() => parseInstallReference('npm:@Scope/Bad#opencode')).toThrow('npm install references must look like')
+    expect(() => parseInstallReference('team:acme/docs-ops@#cursor')).toThrow('version cannot be empty')
+  })
+
+  it('rejects invalid or empty targets', () => {
+    expect(() => parseInstallReference('local:./dist/codex#')).toThrow('target cannot be empty')
+    expect(() => parseInstallReference('local:./dist/codex#not-a-host')).toThrow('Unknown install reference target "not-a-host"')
+  })
+})


### PR DESCRIPTION
## Summary
- Add a parser-backed canonical install reference contract for `local`, `github`, `npm`, and reserved `team` schemes.
- Export parser/types so future install-link, ownership, and publish flows can reuse one validated shape.
- Document current status and non-goals so this does not imply shipped registry, team auth, or `pluxx install <reference>` execution.

## Scope
Picked #227 as the next smallest shippable slice after #375 and #376.

This does not implement install-from-reference execution, install ownership/prune behavior (#230), discovery vs registry model work (#228), DistributionSpec refactor work (#305), release install widget work (#225), trust tiers (#229), team/private registry workflow (#233), or publish/brand proof (#307). #306 is already closed by #375.

Closes #227.
Related: #225, #228, #229, #230, #231, #232, #233, #305, #306, #307.

## Validation
- `npm ci`
- `npm run build`
- `npm run typecheck`
- `npx vitest run tests/install-reference.test.ts tests/distribution-lifecycle.test.ts`
- `npm test`