### PR TITLE
fix: verify released host installs

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -283,9 +283,12 @@ function collectInstalledPlaintextSecretFindings(rootDir: string): InstalledPlai
       if (!content.includes(candidate.value)) continue
       for (const label of candidate.labels) labels.add(label)
     }
-    for (const sentinel of TEST_SECRET_SENTINELS) {
-      if (sentinel.pattern.test(content)) {
-        labels.add(sentinel.label)
+    const isDependencySource = relativePath.split('/').includes('node_modules')
+    if (!isDependencySource) {
+      for (const sentinel of TEST_SECRET_SENTINELS) {
+        if (sentinel.pattern.test(content)) {
+          labels.add(sentinel.label)
+        }
       }
     }
 

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -1,5 +1,5 @@
 import { resolve, dirname, basename, relative } from 'path'
-import { existsSync, symlinkSync, mkdirSync, rmSync, readFileSync, writeFileSync, cpSync, readdirSync } from 'fs'
+import { existsSync, symlinkSync, mkdirSync, rmSync, readFileSync, writeFileSync, cpSync, readdirSync, statSync } from 'fs'
 import { spawnSync } from 'child_process'
 import * as readline from 'readline'
 import type { PluginConfig, TargetPlatform, UserConfigEntry } from '../schema'
@@ -925,7 +925,25 @@ function resolveClaudeInstalledCachePath(pluginName: string, version: string | u
   if (!version) return undefined
 
   const home = process.env.HOME ?? '~'
-  return resolve(home, '.claude/plugins/cache', getClaudeMarketplaceName(pluginName), pluginName, version)
+  const cacheRoot = resolve(home, '.claude/plugins/cache')
+  const expectedPath = resolve(cacheRoot, getClaudeMarketplaceName(pluginName), pluginName, version)
+  if (existsSync(expectedPath)) return expectedPath
+  if (!existsSync(cacheRoot)) return expectedPath
+
+  const candidates: Array<{ path: string; mtimeMs: number }> = []
+  for (const marketplace of readdirSync(cacheRoot, { withFileTypes: true })) {
+    if (!marketplace.isDirectory()) continue
+    const candidatePath = resolve(cacheRoot, marketplace.name, pluginName, version)
+    if (!existsSync(candidatePath)) continue
+    if (readBundleManifestVersion(candidatePath, 'claude-code') !== version) continue
+    try {
+      candidates.push({ path: candidatePath, mtimeMs: statSync(candidatePath).mtimeMs })
+    } catch {
+      // Ignore unreadable marketplace cache candidates.
+    }
+  }
+
+  return candidates.sort((a, b) => b.mtimeMs - a.mtimeMs)[0]?.path ?? expectedPath
 }
 
 function resolveExpectedInstalledConsumerPath(target: PlannedInstallTarget, pluginName: string): string {

--- a/src/cli/publish.ts
+++ b/src/cli/publish.ts
@@ -1105,6 +1105,11 @@ if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(pluginName)) {
   throw new Error('Cannot register Codex agents for an invalid plugin name.')
 }
 
+fs.rmSync(path.join(codexHome, 'plugins/cache/local-plugins', pluginName), {
+  recursive: true,
+  force: true,
+})
+
 const sourceRoot = path.join(installDir, '.codex/agents')
 const globalAgentRoot = path.join(codexHome, 'agents')
 const agentRoot = path.join(globalAgentRoot, pluginName)

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -809,6 +809,22 @@ describe('doctorConsumer', () => {
     }
   })
 
+  it('does not scan dependency source trees for maintained secret sentinels', async () => {
+    const dir = createSafeConsumerFixture()
+
+    try {
+      const dependencyFile = resolve(dir, 'node_modules/effect/src/Redacted.ts')
+      mkdirSync(resolve(dependencyFile, '..'), { recursive: true })
+      writeFileSync(dependencyFile, `export const documentationExample = "${'secret'}-key"\n`)
+
+      const report = await doctorConsumer(dir)
+      expect(report.ok).toBe(true)
+      expect(report.checks.some((check) => check.code === 'consumer-plaintext-secret-leak')).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
   it('fails when an installed bundle contains plaintext secret material', async () => {
     const dir = createConsumerFixture()
 

--- a/tests/publish.test.ts
+++ b/tests/publish.test.ts
@@ -1144,6 +1144,19 @@ describe('runPublish', () => {
     expect(run.installerContent).toContain('Codex agent name collision')
   })
 
+  it('clears the target plugin stale Codex active cache in generated installers', () => {
+    const staleCache = resolve(ROOT, 'codex-home/plugins/cache/local-plugins/publish-plugin/1.2.2')
+    mkdirSync(staleCache, { recursive: true })
+    writeFileSync(resolve(staleCache, 'stale.txt'), 'stale\n')
+
+    const run = runGeneratedCodexInstaller({
+      '.codex-plugin/plugin.json': JSON.stringify({ name: 'publish-plugin', version: '1.2.3' }),
+    })
+
+    expect(run.status).toBe(0)
+    expect(existsSync(resolve(ROOT, 'codex-home/plugins/cache/local-plugins/publish-plugin'))).toBe(false)
+  })
+
   it('allows generated installers to move unchanged owned Codex agent registrations', () => {
     const previousContent = 'name = "reviewer"\ndescription = "Reviews evidence."\ndeveloper_instructions = "Review carefully."\n'
     const oldAgentPath = resolve(ROOT, 'codex-home/agents/publish-plugin/reviewer.toml')

--- a/tests/verify-install.test.ts
+++ b/tests/verify-install.test.ts
@@ -75,6 +75,28 @@ afterEach(() => {
 })
 
 describe('verifyInstall', () => {
+  it('finds an installed Claude release bundle in a non-development marketplace cache', async () => {
+    mkdirSync(resolve(DIST_DIR, 'claude-code/.claude-plugin'), { recursive: true })
+    mkdirSync(resolve(DIST_DIR, 'claude-code/skills/research'), { recursive: true })
+    writeFileSync(
+      resolve(DIST_DIR, 'claude-code/.claude-plugin/plugin.json'),
+      JSON.stringify({ name: 'verify-plugin', version: '0.1.0', skills: './skills/' }),
+    )
+    writeFileSync(resolve(DIST_DIR, 'claude-code/skills/research/SKILL.md'), '# Research\n')
+
+    const releaseBundle = resolve(HOME_DIR, '.claude', 'plugins', 'cache', 'verify-plugin-releases', 'verify-plugin', '0.1.0')
+    mkdirSync(resolve(releaseBundle, '..'), { recursive: true })
+    cpSync(resolve(DIST_DIR, 'claude-code'), releaseBundle, { recursive: true })
+
+    const result = await verifyInstall(makeClaudeConfig(), {
+      rootDir: ROOT,
+      targets: ['claude-code'],
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.checks[0]?.consumerPath).toBe(releaseBundle)
+  })
+
   it('passes for an installed codex bundle in its native local path', async () => {
     mkdirSync(resolve(DIST_DIR, 'codex/.codex-plugin'), { recursive: true })
     writeFileSync(


### PR DESCRIPTION
## Summary

Harden released-install verification after the SendLens 0.1.48 post-install proof exposed three gaps:

- Claude verification now finds the matching plugin/version across native marketplace cache roots, while still preferring the expected `pluxx-local-<plugin>` development cache when present.
- Generated Codex release installers now clear only `$CODEX_HOME/plugins/cache/local-plugins/<plugin>` before registration, matching normal `pluxx install` cache behavior.
- Installed-bundle secret scanning no longer applies generic maintained test-secret sentinels to dependency source under `node_modules`; concrete configured secret values remain scanned everywhere.

## Validation

- Test-first regressions failed before implementation and pass afterward.
- Focused verification: 3 files, 102 tests passed.
- Full release gate: 53 files, 584 tests passed.
- Typecheck, build, packaged Node runtime verification, and dry-run npm pack passed.
- Real SendLens 0.1.48 verification now passes for Claude Code's `sendlens-releases` cache, Cursor, and OpenCode.

## Post-Deploy Validation

- Reinstall the generated SendLens Codex release asset and confirm the stale 0.1.47 active cache is removed.
- Run `pluxx verify-install --target claude-code cursor codex opencode` against SendLens 0.1.48/0.1.49.
- Healthy signal: all four hosts pass with only expected missing-runtime-config warnings when provider credentials are not materialized.
- Roll back to 0.1.30 if marketplace cache selection becomes ambiguous or cache cleanup escapes the target plugin path.

Fixes PLUXX-311.
