### PR TITLE
Add Pluxx next ship decision note

### DIFF
--- a/docs/orchid/decisions/2026-06-26-pluxx-next-ship-review.md
+++ b/docs/orchid/decisions/2026-06-26-pluxx-next-ship-review.md
@@ -1,0 +1,126 @@
+# 2026-06-26 Pluxx Next Ship Review
+
+## Context
+
+This review answers: what is Pluxx now, what has recently shipped, and what should ship next to make it stronger and more robust.
+
+Sources checked:
+
+- Repo docs: `docs/start-here.md`, `docs/todo/queue.md`, `docs/todo/master-backlog.md`, `docs/roadmap.md`, `docs/core-four-reliability-register.md`, `docs/release-distribution-proof-map.md`, `docs/pluxx-plugin-surface-audit.md`
+- Recent commits on `main` through `73a8686 Add install reference syntax parser (#377)`
+- Linear projects and issues, especially:
+  - `Pluxx Primitive Compiler Hardening`
+  - `Pluxx Cross-Host Robustness From Superpowers`
+  - `Pluxx Install Surface and Trust UX`
+  - `Competitive readiness`
+  - `Pluxx OSS Launch / GTM`
+  - `PLUXX-196`, `PLUXX-226`, `PLUXX-248`, `PLUXX-264`, `PLUXX-191`, `PLUXX-193`, `PLUXX-188`, `PLUXX-190`
+- AgentRig public repo cloned read-only at `/private/tmp/agentrig-review-20260626`
+
+## Product Read
+
+Pluxx is no longer mainly a theoretical cross-host compiler. It is now an OSS authoring substrate for maintaining one plugin source project and producing native outputs for Claude Code, Cursor, Codex, and OpenCode.
+
+The sharp wedge is still:
+
+- import or migrate real MCP-backed/native plugin surfaces
+- maintain one canonical source project
+- compile honest native host outputs
+- verify installed state and runtime behavior
+- keep source, generated bundle, installed bundle, docs, and proof aligned
+
+The wrong move would be to collapse the story into generic "build once, run anywhere" distribution copy. Linear issue `PLUXX-196` already calls out AgentRig as a real competitor on that broad framing. Pluxx should keep winning on authoring, compilation, maintenance, and proof, while selectively borrowing install/trust ideas.
+
+## Recently Shipped
+
+The recent shipped work is mostly robustness and installed-state hardening:
+
+- install reference syntax parsing
+- local docs ingestion cleanup
+- Codex companion apply command
+- centralized host install discovery truth
+- tighter Node runtime launcher contract
+- stronger MCP sync metadata validation
+- generated bundle drift checks
+- Codex cache content verification during install checks
+- deeper core-four reliability proof
+- docs/runtime contract updates
+- shared command and agent capability truth
+- generated hook portability hardening
+- host adapter bundle behavior tests
+- release workflow runtime update
+- saved installer `userConfig` reuse on reinstall
+- release `v0.1.22`
+
+This means the next work should not be another broad rewrite. The codebase has already been moving toward tighter contracts. The next slice should deepen that into one visibly useful workflow.
+
+## AgentRig Ideas Worth Stealing
+
+AgentRig has several product ideas Pluxx should absorb without copying its category posture:
+
+- Selection installs: install only selected skills, MCPs, or hooks from a larger plugin.
+- Closure checks: refuse selected installs when required files or dependencies live outside the selected artifact root.
+- Install ledger: record files and JSON writes with hashes so uninstall/prune only removes values the tool still owns.
+- Trust tiers: separate discovery from installability; listed is not installable, reviewed/official is.
+- External repo provenance: scanned repos are useful source material, not trusted registry artifacts.
+- Rigs: named profiles that apply multiple plugins together.
+- Security hooks: block forbidden staged files and run secret/misconfig checks.
+
+The Pluxx-shaped version should be compiler-first: make those concepts support source-project authoring, installed verification, and distribution proof rather than turning Pluxx into only a registry installer.
+
+## Recommended Next Ship
+
+Ship a first-class Codex companion apply and verify workflow.
+
+This maps directly to existing Linear:
+
+- `PLUXX-226`: Make Codex companion application and verification a first-class workflow
+- `PLUXX-264`: Implement a Codex apply flow for generated hooks, readiness, and companion config
+- `PLUXX-248`: Add Codex hook apply/verify workflow and hook behavioral proof
+
+Why this is the best next slice:
+
+- It improves real robustness where Pluxx currently has an honest gap: Codex cannot natively preserve every primitive from generated bundle files alone.
+- It makes generated companion artifacts operational instead of advisory.
+- It continues the recent shipped pattern: installed-state and runtime truth over file-shape claims.
+- It is concrete enough to ship and test, unlike a broad trust-layer/control-plane push.
+- It gives public docs a sharper claim: Pluxx does not just warn about host degradation; it helps apply and verify the external state needed to make the target behave.
+
+Minimum shippable behavior:
+
+- Add or complete a `pluxx codex apply` path that reads generated Codex companion artifacts from a built plugin.
+- Apply safe, reviewable config stanzas for hooks, readiness, MCP approvals, and other companion config where current host behavior requires external wiring.
+- Back up or diff target config before modifying it.
+- Print exactly what was applied, skipped, already present, or unsafe.
+- Add `pluxx codex verify` or fold verification into `verify-install` so the tool checks active project/user config, plugin cache state, generated companion artifacts, and known Codex caveats.
+- Add tests for idempotency, stale config, malformed companion artifacts, and no-op behavior when companion files are absent.
+- Update docs and the self-hosted Pluxx plugin workflow so users can discover the path from inside a host.
+
+## Follow-On Slice
+
+After Codex companion apply/verify, ship install ownership tracking.
+
+This maps to:
+
+- `PLUXX-191`: Track install ownership for safe uninstall and prune flows
+- `PLUXX-193`: Prototype multi-plugin environment apply workflow
+- `PLUXX-188`: Define discovery index vs installable registry contract
+- `PLUXX-190`: Design trust tiers and policy language for plugin installs
+
+AgentRig's ledger pattern is the useful model here. Pluxx should track installed files and host JSON writes with hashes, then use that ledger for conservative uninstall, prune, reinstall, and "what did Pluxx touch?" diagnostics.
+
+## Defer
+
+Defer these until the apply/verify and ledger layers are real:
+
+- broad managed trust/distribution control plane
+- marketplace submission APIs
+- generic registry-first positioning
+- new first-class host expansion beyond the current beta lanes
+- multi-plugin rigs as a product centerpiece
+
+Those can matter later, but they are weaker than improving the concrete install/runtime truth today.
+
+## Repo Hygiene Note
+
+The Orchid repo preflight found the repo usable but missing the standard `docs/orchid/*` artifact tree and the private scratch ignore entry. This decision note starts the durable artifact path. A future repo-hygiene task should run the full Orchid repo setup if the team wants all standard artifact folders and hooks installed.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -19,6 +19,7 @@ Last updated: 2026-06-27
   - [docs/runtime-contract.md](./runtime-contract.md)
   - [docs/core-four-primitive-proof-ledger.md](./core-four-primitive-proof-ledger.md)
   - [docs/pluxx-plugin-surface-audit.md](./pluxx-plugin-surface-audit.md)
