### PR TITLE
PLUXX-301 Add host detection for install planning

### DIFF
--- a/docs/core-four-install-update-lifecycle.md
+++ b/docs/core-four-install-update-lifecycle.md
@@ -44,6 +44,43 @@ This is the code-owned source of truth for issue #306: install method, local pat
 | Codex | local plugin dir plus marketplace catalog entry | replace local bundle or rerun installer | use `Plugins > Refresh` if available in the current UI, otherwise restart Codex | plugin-bundled MCP servers may show on the plugin detail page without appearing in the global MCP servers page |
 | OpenCode | local plugin dir, entry wrapper, or config-based plugin loading | replace local bundle or update config/plugin reference | restart or reload OpenCode | the supplied docs do not document a dedicated hot-reload plugin command |
 
+## Host Detection Contract
+
+Pluxx owns reusable install-host detection for the core four. Downstream repos should not reimplement Claude Code, Cursor, Codex, or OpenCode detection just to decide which install command or generated installer affordance to show.
+
+The first detection surface is install planning:
+
+```bash
+pluxx install --dry-run --json
+```
+
+The JSON includes:
+
+- `hostDetection`: a deterministic core-four map with one result per host
+- `hostDetection.detectedHosts`: detected host families in stable core-four order
+- `hostDetection.hosts[].evidence`: concrete evidence items
+- `targetSelection`: the selected install targets plus whether they came from explicit `--target` flags or `pluxx.config` targets
+
+Detection evidence is intentionally conservative and read-only. It can include:
+
+- `cli`: host command found on `PATH`
+- `app`: known app bundle where that host has a practical local app signal
+- `user-config`: user-level host config
+- `project-config`: project-level host config
+- `installed-plugin`: existing host plugin output path or Pluxx-managed local plugin catalog path
+
+`project-config` evidence is reported for explainability, but it does not mark a host as detected by itself. A workspace may contain `.codex/`, `.cursor/`, or `.mcp.json` files even when the corresponding host is not installed on the user's machine. `hostDetection.detectedHosts` and install suggestions require machine-level evidence such as a CLI, app bundle, user config, or existing installed plugin path.
+
+Detection does not prove the host is currently running, authenticated, healthy, trusted, or ready to load a specific plugin. It also does not mutate host config.
+
+Explicit target selection remains authoritative. If a user runs:
+
+```bash
+pluxx install --target codex --dry-run --json
+```
+
+then `targetSelection.selectedTargets` stays `["codex"]` even if Pluxx also detects Cursor or OpenCode locally. Detection can suggest install targets for planning and generated installer UX, but it does not override `--target` or rewrite host configs just because a host exists.
+
 ## Important Distinction
 
 There are two different update cases:

--- a/site/reference/cli-reference.mdx
+++ b/site/reference/cli-reference.mdx
@@ -196,6 +196,14 @@ Install built bundles into local host tooling for testing.
 npx @orchid-labs/pluxx install --target claude-code,codex
 ```
 
+Preview the install plan as JSON:
+
+```bash
+npx @orchid-labs/pluxx install --dry-run --json
+```
+
+Dry-run JSON includes `hostDetection` for Claude Code, Cursor, Codex, and OpenCode plus `targetSelection`. Detection is read-only and informational: explicit `--target` values remain authoritative, project config alone does not count as an installed host signal, and Pluxx never mutates host config just because a host was detected.
+
 If the plugin contains local hooks, pass `--trust` after reviewing them:
 
 ```bash

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -89,6 +89,7 @@ import {
   type DiscoveredInstalledMcpServer,
   type InstalledMcpHost,
 } from './discover-installed-mcp'
+import { buildHostTargetSelection, detectHostFamilies } from '../host-detection'
 
 const CLI_PACKAGE_NAME = '@orchid-labs/pluxx'
 const rawArgs = process.argv.slice(2)