+  - [docs/orchid/decisions/2026-06-26-pluxx-next-ship-review.md](./orchid/decisions/2026-06-26-pluxx-next-ship-review.md)
   - [docs/pluxx-self-hosted-core-four-proof.md](./pluxx-self-hosted-core-four-proof.md)
   - [docs/core-four-provider-docs-audit.md](./core-four-provider-docs-audit.md)
   - [docs/core-four-reliability-register.md](./core-four-reliability-register.md)
@@ -63,6 +64,17 @@ That means Pluxx should become excellent at:
 - sync
 
 before it spends serious energy on an operated control plane.
+
+The current next ship decision is to make Codex companion apply and verify first-class:
+
+- apply generated Codex companion config safely, with reviewable diffs or backups
+- verify active project/user config, plugin cache state, generated companion artifacts, and known Codex caveats
+- cover idempotency, stale config, malformed companion artifacts, and absent companion files
+- align execution with `PLUXX-226`, `PLUXX-264`, and `PLUXX-248`
+
+See [docs/orchid/decisions/2026-06-26-pluxx-next-ship-review.md](./orchid/decisions/2026-06-26-pluxx-next-ship-review.md).
+
+The follow-on slice is install ownership tracking for conservative uninstall, prune, reinstall, and "what did Pluxx touch?" diagnostics.
 
 ## Current Priority Order
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Last updated: 2026-06-24
+Last updated: 2026-06-27
 
 ## Doc Links
 
@@ -98,6 +98,10 @@ The closure plan is now narrower than it was before:
 - the next reliability pass should now run from [docs/core-four-reliability-register.md](./core-four-reliability-register.md):
   - Claude Code and Codex stay the priority hosts
   - the immediate focus is agents, hooks, settings/discovery, and distribution-edge proof rather than broad compiler rewrites
+- the next concrete OSS-authoring robustness slice is Codex companion apply/verify:
+  - make generated readiness, hook, MCP approval, and companion config artifacts operational and verifiable instead of advisory only
+  - keep the work aligned with `PLUXX-226`, `PLUXX-264`, `PLUXX-248`, and [docs/orchid/decisions/2026-06-26-pluxx-next-ship-review.md](./orchid/decisions/2026-06-26-pluxx-next-ship-review.md)
+  - treat install ownership tracking as the follow-on slice
 - local stdio import quality is now stronger for the common "I already have an MCP" path:
   - `init --from-mcp` auto-recovers `passthrough` for project-relative runtimes such as `./build/index.js`
   - `lint` catches unbundled stdio runtime payloads earlier

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -1,6 +1,6 @@
 # Start Here
 
-Last updated: 2026-06-24
+Last updated: 2026-06-27
 
 ## Doc Links
 
@@ -213,6 +213,11 @@ The repo already proves a lot.
 - that Platform Change Ops example has now also been installed and `verify-install` checked from the source project across Claude Code, Cursor, Codex, and OpenCode
 - native Claude install verification now follows Claude's real cache install path (`~/.claude/plugins/cache/<marketplace>/<plugin>/<version>`) instead of the old direct plugin-directory assumption
 - the new shared `src/skills.ts` parser is now the common skill reader for lint, Agent Mode, migrate, and Claude skill rewrites instead of four separate ad hoc parsers
+- the current next robustness slice is making Codex companion apply/verify first-class enough that generated readiness, hook, MCP approval, and companion config guidance becomes operational and verifiable rather than advisory only:
+  - `PLUXX-226`
+  - `PLUXX-264`
+  - `PLUXX-248`
+  - [docs/orchid/decisions/2026-06-26-pluxx-next-ship-review.md](./orchid/decisions/2026-06-26-pluxx-next-ship-review.md)
 - canonical skill metadata is now richer than a frontmatter-only slice:
   - Agent Mode now sees adjacent support files such as `examples/`, helper `scripts/`, and neighboring references as part of the skill surface
   - migrate now preserves canonical skill titles and richer skill frontmatter through one shared metadata path instead of rebuilding that meaning ad hoc

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -21,6 +21,7 @@ Last updated: 2026-06-27
   - [docs/core-four-primitive-proof-ledger.md](./core-four-primitive-proof-ledger.md)
   - [docs/core-four-provider-docs-audit.md](./core-four-provider-docs-audit.md)
   - [docs/core-four-translation-hit-list.md](./core-four-translation-hit-list.md)
+  - [docs/orchid/decisions/2026-06-26-pluxx-next-ship-review.md](./orchid/decisions/2026-06-26-pluxx-next-ship-review.md)
   - [docs/pluxx-self-hosted-core-four-proof.md](./pluxx-self-hosted-core-four-proof.md)
   - [README.md](../README.md)
 - Update together:
@@ -113,6 +114,22 @@ Potential surfaces:
 - runtime health and governance
 
 This is important strategically, but it should not drive the near-term roadmap.
+
+## Current Next Ship
+
+The next concrete product slice is a first-class Codex companion apply and verify workflow.
+
+Generated Codex companion artifacts should become operational rather than only advisory:
+
+- apply safe, reviewable config stanzas for hooks, readiness, MCP approvals, and adjacent companion config
+- back up or diff target config before modifying it
+- print exactly what was applied, skipped, already present, or unsafe
+- verify active project/user config, plugin cache state, generated companion artifacts, and known Codex caveats
+- cover idempotency, stale config, malformed companion artifacts, and no-op behavior when companion files are absent
+
+The decision note is [docs/orchid/decisions/2026-06-26-pluxx-next-ship-review.md](./orchid/decisions/2026-06-26-pluxx-next-ship-review.md).
+
+After that, install ownership tracking is the next follow-on because it supports conservative uninstall, prune, reinstall, and diagnostics.
 
 ## Who Pluxx Is For Right Now
 