@@ -3228,10 +3229,14 @@ async function runInstall() {
   if (runtime.dryRun) {
     const plan = planInstallPlugin(distDir, config.name, platforms)
     const hookCommands = listHookCommands(config.hooks)
+    const hostDetection = detectHostFamilies({ rootDir: process.cwd() })
+    const targetSelection = buildHostTargetSelection(config.targets, targets, hostDetection)
     const summary = {
       dryRun: true,
       pluginName: config.name,
       platforms,
+      targetSelection,
+      hostDetection,
       notes: getInstallFollowupNotes(platforms),
       trustRequired: hookCommands.length > 0,
       userConfig: plannedUserConfig.map((entry) => ({
@@ -3256,6 +3261,11 @@ async function runInstall() {
       plan.forEach((target) => {
         console.log(`  ${target.platform} -> ${target.description}${target.built ? '' : ' (not built)'}`)
       })
+      console.log(`  detected hosts: ${targetSelection.detectedHosts.join(', ') || 'none'}`)
+      if (targetSelection.suggestedTargets.length > 0) {
+        console.log(`  suggested targets: ${targetSelection.suggestedTargets.join(', ')}`)
+      }
+      console.log(`  target selection: ${targetSelection.note}`)
       if (plannedUserConfig.length > 0) {
         console.log('  userConfig:')
         plannedUserConfig.forEach((entry) => {

--- a/src/host-detection.ts
+++ b/src/host-detection.ts
@@ -1,0 +1,232 @@
+import { accessSync, constants, existsSync, statSync } from 'fs'
+import { delimiter, resolve } from 'path'
+import { homedir } from 'os'
+import type { TargetPlatform } from './schema'
+import { CORE_FOUR_PLATFORMS, type CoreFourPlatform } from './validation/platform-rules'
+
+export const CORE_HOST_FAMILIES = CORE_FOUR_PLATFORMS
+
+export type HostDetectionEvidenceType =
+  | 'cli'
+  | 'app'
+  | 'user-config'
+  | 'project-config'
+  | 'installed-plugin'
+
+export interface HostDetectionEvidence {
+  type: HostDetectionEvidenceType
+  label: string
+  path?: string
+  command?: string
+}
+
+export interface HostDetectionResult {
+  host: CoreFourPlatform
+  detected: boolean
+  evidence: HostDetectionEvidence[]
+}
+
+export interface HostDetectionReport {
+  hosts: HostDetectionResult[]
+  detectedHosts: CoreFourPlatform[]
+}
+
+export interface HostDetectionOptions {
+  rootDir?: string
+  homeDir?: string
+  pathEnv?: string
+  appDirs?: string[]
+  platform?: NodeJS.Platform
+  hosts?: readonly CoreFourPlatform[]
+}
+
+export interface HostTargetSelection {
+  source: 'explicit-targets' | 'config-targets'
+  selectedTargets: TargetPlatform[]
+  detectedHosts: CoreFourPlatform[]
+  suggestedTargets: CoreFourPlatform[]
+  explicitOverride: boolean
+  note: string
+}
+
+interface HostEvidenceCandidate {
+  type: HostDetectionEvidenceType
+  label: string
+  path?: (context: HostDetectionContext) => string
+  command?: string
+}
+
+interface HostDetectionContext {
+  rootDir: string
+  homeDir: string
+  pathEnv: string
+  appDirs: string[]
+  platform: NodeJS.Platform
+}
+
+const HOST_EVIDENCE: Record<CoreFourPlatform, HostEvidenceCandidate[]> = {
+  'claude-code': [
+    { type: 'cli', label: 'Claude Code CLI', command: 'claude' },
+    { type: 'user-config', label: 'Claude user config', path: ({ homeDir }) => resolve(homeDir, '.claude.json') },
+    { type: 'user-config', label: 'Claude settings directory', path: ({ homeDir }) => resolve(homeDir, '.claude/settings.json') },
+    { type: 'project-config', label: 'Claude project MCP config', path: ({ rootDir }) => resolve(rootDir, '.mcp.json') },
+    { type: 'project-config', label: 'Claude project settings', path: ({ rootDir }) => resolve(rootDir, '.claude/settings.json') },
+    { type: 'installed-plugin', label: 'Claude plugin cache', path: ({ homeDir }) => resolve(homeDir, '.claude/plugins/cache') },
+    { type: 'installed-plugin', label: 'Legacy Claude plugin directory', path: ({ homeDir }) => resolve(homeDir, '.claude/plugins') },
+  ],
+  cursor: [
+    { type: 'cli', label: 'Cursor CLI', command: 'cursor' },
+    { type: 'cli', label: 'Cursor agent CLI', command: 'cursor-agent' },
+    { type: 'app', label: 'Cursor app bundle', path: ({ appDirs }) => resolveFirstAppPath(appDirs, 'Cursor.app') },
+    { type: 'user-config', label: 'Cursor user MCP config', path: ({ homeDir }) => resolve(homeDir, '.cursor/mcp.json') },
+    { type: 'user-config', label: 'Cursor user settings', path: ({ homeDir }) => resolve(homeDir, '.cursor/settings.json') },
+    { type: 'project-config', label: 'Cursor project MCP config', path: ({ rootDir }) => resolve(rootDir, '.cursor/mcp.json') },
+    { type: 'project-config', label: 'Cursor project rules', path: ({ rootDir }) => resolve(rootDir, '.cursor/rules') },
+    { type: 'project-config', label: 'Cursor root MCP config', path: ({ rootDir }) => resolve(rootDir, 'mcp.json') },
+    { type: 'installed-plugin', label: 'Cursor local plugins', path: ({ homeDir }) => resolve(homeDir, '.cursor/plugins/local') },
+  ],
+  codex: [
+    { type: 'cli', label: 'Codex CLI', command: 'codex' },
+    { type: 'app', label: 'Codex app bundle', path: ({ appDirs }) => resolveFirstAppPath(appDirs, 'Codex.app') },
+    { type: 'user-config', label: 'Codex user config', path: ({ homeDir }) => resolve(homeDir, '.codex/config.toml') },
+    { type: 'project-config', label: 'Codex project config', path: ({ rootDir }) => resolve(rootDir, '.codex/config.toml') },
+    { type: 'project-config', label: 'Codex project agents', path: ({ rootDir }) => resolve(rootDir, '.codex/agents') },
+    { type: 'installed-plugin', label: 'Codex local plugins', path: ({ homeDir }) => resolve(homeDir, '.codex/plugins') },
+    { type: 'installed-plugin', label: 'Codex local marketplace catalog', path: ({ homeDir }) => resolve(homeDir, '.agents/plugins/marketplace.json') },
+  ],
+  opencode: [
+    { type: 'cli', label: 'OpenCode CLI', command: 'opencode' },
+    { type: 'user-config', label: 'OpenCode user config', path: ({ homeDir }) => resolve(homeDir, '.config/opencode/opencode.json') },
+    { type: 'project-config', label: 'OpenCode project config', path: ({ rootDir }) => resolve(rootDir, 'opencode.json') },
+    { type: 'project-config', label: 'OpenCode alternate project config', path: ({ rootDir }) => resolve(rootDir, '.opencode.json') },
+    { type: 'project-config', label: 'OpenCode project directory', path: ({ rootDir }) => resolve(rootDir, '.opencode') },
+    { type: 'installed-plugin', label: 'OpenCode local plugins', path: ({ homeDir }) => resolve(homeDir, '.config/opencode/plugins') },
+    { type: 'installed-plugin', label: 'OpenCode synced skills', path: ({ homeDir }) => resolve(homeDir, '.config/opencode/skills') },
+  ],
+}
+
+export function detectHostFamilies(options: HostDetectionOptions = {}): HostDetectionReport {
+  const context: HostDetectionContext = {
+    rootDir: options.rootDir ?? process.cwd(),
+    homeDir: options.homeDir ?? homedir(),
+    pathEnv: options.pathEnv ?? process.env.PATH ?? '',
+    appDirs: options.appDirs ?? defaultAppDirs(options.homeDir ?? homedir()),
+    platform: options.platform ?? process.platform,
+  }
+  const hostSet = new Set(options.hosts ?? CORE_HOST_FAMILIES)
+  const hosts = CORE_HOST_FAMILIES
+    .filter((host) => hostSet.has(host))
+    .map((host) => detectHostFamily(host, context))
+
+  return {
+    hosts,
+    detectedHosts: hosts.filter((host) => host.detected).map((host) => host.host),
+  }
+}
+
+export function buildHostTargetSelection(
+  configTargets: TargetPlatform[],
+  explicitTargets: TargetPlatform[] | undefined,
+  report: HostDetectionReport,
+): HostTargetSelection {
+  const selectedTargets = explicitTargets ?? configTargets
+  const configCoreTargets = configTargets.filter(isCoreHostFamily)
+  const suggestedTargets = report.detectedHosts.filter((host) => configCoreTargets.includes(host))
+  const explicitOverride = explicitTargets !== undefined
+
+  return {
+    source: explicitOverride ? 'explicit-targets' : 'config-targets',
+    selectedTargets,
+    detectedHosts: report.detectedHosts,
+    suggestedTargets,
+    explicitOverride,
+    note: explicitOverride
+      ? 'Explicit --target selection is authoritative; host detection did not change selected targets.'
+      : 'Host detection is informational; install targets still come from pluxx.config targets.',
+  }
+}
+
+function detectHostFamily(host: CoreFourPlatform, context: HostDetectionContext): HostDetectionResult {
+  const evidence = HOST_EVIDENCE[host]
+    .map((candidate) => resolveEvidence(candidate, context))
+    .filter((item): item is HostDetectionEvidence => item !== undefined)
+
+  return {
+    host,
+    detected: evidence.some(isMachineLevelEvidence),
+    evidence,
+  }
+}
+
+function isMachineLevelEvidence(evidence: HostDetectionEvidence): boolean {
+  return evidence.type !== 'project-config'
+}
+
+function resolveEvidence(
+  candidate: HostEvidenceCandidate,
+  context: HostDetectionContext,
+): HostDetectionEvidence | undefined {
+  if (candidate.command) {
+    const commandPath = findExecutable(candidate.command, context.pathEnv, context.platform)
+    if (!commandPath) return undefined
+    return {
+      type: candidate.type,
+      label: candidate.label,
+      command: candidate.command,
+      path: commandPath,
+    }
+  }
+
+  if (!candidate.path) return undefined
+  const evidencePath = candidate.path(context)
+  if (!evidencePath || !existsSync(evidencePath)) return undefined
+
+  return {
+    type: candidate.type,
+    label: candidate.label,
+    path: evidencePath,
+  }
+}
+
+function findExecutable(command: string, pathEnv: string, platform: NodeJS.Platform): string | undefined {
+  if (!pathEnv.trim()) return undefined
+
+  const names = platform === 'win32'
+    ? [command, `${command}.exe`, `${command}.cmd`, `${command}.bat`]
+    : [command]
+
+  for (const dir of pathEnv.split(delimiter).filter(Boolean)) {
+    for (const name of names) {
+      const candidate = resolve(dir, name)
+      if (isExecutableFile(candidate, platform)) return candidate
+    }
+  }
+
+  return undefined
+}
+
+function isExecutableFile(path: string, platform: NodeJS.Platform): boolean {
+  try {
+    if (!statSync(path).isFile()) return false
+    if (platform === 'win32') return true
+    accessSync(path, constants.X_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function defaultAppDirs(homeDir: string): string[] {
+  return [
+    '/Applications',
+    resolve(homeDir, 'Applications'),
+  ]
+}
+
+function resolveFirstAppPath(appDirs: string[], appName: string): string {
+  return appDirs.map((dir) => resolve(dir, appName)).find((path) => existsSync(path)) ?? resolve(appDirs[0] ?? '/', appName)
+}
+
+function isCoreHostFamily(target: TargetPlatform): target is CoreFourPlatform {
+  return (CORE_HOST_FAMILIES as readonly TargetPlatform[]).includes(target)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,6 +109,17 @@ export {
   type TeamInstallReference,
 } from './install-reference'
 export {
+  CORE_HOST_FAMILIES,
+  buildHostTargetSelection,
+  detectHostFamilies,
+  type HostDetectionEvidence,
+  type HostDetectionEvidenceType,
+  type HostDetectionOptions,
+  type HostDetectionReport,
+  type HostDetectionResult,
+  type HostTargetSelection,
+} from './host-detection'
+export {
   printVerifyInstallResult,
   verifyInstall,
   type VerifyInstallCheck,

--- a/tests/cli-phase2.test.ts
+++ b/tests/cli-phase2.test.ts
@@ -404,9 +404,34 @@ env = { STUB_API_KEY = "$STUB_API_KEY" }
 
       const summary = JSON.parse(stdout) as {
         dryRun: boolean
+        platforms: string[]
+        targetSelection: {
+          source: string
+          selectedTargets: string[]
+          explicitOverride: boolean
+        }
+        hostDetection: {
+          detectedHosts: string[]
+          hosts: Array<{
+            host: string
+            detected: boolean
+            evidence: unknown[]
+          }>
+        }
         installTargets: Array<{ platform: string; built: boolean }>
       }
       expect(summary.dryRun).toBe(true)
+      expect(summary.platforms).toEqual(['claude-code'])
+      expect(summary.targetSelection).toMatchObject({
+        source: 'config-targets',
+        selectedTargets: ['claude-code'],
+        explicitOverride: false,
+      })
+      expect(Array.isArray(summary.hostDetection.detectedHosts)).toBe(true)
+      expect(summary.hostDetection.hosts).toHaveLength(4)
+      expect(summary.hostDetection.hosts[0]?.host).toBe('claude-code')
+      expect(typeof summary.hostDetection.hosts[0]?.detected).toBe('boolean')
+      expect(Array.isArray(summary.hostDetection.hosts[0]?.evidence)).toBe(true)
       expect(summary.installTargets[0]?.platform).toBe('claude-code')
       expect(summary.installTargets[0]?.built).toBe(true)
       expect(existsSync(resolve(homeDir, '.claude/plugins/dry-run-plugin'))).toBe(false)

--- a/tests/host-detection.test.ts
+++ b/tests/host-detection.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { resolve } from 'path'
+import {
+  buildHostTargetSelection,
+  detectHostFamilies,
+  type HostDetectionEvidenceType,
+  type HostDetectionReport,
+} from '../src/host-detection'
+import type { TargetPlatform } from '../src/schema'
+
+let rootDir = ''
+let homeDir = ''
+let binDir = ''
+let appDir = ''
+
+beforeEach(() => {
+  rootDir = mkdtempSync(resolve(tmpdir(), 'pluxx-host-detect-root-'))
+  homeDir = mkdtempSync(resolve(tmpdir(), 'pluxx-host-detect-home-'))
+  binDir = resolve(rootDir, 'bin')
+  appDir = resolve(rootDir, 'Applications')
+  mkdirSync(binDir, { recursive: true })
+  mkdirSync(appDir, { recursive: true })
+})
+
+afterEach(() => {
+  rmSync(rootDir, { recursive: true, force: true })
+  rmSync(homeDir, { recursive: true, force: true })
+})
+
+describe('host detection', () => {
+  it('detects core-four host families from CLI, app, config, project config, and installed plugin evidence', () => {
+    writeExecutable('claude')
+    writeExecutable('cursor-agent')
+    writeExecutable('codex')
+    writeExecutable('opencode')
+
+    mkdirSync(resolve(appDir, 'Cursor.app'), { recursive: true })
+    mkdirSync(resolve(appDir, 'Codex.app'), { recursive: true })
+
+    writeJson(resolve(homeDir, '.claude.json'), { projects: {} })
+    writeJson(resolve(rootDir, '.claude/settings.json'), {})
+    mkdirSync(resolve(homeDir, '.claude/plugins/cache/pluxx-local-demo/demo/1.0.0'), { recursive: true })
+
+    writeJson(resolve(homeDir, '.cursor/mcp.json'), { mcpServers: {} })
+    writeJson(resolve(rootDir, '.cursor/mcp.json'), { mcpServers: {} })
+    mkdirSync(resolve(homeDir, '.cursor/plugins/local/demo'), { recursive: true })
+
+    writeText(resolve(homeDir, '.codex/config.toml'), 'model = "gpt-5"\n')
+    writeText(resolve(rootDir, '.codex/config.toml'), 'model = "gpt-5"\n')
+    mkdirSync(resolve(homeDir, '.codex/plugins/demo'), { recursive: true })
+
+    writeJson(resolve(homeDir, '.config/opencode/opencode.json'), {})
+    writeJson(resolve(rootDir, 'opencode.json'), {})
+    mkdirSync(resolve(homeDir, '.config/opencode/plugins/demo'), { recursive: true })
+
+    const report = detectHostFamilies({
+      rootDir,
+      homeDir,
+      pathEnv: binDir,
+      appDirs: [appDir],
+      platform: 'darwin',
+    })
+
+    expect(report.detectedHosts).toEqual(['claude-code', 'cursor', 'codex', 'opencode'])
+    expect(evidenceTypes(report, 'claude-code')).toEqual(expect.arrayContaining(['cli', 'user-config', 'project-config', 'installed-plugin']))
+    expect(evidenceTypes(report, 'cursor')).toEqual(expect.arrayContaining(['cli', 'app', 'user-config', 'project-config', 'installed-plugin']))
+    expect(evidenceTypes(report, 'codex')).toEqual(expect.arrayContaining(['cli', 'app', 'user-config', 'project-config', 'installed-plugin']))
+    expect(evidenceTypes(report, 'opencode')).toEqual(expect.arrayContaining(['cli', 'user-config', 'project-config', 'installed-plugin']))
+  })
+
+  it('returns deterministic negative results when no temp fixture evidence exists', () => {
+    const report = detectHostFamilies({
+      rootDir,
+      homeDir,
+      pathEnv: '',
+      appDirs: [appDir],
+      platform: 'darwin',
+    })
+
+    expect(report.detectedHosts).toEqual([])
+    expect(report.hosts.map((host) => ({
+      host: host.host,
+      detected: host.detected,
+      evidence: host.evidence,
+    }))).toEqual([
+      { host: 'claude-code', detected: false, evidence: [] },
+      { host: 'cursor', detected: false, evidence: [] },
+      { host: 'codex', detected: false, evidence: [] },
+      { host: 'opencode', detected: false, evidence: [] },
+    ])
+  })
+
+  it('reports project config evidence without treating it as an installed host signal', () => {
+    writeText(resolve(rootDir, '.codex/config.toml'), 'model = "gpt-5"\n')
+
+    const report = detectHostFamilies({
+      rootDir,
+      homeDir,
+      pathEnv: '',
+      appDirs: [appDir],
+      platform: 'darwin',
+      hosts: ['codex'],
+    })
+
+    expect(report.detectedHosts).toEqual([])
+    expect(report.hosts).toEqual([
+      {
+        host: 'codex',
+        detected: false,
+        evidence: [
+          {
+            type: 'project-config',
+            label: 'Codex project config',
+            path: resolve(rootDir, '.codex/config.toml'),
+          },
+        ],
+      },
+    ])
+  })
+
+  it('keeps explicit install targets authoritative while exposing suggestions', () => {
+    const report: HostDetectionReport = {
+      detectedHosts: ['codex', 'opencode'],
+      hosts: [],
+    }
+    const configTargets: TargetPlatform[] = ['claude-code', 'codex', 'github-copilot']
+
+    const explicit = buildHostTargetSelection(configTargets, ['cursor'], report)
+    expect(explicit.source).toBe('explicit-targets')
+    expect(explicit.selectedTargets).toEqual(['cursor'])
+    expect(explicit.suggestedTargets).toEqual(['codex'])
+    expect(explicit.explicitOverride).toBe(true)
+    expect(explicit.note).toContain('Explicit --target selection is authoritative')
+
+    const fromConfig = buildHostTargetSelection(configTargets, undefined, report)
+    expect(fromConfig.source).toBe('config-targets')
+    expect(fromConfig.selectedTargets).toEqual(configTargets)
+    expect(fromConfig.suggestedTargets).toEqual(['codex'])
+    expect(fromConfig.explicitOverride).toBe(false)
+  })
+})
+
+function evidenceTypes(report: HostDetectionReport, host: string): HostDetectionEvidenceType[] {
+  return report.hosts.find((entry) => entry.host === host)?.evidence.map((evidence) => evidence.type) ?? []
+}
+
+function writeExecutable(name: string): void {
+  const filepath = resolve(binDir, name)
+  writeFileSync(filepath, '#!/usr/bin/env sh\nexit 0\n')
+  chmodSync(filepath, 0o755)
+}
+
+function writeJson(filepath: string, value: unknown): void {
+  mkdirSync(resolve(filepath, '..'), { recursive: true })
+  writeFileSync(filepath, JSON.stringify(value, null, 2) + '\n')
+}
+
+function writeText(filepath: string, value: string): void {
+  mkdirSync(resolve(filepath, '..'), { recursive: true })
+  writeFileSync(filepath, value)
+}


### PR DESCRIPTION
## Summary
- add reusable core-four host detection with CLI/app/user-config/project-config/installed-plugin evidence
- expose read-only hostDetection and targetSelection in install dry-run output
- document the detection contract and project-config-only caveat

## Validation
- npm test -- --run tests/host-detection.test.ts tests/cli-phase2.test.ts
- npm run typecheck
- npm run build
- git diff --check

Linear: PLUXX-301