--- a/docs/todo/master-backlog.md
+++ b/docs/todo/master-backlog.md
@@ -32,6 +32,7 @@ This is not the same thing as the short queue.
   - [docs/runtime-contract.md](../runtime-contract.md)
   - [docs/core-four-primitive-proof-ledger.md](../core-four-primitive-proof-ledger.md)
   - [docs/pluxx-plugin-surface-audit.md](../pluxx-plugin-surface-audit.md)
+  - [docs/orchid/decisions/2026-06-26-pluxx-next-ship-review.md](../orchid/decisions/2026-06-26-pluxx-next-ship-review.md)
   - [docs/pluxx-self-hosted-core-four-proof.md](../pluxx-self-hosted-core-four-proof.md)
   - [docs/core-four-provider-docs-audit.md](../core-four-provider-docs-audit.md)
   - [docs/core-four-reliability-register.md](../core-four-reliability-register.md)
@@ -100,6 +101,13 @@ Any person or agent should be able to enter the repo and answer:
 - [ ] Decide which docs are public product docs vs strategy docs vs internal-only GTM docs
 - [ ] Move account-specific GTM and customer notes out of the public repo
 - [ ] Define a simple rule for when repo docs should be updated alongside Linear
+- [ ] Ship the first-class Codex companion apply and verify workflow as the next concrete product slice:
+  - apply generated Codex companion config safely with reviewable diffs/backups
+  - verify active project/user config, plugin cache state, generated companion artifacts, and known Codex caveats
+  - cover idempotency, stale config, malformed companion artifacts, and absent companion files
+  - keep execution aligned with `PLUXX-226`, `PLUXX-264`, and `PLUXX-248`
+  - see [docs/orchid/decisions/2026-06-26-pluxx-next-ship-review.md](../orchid/decisions/2026-06-26-pluxx-next-ship-review.md)
+- [ ] Follow Codex companion apply/verify with install ownership tracking so uninstall, prune, reinstall, and "what did Pluxx touch?" diagnostics can stay conservative
 - [~] Keep OpenClaw in the documented beta-target lane until native generator, doctor, and smoke proof exist:
   - [docs/openclaw-target-evaluation.md](../openclaw-target-evaluation.md)
 - [~] Turn the provider and branding audits into an explicit closure tracker for every mapped cross-host feature:

--- a/docs/todo/master-backlog.md
+++ b/docs/todo/master-backlog.md
@@ -1,6 +1,6 @@
 # Master Backlog
 
-Last updated: 2026-06-24
+Last updated: 2026-06-27
 
 This is the most complete repo-native backlog for Pluxx.
 
@@ -89,6 +89,12 @@ Any person or agent should be able to enter the repo and answer:
   - marketplace submission APIs, managed trust/distribution, automatic rollback/unpublish, and real authenticated publish plus rollback proof remain open
 - [~] Keep [docs/core-four-primitive-proof-ledger.md](../core-four-primitive-proof-ledger.md) current as the primitive-by-host proof ledger for the core-four native shipping claim
 - [~] Close the remaining ticket-state drift where shipped work can still appear as backlog in Linear
+- [~] Make Codex companion apply/verify the next concrete robustness slice so generated readiness, hook, MCP approval, and companion config artifacts become operational and verifiable instead of advisory only:
+  - `PLUXX-226`
+  - `PLUXX-264`
+  - `PLUXX-248`
+  - [docs/orchid/decisions/2026-06-26-pluxx-next-ship-review.md](../orchid/decisions/2026-06-26-pluxx-next-ship-review.md)
+  - install ownership tracking remains the follow-on slice, not the immediate center
 - [~] Keep the README top section, website hero, GitHub About metadata, and docs homepage messaging aligned
 - [ ] Remove or rewrite any stale docs that still describe already-shipped work as future work
 - [ ] Decide which docs are public product docs vs strategy docs vs internal-only GTM docs

--- a/docs/todo/queue.md
+++ b/docs/todo/queue.md
@@ -1,6 +1,6 @@
 # Pluxx Queue
 
-Last updated: 2026-06-24
+Last updated: 2026-06-27
 
 ## Doc Links
 
@@ -216,6 +216,10 @@ Goal:
 Open work:
 
 - keep [docs/start-here.md](../start-here.md), this queue, the master backlog, and Linear aligned
+- treat Codex companion apply/verify as the next concrete robustness slice:
+  - make generated readiness, hook, MCP approval, and companion config guidance operational instead of advisory only
+  - keep this aligned with `PLUXX-226`, `PLUXX-264`, `PLUXX-248`, and [docs/orchid/decisions/2026-06-26-pluxx-next-ship-review.md](../orchid/decisions/2026-06-26-pluxx-next-ship-review.md)
+  - use install ownership tracking as the follow-on, not the immediate queue center
 - use [docs/core-four-reliability-register.md](../core-four-reliability-register.md) as the current Claude Code and Codex failure-mode inventory:
   - keep the documented break modes aligned with the actual proof stack
   - treat Cursor and OpenCode as secondary reliability follow-ons rather than flattening all four hosts into one identical work block
@@ -490,7 +494,7 @@ These are real, but not the current queue:
 Right now the priority order is:
 
 1. keep the product story and source-of-truth docs clean
-2. make the OSS authoring substrate obviously useful
+2. make the OSS authoring substrate obviously useful, starting with Codex companion apply/verify as the next small robustness slice
 3. prove richer plugin depth with a flagship example
 4. make the Pluxx plugin itself excellent
 5. use customer discovery to learn where the later trust layer should go

--- a/docs/todo/queue.md
+++ b/docs/todo/queue.md
@@ -19,6 +19,7 @@ Last updated: 2026-06-27
   - [docs/runtime-contract.md](../runtime-contract.md)
   - [docs/core-four-primitive-proof-ledger.md](../core-four-primitive-proof-ledger.md)
   - [docs/pluxx-plugin-surface-audit.md](../pluxx-plugin-surface-audit.md)
+  - [docs/orchid/decisions/2026-06-26-pluxx-next-ship-review.md](../orchid/decisions/2026-06-26-pluxx-next-ship-review.md)
   - [docs/pluxx-self-hosted-core-four-proof.md](../pluxx-self-hosted-core-four-proof.md)
   - [docs/core-four-provider-docs-audit.md](../core-four-provider-docs-audit.md)
   - [docs/core-four-reliability-register.md](../core-four-reliability-register.md)
@@ -227,6 +228,12 @@ Open work:
 - tighten the remaining top-level docs framing and entrypoint docs
 - keep [docs/release-distribution-proof-map.md](../release-distribution-proof-map.md) aligned with CLI release/publish behavior and proof docs
 - keep [docs/core-four-primitive-proof-ledger.md](../core-four-primitive-proof-ledger.md) aligned with the matrix, reliability register, and maintained example proofs
+- make Codex companion apply and verify the next concrete product slice:
+  - turn generated Codex companion artifacts into a safe operational workflow rather than only advisory files
+  - cover hooks, readiness, MCP approval stanzas, companion config diffs/backups, idempotency, stale config, malformed companion artifacts, and no-op behavior when companion files are absent
+  - keep this aligned with `PLUXX-226`, `PLUXX-264`, and `PLUXX-248`
+  - use [docs/orchid/decisions/2026-06-26-pluxx-next-ship-review.md](../orchid/decisions/2026-06-26-pluxx-next-ship-review.md) as the decision note
+- after Codex companion apply/verify, ship install ownership tracking for conservative uninstall, prune, reinstall, and "what did Pluxx touch?" diagnostics
 - keep GTM-sensitive material out of the public repo
 - continue reconciling stale planning artifacts that still describe already-shipped work as future work
 - close the remaining Linear drift where shipped work like installed-MCP discovery is still marked as backlog


### PR DESCRIPTION
## Summary
- Add the durable Pluxx next-ship decision note under docs/orchid/decisions.

## Validation
- git diff --cached --check
- repo-preflight.sh /Users/brandonguerrero/.codex/worktrees/20ddd283-afce-40cf-baee-1a3cc1b1ecb7/pluxx