### PR TITLE
feat(eval): add semantic eval v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ tests/.install-fixture/
 
 # Agent scratch artifacts
 .agent-artifacts/
+.pluxx/behavioral-receipts/

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Full docs tree:
 
 Pluxx includes more than scaffold generation:
 
-- `pluxx eval` checks scaffold and prompt-pack quality
+- `pluxx eval` reports deterministic scaffold contracts separately from an evidence-bearing semantic rubric for tool coverage, routing, taxonomy, examples, arguments, delegation, setup truth, and cross-file consistency; projects can set warning/failure thresholds with `eval.warningThreshold` and `eval.failureThreshold`
 - `pluxx migrate <path>` imports an existing host-native plugin into a Pluxx project
 - `pluxx doctor --consumer <bundle>` inspects built or installed plugin bundles from the user side
 - `pluxx mcp proxy --record` and `--replay` give you deterministic MCP tapes for debugging and CI

--- a/docs/orchid/plans/2026-07-12-pluxx-316-semantic-eval-v2.md
+++ b/docs/orchid/plans/2026-07-12-pluxx-316-semantic-eval-v2.md
@@ -1,0 +1,118 @@
+---
+title: Semantic Eval v2 and Outcome-Based Workflow Proof - Plan
+type: feat
+date: 2026-07-12
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: linear-pluxx-316
+execution: code
+---
+
+# Semantic Eval v2 and Outcome-Based Workflow Proof - Plan
+
+## Goal Capsule
+
+- Deliver PLUXX-316 from `origin/main` as one focused change.
+- Separate deterministic scaffold checks from semantic quality checks.
+- Strengthen behavioral receipts with workflow identity, assertions, and factual artifacts.
+- Preserve compatibility for legitimate manual projects.
+
+---
+
+## Product Contract
+
+### Problem Frame
+
+The evaluator proves generated headings and phrases more reliably than workflow coherence. The behavioral harness treats response substrings as sufficient evidence and does not preserve a structured receipt of the invoked workflow surface and produced artifacts.
+
+### Requirements
+
+- R1. Report scaffold-contract checks separately from semantic rubric checks.
+- R2. Score tool coverage, routing correctness, taxonomy coherence, realistic examples, argument guidance, delegation, setup truth, and cross-file consistency.
+- R3. Support project-level warning and failure thresholds with safe defaults.
+- R4. Fail an adversarial fixture that preserves expected headings and phrases while replacing coherent workflow content.
+- R5. Keep legitimate manual projects, including `example/pluxx` and `example/docs-ops`, passing without MCP scaffold metadata.
+- R6. Return behavioral receipts that identify target, command, skill or agent, assertions, and artifact results.
+- R7. Maintain self-hosted cases for import, refine, prove, translate, troubleshoot, and publish dry-run.
+- R8. Keep flagship and docs-ingestion projects as maintained semantic regression inputs.
+
+### Scope Boundaries
+
+- This issue does not replace deterministic lint, introduce model-backed grading, refresh old proof claims, or change host translation semantics.
+- Live publishing and proof-version governance remain outside PLUXX-316.
+
+### Acceptance Examples
+
+- AE1. A heading-complete but generic or contradictory fixture fails semantic evaluation while its contract checks still pass.
+- AE2. A maintained manual project receives fair semantic checks without fabricated MCP or delegation requirements.
+- AE3. A behavioral result records the host target, workflow identifiers, response assertions, and factual artifact checks.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. Tag checks by domain in `src/cli/eval.ts` so JSON and console consumers can distinguish contract from semantic results without a second command.
+- KTD2. Use a deterministic, evidence-bearing rubric so the official suite stays reproducible.
+- KTD3. Add semantic thresholds to the validated public project config so TypeScript and JSON projects share one typed policy surface and invalid ranges fail at config load.
+- KTD4. Mark inapplicable criteria explicitly instead of assigning zero scores.
+- KTD5. Extend behavioral fixtures with workflow identity and artifact assertions while preserving existing response assertion behavior.
+
+### High-Level Technical Design
+
+`runEvalSuite` loads project configuration, authored instructions, skills, commands, optional MCP metadata, and optional eval policy. Contract checks remain exact and generated-scaffold-specific. A semantic rubric emits criterion scores and evidence, then thresholds translate the aggregate score into success, warning, or failure. The behavioral runner normalizes each case into a receipt and evaluates response and filesystem assertions after the host command exits.
+
+---
+
+## Implementation Units
+
+### U1. Semantic rubric and threshold policy
+
+- **Goal:** Add deterministic semantic evaluation with separate reporting and configurable thresholds.
+- **Files:** `src/cli/eval.ts`, `tests/eval.test.ts`, and focused fixtures.
+- **Test Scenarios:** Healthy generated fixture passes; adversarial heading-complete fixture fails; manual projects pass; threshold overrides alter classification; contract failures remain independently visible.
+- **Covers:** R1-R5, R8, AE1-AE2.
+
+### U2. Behavioral receipts and artifact assertions
+
+- **Goal:** Produce structured receipts with factual artifact proof.
+- **Files:** `src/cli/behavioral.ts`, `tests/behavioral-smoke.test.ts`.
+- **Test Scenarios:** Receipts contain host and workflow identifiers; artifact existence and content assertions pass and fail; legacy configs remain valid.
+- **Covers:** R6, AE3.
+
+### U3. Maintained regression inputs
+
+- **Goal:** Make the named self-hosted workflows and maintained projects regression inputs.
+- **Files:** Self-hosted behavioral cases, example eval policies, docs-ingestion fixture surfaces, and targeted tests.
+- **Test Scenarios:** Six self-hosted flows declare workflow identity and artifact assertions; flagship and docs-ingestion inputs run through semantic evaluation.
+- **Covers:** R5-R8.
+
+### U4. Product truth and operator documentation
+
+- **Goal:** Document the new eval and receipt contract and align affected canonical planning surfaces.
+- **Files:** Evaluator documentation plus affected canonical docs identified by their `Doc Links` blocks.
+- **Covers:** R1-R3, R6-R8.
+
+---
+
+## Verification Contract
+
+| Gate | Command | Done signal |
+|---|---|---|
+| Eval coverage | `npx vitest run tests/eval.test.ts` | semantic, adversarial, manual-project, and threshold cases pass |
+| Behavioral coverage | `npx vitest run tests/behavioral-smoke.test.ts` | receipts and artifact assertions pass |
+| Release compatibility | `npx vitest run tests/release-smoke.test.ts` | maintained fixture packaging remains valid |
+| Type safety | `npm run typecheck` | zero TypeScript errors |
+| Build | `npm run build` | distribution build succeeds |
+| Official suite | `npm test` | full suite passes serially |
+
+---
+
+## Definition of Done
+
+- Requirements R1-R8 are implemented or explicitly blocked without weakening behavior.
+- New failure modes are proven by deterministic tests.
+- CE code review has no unresolved actionable findings.
+- Repo docs and Linear truth link the implementation and current validation.
+- A focused PR links PLUXX-316 and GitHub issue #406, carries the enrolled repair label, and is mergeable without being merged.

--- a/docs/orchid/reviews/2026-07-12-pluxx-316-semantic-eval-v2.md
+++ b/docs/orchid/reviews/2026-07-12-pluxx-316-semantic-eval-v2.md
@@ -1,0 +1,22 @@
+# PLUXX-316 Semantic Eval v2 Review
+
+## Verdict
+
+Ready for PR. The full CE review found no unresolved actionable findings after fixes.
+
+## Resolved Findings
+
+- Behavioral artifacts now distinguish pre-existing evidence from created or changed runner outcomes.
+- Runner failures retain declared artifact results, and resolved artifact paths cannot escape the project root.
+- Empty and placeholder manual projects fail, while valid minimal and migrated baselines avoid false rejection.
+- Tool mappings and delegation targets resolve against authored skills and agents.
+- Contradictory keyword-stuffed workflows fail semantic evaluation.
+- Core-four behavioral fixture coverage remains mandatory except for the five explicitly Codex-only self-hosted workflow cases added by PLUXX-316.
+- Semantic threshold configuration is validated for defaults, bounds, and ordering.
+
+## Validation
+
+- `npm run build`
+- `npm run typecheck`
+- Targeted eval, behavioral, release-smoke, schema, Phase 2 CLI, and migration tests: 85/85
+- Official `npm test`: 598/598 across 53 test files

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -411,9 +411,10 @@ These matter, but they are not the immediate center:
 
 ### Eval and regression confidence
 
-- stronger `pluxx eval` coverage
-- more stable fixtures around prompt-pack quality
-- reference-plugin and docs-ingestion fixtures
+- `pluxx eval` now separates scaffold contracts from an eight-criterion deterministic semantic rubric
+- warning and failure thresholds are configurable per project
+- adversarial incoherence, the self-hosted plugin, the flagship plugin, and docs-ingestion projects are maintained regression inputs
+- model-assisted grading remains optional future depth, not a prerequisite for deterministic release confidence
 
 ### Migration and sync depth
 

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -248,6 +248,8 @@ The repo already proves a lot.
 - installed behavioral proof is now stronger than simple file-shape verification:
   - the behavioral harness now supports host-specific runner args plus expected-failure cases without treating intentional nonzero exits as harness failures
   - maintained smoke fixtures can now declare an explicit `commandId` plus required output markers, so command-proof cases fail if the prompt does not reference the command or the response shape is too vague
+  - behavioral receipts now preserve the host target, command/skill/agent identity, response assertions, and factual project-relative artifact checks
+  - the self-hosted plugin keeps maintained import, refine, prove, translate, troubleshoot, and publish-dry-run cases, with publish proof remaining separate from a real release
   - `example/docs-ops`, `example/exa-plugin`, and `example/platform-change-ops` now each carry maintained behavioral smoke fixtures with command-specific output assertions instead of relying only on "did not bail" checks or one-off walkthroughs
   - `doctor --consumer` and `verify-install` now execute bundled Claude and Cursor permission-hook scripts and fail if the generated decisions are not actually usable
 - primitive-by-primitive core-four reliability tracking is now explicit instead of spread across proof docs and translation tables:
@@ -256,6 +258,10 @@ The repo already proves a lot.
   - `npm test` now acquires a worktree-local suite lock before running the full Vitest pass
   - `tests/run-vitest-exclusive.test.ts` now proves both active-lock refusal and stale-lock cleanup
   - deeper fixture isolation is still follow-on work
+- `pluxx eval` now separates exact generated-scaffold contracts from deterministic semantic quality scoring:
+  - the semantic rubric covers tool coverage, routing, taxonomy, examples, arguments, delegation, setup truth, and cross-file consistency
+  - project config can set explicit warning and failure thresholds
+  - heading-complete but incoherent fixtures fail, while maintained manual, flagship, and docs-ingestion projects remain regression inputs
 - agent explainability is now less generator-local:
   - `src/agent-translation-registry.ts` now backs degraded-field messaging for Cursor, Codex, and OpenCode instead of parallel per-target strings
   - generated Cursor and Codex agent surfaces now emit the same registry-backed translation notes that `lint` uses

--- a/docs/status-quo-vs-pluxx-story.md
+++ b/docs/status-quo-vs-pluxx-story.md
@@ -290,6 +290,8 @@ It answers questions like:
 - do the instructions explain the product clearly?
 - did the migration preserve the important behavior?
 
+The evaluator reports exact scaffold contracts separately from semantic quality. Its deterministic rubric records evidence for tool coverage, routing, taxonomy coherence, realistic examples, arguments, delegation, setup truth, and cross-file consistency, then applies project-configured warning and failure thresholds.
+
 This is the difference between:
 
 - "the plugin exists"

--- a/docs/todo/master-backlog.md
+++ b/docs/todo/master-backlog.md
@@ -446,9 +446,10 @@ These are already part of the strategy direction and should stay in view:
 
 ### 10. Eval depth and regression confidence
 
-- [~] Keep `pluxx eval` meaningful as a product surface, not just a maintainer nicety
-- [ ] Expand regression coverage where prompt-pack quality still feels too subjective
-- [ ] Use the flagship plugin and docs-ingestion flow as stable eval fixtures
+- [x] Separate deterministic scaffold contracts from semantic quality scoring in `pluxx eval`
+- [x] Add configurable semantic warning/failure thresholds and adversarial incoherence coverage
+- [x] Use the self-hosted plugin, flagship plugin, and docs-ingestion projects as maintained semantic regression inputs
+- [ ] Add model-assisted evaluation only if deterministic rubric evidence proves insufficient for a future failure class
 
 ### 11. Migration and sync depth
 

--- a/docs/todo/queue.md
+++ b/docs/todo/queue.md
@@ -286,8 +286,14 @@ Open work:
   - installed behavioral proof is now materially stronger:
     - the behavioral harness supports expected-failure cases and host-specific runner args for maintained smoke fixtures
     - maintained smoke fixtures can now declare an explicit `commandId` plus required output markers, so command-proof cases fail when the prompt does not reference the command or the output shape stays vague
+    - receipts now identify target, command/skill/agent, assertions, and artifact outcomes instead of reducing proof to marker matches
+    - `example/pluxx` now maintains import, refine, prove, translate, troubleshoot, and publish-dry-run workflow cases
     - `example/docs-ops`, `example/exa-plugin`, and `example/platform-change-ops` now each carry maintained behavioral smoke configs with command-specific assertions instead of relying only on ad hoc walkthroughs
     - `doctor --consumer` and `verify-install` now execute generated Claude/Cursor bundled permission-hook scripts and fail if those installed decisions are invalid
+  - semantic eval is now a separate evidence-bearing layer over scaffold contract checks:
+    - eight deterministic criteria cover tool coverage through cross-file consistency
+    - warning/failure thresholds are configurable in project config
+    - adversarial incoherence and maintained manual/flagship/docs-ingestion regressions are covered in tests
   - agent translation explainability is now less duplicated:
     - `src/agent-translation-registry.ts` now drives degraded-field messaging for Cursor, Codex, and OpenCode
     - generated Cursor and Codex agent surfaces now emit the same translation story that `lint` uses

--- a/example/pluxx/.pluxx/behavioral-smoke.json
+++ b/example/pluxx/.pluxx/behavioral-smoke.json
@@ -3,6 +3,7 @@
     {
       "name": "verify-install",
       "commandId": "verify-install",
+      "skillId": "pluxx-verify-install",
       "targets": {
         "claude-code": {
           "prompt": "/pluxx:verify-install claude-code. Return sections titled Passed targets: and Smallest next step:.",
@@ -51,8 +52,69 @@
       }
     },
     {
+      "name": "import-mcp",
+      "commandId": "import-mcp",
+      "skillId": "pluxx-import-mcp",
+      "targets": {
+        "codex": {
+          "prompt": "Use Pluxx command `import-mcp` to plan a dry-run import from https://example.com/mcp. Do not change the plugin. Write .pluxx/behavioral-receipts/import-mcp.json with {\"case\":\"import-mcp\",\"outcome\":\"planned\",\"dryRun\":true}. Return sections titled Planned command: and Validation gates:.",
+          "require": ["Planned command:", "Validation gates:", "--dry-run"],
+          "forbid": ["context too long", "skill bailed", "Import complete"],
+          "artifacts": [{
+            "path": ".pluxx/behavioral-receipts/import-mcp.json",
+            "state": "changed",
+            "require": ["\"case\":", "\"outcome\":", "\"dryRun\":true"]
+          }, {
+            "path": "skills/pluxx-import-mcp/SKILL.md",
+            "require": ["pluxx init --from-mcp", "--dry-run --json"]
+          }]
+        }
+      }
+    },
+    {
+      "name": "refine-plugin",
+      "commandId": "refine-plugin",
+      "skillId": "pluxx-refine-plugin",
+      "targets": {
+        "codex": {
+          "prompt": "Use Pluxx command `refine-plugin` to inspect this source project without changing it. Write .pluxx/behavioral-receipts/refine-plugin.json with {\"case\":\"refine-plugin\",\"outcome\":\"reviewed\",\"changed\":false}. Return sections titled Recommended pass: and Validation gates:.",
+          "require": ["Recommended pass:", "Validation gates:"],
+          "forbid": ["context too long", "skill bailed"],
+          "artifacts": [{
+            "path": ".pluxx/behavioral-receipts/refine-plugin.json",
+            "state": "changed",
+            "require": ["\"case\":", "\"outcome\":", "\"changed\":false"]
+          }, {
+            "path": "skills/pluxx-refine-plugin/SKILL.md",
+            "require": ["pluxx agent", "pluxx test"]
+          }]
+        }
+      }
+    },
+    {
+      "name": "prove-plugin",
+      "commandId": "prove-plugin",
+      "skillId": "pluxx-prove-plugin",
+      "targets": {
+        "codex": {
+          "prompt": "Use Pluxx command `prove-plugin` to plan proof for this source project without installing or publishing. Write .pluxx/behavioral-receipts/prove-plugin.json with {\"case\":\"prove-plugin\",\"outcome\":\"planned\",\"published\":false}. Return sections titled Proof matrix: and Missing evidence:.",
+          "require": ["Proof matrix:", "Missing evidence:"],
+          "forbid": ["context too long", "skill bailed", "Published"],
+          "artifacts": [{
+            "path": ".pluxx/behavioral-receipts/prove-plugin.json",
+            "state": "changed",
+            "require": ["\"case\":", "\"outcome\":", "\"published\":false"]
+          }, {
+            "path": "skills/pluxx-prove-plugin/SKILL.md",
+            "require": ["pluxx test", "verify-install"]
+          }]
+        }
+      }
+    },
+    {
       "name": "translate-hosts",
       "commandId": "translate-hosts",
+      "skillId": "pluxx-translate-hosts",
       "targets": {
         "claude-code": {
           "prompt": "/pluxx:translate-hosts hooks codex. Return sections titled Preserve/translate/degrade/drop: and Highest-value source-shape fix:.",
@@ -77,7 +139,7 @@
           ]
         },
         "codex": {
-          "prompt": "Use Pluxx command `translate-hosts` to review Codex hook translation truth. Return sections titled Preserve/translate/degrade/drop: and Highest-value source-shape fix:.",
+          "prompt": "Use Pluxx command `translate-hosts` to review Codex hook translation truth. Write .pluxx/behavioral-receipts/translate-hosts.json with {\"case\":\"translate-hosts\",\"target\":\"codex\",\"outcome\":\"reviewed\"}. Return sections titled Preserve/translate/degrade/drop: and Highest-value source-shape fix:.",
           "require": [
             "Preserve/translate/degrade/drop:",
             "Highest-value source-shape fix:"
@@ -85,7 +147,15 @@
           "forbid": [
             "context too long",
             "skill bailed"
-          ]
+          ],
+          "artifacts": [{
+            "path": ".pluxx/behavioral-receipts/translate-hosts.json",
+            "state": "changed",
+            "require": ["\"case\":", "\"target\":\"codex\"", "\"outcome\":"]
+          }, {
+            "path": "skills/pluxx-translate-hosts/SKILL.md",
+            "require": ["Preserve", "translate", "degrade", "drop"]
+          }]
         },
         "opencode": {
           "prompt": "/translate-hosts hooks codex. Return sections titled Preserve/translate/degrade/drop: and Highest-value source-shape fix:.",
@@ -97,6 +167,46 @@
             "context too long",
             "skill bailed"
           ]
+        }
+      }
+    },
+    {
+      "name": "troubleshoot-install",
+      "commandId": "troubleshoot-install",
+      "skillId": "pluxx-troubleshoot-install",
+      "targets": {
+        "codex": {
+          "prompt": "Use Pluxx command `troubleshoot-install` to diagnose a hypothetical stale Codex install without changing it. Write .pluxx/behavioral-receipts/troubleshoot-install.json with {\"case\":\"troubleshoot-install\",\"outcome\":\"diagnosed\",\"changed\":false}. Return sections titled Diagnostic command: and Smallest repair:.",
+          "require": ["Diagnostic command:", "Smallest repair:", "doctor --consumer"],
+          "forbid": ["context too long", "skill bailed", "Reinstalled"],
+          "artifacts": [{
+            "path": ".pluxx/behavioral-receipts/troubleshoot-install.json",
+            "state": "changed",
+            "require": ["\"case\":", "\"outcome\":", "\"changed\":false"]
+          }, {
+            "path": "skills/pluxx-troubleshoot-install/SKILL.md",
+            "require": ["doctor --consumer", "verify-install"]
+          }]
+        }
+      }
+    },
+    {
+      "name": "publish-dry-run",
+      "commandId": "publish-plugin",
+      "skillId": "pluxx-publish-plugin",
+      "targets": {
+        "codex": {
+          "prompt": "Use Pluxx command `publish-plugin` to plan a publish dry run without publishing. Write .pluxx/behavioral-receipts/publish-dry-run.json with {\"case\":\"publish-dry-run\",\"outcome\":\"planned\",\"published\":false}. Return sections titled Planned targets: and Planned artifacts:.",
+          "require": ["Planned targets:", "Planned artifacts:", "--dry-run"],
+          "forbid": ["context too long", "skill bailed", "Published successfully"],
+          "artifacts": [{
+            "path": ".pluxx/behavioral-receipts/publish-dry-run.json",
+            "state": "changed",
+            "require": ["\"case\":", "\"outcome\":", "\"published\":false"]
+          }, {
+            "path": "skills/pluxx-publish-plugin/SKILL.md",
+            "require": ["pluxx publish --dry-run --json", "Never turn a proof request into a release"]
+          }]
         }
       }
     }

--- a/example/pluxx/commands/publish-plugin.md
+++ b/example/pluxx/commands/publish-plugin.md
@@ -11,8 +11,9 @@ Arguments: $ARGUMENTS
 
 1. Use the `pluxx-publish-plugin` skill.
 2. Validate that the current project is healthy enough to publish.
-3. Run `pluxx publish` with the requested release options when appropriate.
-4. Summarize the release artifacts and install scripts that were produced.
-5. Call out anything that still blocks an actual release.
+3. Run `pluxx publish --dry-run --json` first and report the factual plan.
+4. Run `pluxx publish` with the requested release options only when the user explicitly approves a real publish.
+5. Summarize the planned or produced release artifacts and installer scripts.
+6. Call out anything that still blocks an actual release.
 
 Return what was published, what artifacts were generated, and any remaining release caveats.

--- a/example/pluxx/skills/pluxx-publish-plugin/SKILL.md
+++ b/example/pluxx/skills/pluxx-publish-plugin/SKILL.md
@@ -14,6 +14,7 @@ Use this skill when the user wants to package and distribute the current plugin 
    - `pluxx lint`
    - `pluxx test`
 2. Run:
+   - `pluxx publish --dry-run --json` first and inspect the planned targets and artifacts
    - `pluxx publish`
    - include release flags when the user asks for a specific release path
 3. Summarize the release outputs:
@@ -25,6 +26,7 @@ Use this skill when the user wants to package and distribute the current plugin 
 ## Rules
 
 - Do not skip validation when the scaffold changed materially.
+- Keep dry-run proof separate from an actual publish. Never turn a proof request into a release.
 - Be honest when the project is still only locally credible and not yet release-ready.
 - If publishing is blocked, return the blockers before any release summary.
 

--- a/src/cli/behavioral.ts
+++ b/src/cli/behavioral.ts
@@ -1,6 +1,7 @@
-import { existsSync, readFileSync } from 'fs'
+import { existsSync, readFileSync, realpathSync, statSync } from 'fs'
 import { spawn } from 'child_process'
-import { resolve } from 'path'
+import { createHash } from 'crypto'
+import { isAbsolute, relative, resolve } from 'path'
 import type { PluginConfig, TargetPlatform } from '../schema'
 import { executeCodexExecCommand } from '../codex-exec-runner'
 
@@ -14,18 +15,31 @@ type BehavioralPlatform = typeof SUPPORTED_PLATFORMS[number]
 interface BehavioralCaseTargetConfig {
   prompt: string
   commandId?: string
+  skillId?: string
+  agentId?: string
   require?: string[]
   forbid?: string[]
   expectedExitCodes?: number[]
   expectFailure?: boolean
   runnerArgs?: string[]
   timeoutMs?: number
+  artifacts?: BehavioralArtifactAssertion[]
 }
 
 interface BehavioralCaseConfig {
   name: string
   commandId?: string
+  skillId?: string
+  agentId?: string
   targets: Partial<Record<BehavioralPlatform, BehavioralCaseTargetConfig>>
+}
+
+interface BehavioralArtifactAssertion {
+  path: string
+  exists?: boolean
+  state?: 'preexisting' | 'created' | 'changed'
+  require?: string[]
+  forbid?: string[]
 }
 
 interface BehavioralConfigFile {
@@ -41,6 +55,8 @@ export interface BehavioralCheckResult {
   platform: BehavioralPlatform
   prompt: string
   commandId?: string
+  skillId?: string
+  agentId?: string
   command: string[]
   ok: boolean
   exitCode: number
@@ -51,6 +67,39 @@ export interface BehavioralCheckResult {
   expectedExitCodes: number[]
   timeoutMs: number
   failures: string[]
+  receipt: BehavioralReceipt
+}
+
+export interface BehavioralArtifactResult {
+  path: string
+  expectedToExist: boolean
+  state: 'preexisting' | 'created' | 'changed'
+  exists: boolean
+  kind?: 'file' | 'directory'
+  bytes?: number
+  require?: string[]
+  forbid?: string[]
+  ok: boolean
+  failures: string[]
+}
+
+interface BehavioralArtifactSnapshot {
+  exists: boolean
+  fingerprint?: string
+  error?: string
+}
+
+export interface BehavioralReceipt {
+  target: BehavioralPlatform
+  commandId?: string
+  skillId?: string
+  agentId?: string
+  assertions: {
+    requiredText: string[]
+    forbiddenText: string[]
+    expectedExitCodes: number[]
+  }
+  artifacts: BehavioralArtifactResult[]
 }
 
 export interface BehavioralSuiteResult {
@@ -81,6 +130,8 @@ export async function runBehavioralSuite(
         config,
         behavioralCase.name,
         behavioralCase.commandId,
+        behavioralCase.skillId,
+        behavioralCase.agentId,
         platform,
         targetConfig,
       ))
@@ -128,6 +179,8 @@ async function runBehavioralCheck(
   config: PluginConfig,
   caseName: string,
   caseCommandId: string | undefined,
+  caseSkillId: string | undefined,
+  caseAgentId: string | undefined,
   platform: BehavioralPlatform,
   targetConfig: BehavioralCaseTargetConfig,
 ): Promise<BehavioralCheckResult> {
@@ -136,6 +189,8 @@ async function runBehavioralCheck(
     throw new Error(`Behavioral smoke case "${caseName}" for ${platform} is missing a prompt.`)
   }
   const commandId = targetConfig.commandId ?? caseCommandId
+  const skillId = targetConfig.skillId ?? caseSkillId
+  const agentId = targetConfig.agentId ?? caseAgentId
   if (commandId) {
     if (!behavioralPromptReferencesCommand(prompt, commandId)) {
       throw new Error(
@@ -157,6 +212,19 @@ async function runBehavioralCheck(
   const timeoutMs = Number.isFinite(targetConfig.timeoutMs) && (targetConfig.timeoutMs ?? 0) > 0
     ? Math.trunc(targetConfig.timeoutMs!)
     : DEFAULT_BEHAVIORAL_TIMEOUT_MS
+  const receiptBase = {
+    target: platform,
+    commandId,
+    skillId,
+    agentId,
+    assertions: {
+      requiredText: targetConfig.require ?? [],
+      forbiddenText: targetConfig.forbid ?? [],
+      expectedExitCodes,
+    },
+  }
+  const artifactAssertions = targetConfig.artifacts ?? []
+  const artifactSnapshots = snapshotArtifactAssertions(rootDir, artifactAssertions)
 
   let command: string[] = []
   let execution: {
@@ -169,11 +237,15 @@ async function runBehavioralCheck(
     execution = await executeBehavioralCommand(platform, command, rootDir, timeoutMs)
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
+    const artifacts = evaluateArtifactAssertions(rootDir, artifactAssertions, artifactSnapshots)
+    const artifactFailures = artifacts.flatMap(artifact => artifact.failures.map(failure => `${artifact.path}: ${failure}`))
     return {
       caseName,
       platform,
       prompt,
       commandId,
+      skillId,
+      agentId,
       command,
       ok: false,
       exitCode: 1,
@@ -183,7 +255,11 @@ async function runBehavioralCheck(
       forbid: targetConfig.forbid,
       expectedExitCodes,
       timeoutMs,
-      failures: [message],
+      failures: [message, ...artifactFailures],
+      receipt: {
+        ...receiptBase,
+        artifacts,
+      },
     }
   }
 
@@ -209,12 +285,16 @@ async function runBehavioralCheck(
       failures.push(`matched forbidden text: ${forbidden}`)
     }
   }
+  const artifacts = evaluateArtifactAssertions(rootDir, artifactAssertions, artifactSnapshots)
+  failures.push(...artifacts.flatMap(artifact => artifact.failures.map(failure => `${artifact.path}: ${failure}`)))
 
   return {
     caseName,
     platform,
     prompt,
     commandId,
+    skillId,
+    agentId,
     command,
     ok: failures.length === 0,
     exitCode: execution.exitCode,
@@ -225,7 +305,158 @@ async function runBehavioralCheck(
     expectedExitCodes,
     timeoutMs,
     failures,
+    receipt: {
+      ...receiptBase,
+      artifacts,
+    },
   }
+}
+
+function evaluateArtifactAssertions(
+  rootDir: string,
+  assertions: BehavioralArtifactAssertion[],
+  snapshots: BehavioralArtifactSnapshot[],
+): BehavioralArtifactResult[] {
+  return assertions.map((assertion, index) => {
+    const expectedToExist = assertion.exists !== false
+    const state = assertion.state ?? 'preexisting'
+    const snapshot = snapshots[index] ?? { exists: false, error: 'artifact preflight snapshot is missing' }
+    const failures: string[] = []
+    if (snapshot.error) failures.push(snapshot.error)
+    try {
+    if (!assertion.path.trim() || isAbsolute(assertion.path)) {
+      failures.push('artifact path must be a non-empty project-relative path')
+      return {
+        path: assertion.path,
+        expectedToExist,
+        state,
+        exists: false,
+        require: assertion.require,
+        forbid: assertion.forbid,
+        ok: false,
+        failures,
+      }
+    }
+
+    const artifactPath = resolve(rootDir, assertion.path)
+    const relativePath = relative(rootDir, artifactPath)
+    if (relativePath === '..' || relativePath.startsWith(`..${process.platform === 'win32' ? '\\' : '/'}`) || isAbsolute(relativePath)) {
+      failures.push('artifact path escapes the project root')
+      return {
+        path: assertion.path,
+        expectedToExist,
+        state,
+        exists: false,
+        require: assertion.require,
+        forbid: assertion.forbid,
+        ok: false,
+        failures,
+      }
+    }
+
+    const present = existsSync(artifactPath)
+    if (present !== expectedToExist) {
+      failures.push(expectedToExist ? 'expected artifact to exist' : 'expected artifact to be absent')
+    }
+
+    let kind: BehavioralArtifactResult['kind']
+    let bytes: number | undefined
+    if (present) {
+      const realRoot = realpathSync(rootDir)
+      const realArtifactPath = realpathSync(artifactPath)
+      const realRelativePath = relative(realRoot, realArtifactPath)
+      if (realRelativePath === '..' || realRelativePath.startsWith(`..${process.platform === 'win32' ? '\\' : '/'}`) || isAbsolute(realRelativePath)) {
+        failures.push('artifact path resolves outside the project root')
+        return {
+          path: assertion.path,
+          expectedToExist,
+          state,
+          exists: true,
+          require: assertion.require,
+          forbid: assertion.forbid,
+          ok: false,
+          failures,
+        }
+      }
+      const stat = statSync(artifactPath)
+      kind = stat.isDirectory() ? 'directory' : 'file'
+      bytes = stat.size
+      const currentFingerprint = fingerprintArtifact(artifactPath)
+      if (state === 'created' && snapshot.exists) {
+        failures.push('expected artifact to be created by the runner, but it existed before execution')
+      }
+      if (state === 'changed' && snapshot.exists && snapshot.fingerprint === currentFingerprint) {
+        failures.push('expected artifact to change during runner execution')
+      }
+      if ((assertion.require?.length || assertion.forbid?.length) && !stat.isFile()) {
+        failures.push('text assertions require a file artifact')
+      } else if (stat.isFile()) {
+        const content = readFileSync(artifactPath, 'utf-8')
+        for (const required of assertion.require ?? []) {
+          if (!includesNeedle(content, required)) failures.push(`missing required text: ${required}`)
+        }
+        for (const forbidden of assertion.forbid ?? []) {
+          if (includesNeedle(content, forbidden)) failures.push(`matched forbidden text: ${forbidden}`)
+        }
+      }
+    }
+
+    return {
+      path: assertion.path,
+      expectedToExist,
+      state,
+      exists: present,
+      kind,
+      bytes,
+      require: assertion.require,
+      forbid: assertion.forbid,
+      ok: failures.length === 0,
+      failures,
+    }
+    } catch (error) {
+      failures.push(`artifact evaluation failed: ${error instanceof Error ? error.message : String(error)}`)
+      return {
+        path: assertion.path,
+        expectedToExist,
+        state,
+        exists: false,
+        require: assertion.require,
+        forbid: assertion.forbid,
+        ok: false,
+        failures,
+      }
+    }
+  })
+}
+
+function snapshotArtifactAssertions(
+  rootDir: string,
+  assertions: BehavioralArtifactAssertion[],
+): BehavioralArtifactSnapshot[] {
+  return assertions.map((assertion) => {
+    try {
+      if (!assertion.path.trim() || isAbsolute(assertion.path)) return { exists: false }
+      const artifactPath = resolve(rootDir, assertion.path)
+      if (!existsSync(artifactPath)) return { exists: false }
+      const realRoot = realpathSync(rootDir)
+      const realArtifactPath = realpathSync(artifactPath)
+      const realRelativePath = relative(realRoot, realArtifactPath)
+      if (realRelativePath === '..' || realRelativePath.startsWith(`..${process.platform === 'win32' ? '\\' : '/'}`) || isAbsolute(realRelativePath)) {
+        return { exists: true, error: 'artifact path resolves outside the project root' }
+      }
+      return { exists: true, fingerprint: fingerprintArtifact(artifactPath) }
+    } catch (error) {
+      return { exists: false, error: `artifact preflight failed: ${error instanceof Error ? error.message : String(error)}` }
+    }
+  })
+}
+
+function fingerprintArtifact(path: string): string {
+  const stat = statSync(path)
+  if (stat.isFile()) {
+    return `file:${createHash('sha256').update(readFileSync(path)).digest('hex')}`
+  }
+  return `directory:${stat.size}:${stat.mtimeMs}`
 }
 
 async function buildBehavioralCommand(

--- a/src/cli/eval.ts
+++ b/src/cli/eval.ts
@@ -11,10 +11,12 @@ import {
   MCP_SCAFFOLD_METADATA_PATH,
   type McpScaffoldMetadata,
 } from './init-from-mcp'
+import { runSemanticEvaluation, type SemanticEvalSummary } from './semantic-eval'
 
 export type EvalLevel = 'error' | 'warning' | 'info' | 'success'
 
 export interface EvalCheck {
+  domain: 'contract' | 'semantic'
   level: EvalLevel
   code: string
   title: string
@@ -29,6 +31,7 @@ export interface EvalReport {
   warnings: number
   infos: number
   checks: EvalCheck[]
+  semantic: SemanticEvalSummary
 }
 
 export interface EvalRunOptions {
@@ -37,11 +40,11 @@ export interface EvalRunOptions {
 
 const AGENT_PROMPT_KINDS: AgentPromptKind[] = ['taxonomy', 'instructions', 'review']
 
-function addCheck(checks: EvalCheck[], check: EvalCheck): void {
-  checks.push(check)
+function addCheck(checks: EvalCheck[], check: Omit<EvalCheck, 'domain'> & { domain?: EvalCheck['domain'] }): void {
+  checks.push({ domain: check.domain ?? 'contract', ...check })
 }
 
-function summarizeChecks(checks: EvalCheck[]): EvalReport {
+function summarizeChecks(checks: EvalCheck[], semantic: SemanticEvalSummary): EvalReport {
   const errors = checks.filter((check) => check.level === 'error').length
   const warnings = checks.filter((check) => check.level === 'warning').length
   const infos = checks.filter((check) => check.level === 'info').length
@@ -52,6 +55,7 @@ function summarizeChecks(checks: EvalCheck[]): EvalReport {
     warnings,
     infos,
     checks,
+    semantic,
   }
 }
 
@@ -437,7 +441,7 @@ export async function runEvalSuite(options: EvalRunOptions = {}): Promise<EvalRe
   const checks: EvalCheck[] = []
 
   try {
-    await loadConfig(rootDir)
+    const config = await loadConfig(rootDir)
     const metadata = await loadMcpScaffoldMetadata(rootDir)
 
     if (!metadata) {
@@ -449,42 +453,73 @@ export async function runEvalSuite(options: EvalRunOptions = {}): Promise<EvalRe
         fix: 'Run this command inside an MCP-derived Pluxx project if you want scaffold and prompt-pack evals.',
         path: MCP_SCAFFOLD_METADATA_PATH,
       })
-      return summarizeChecks(checks)
-    }
-
-    const preparePlan = await planAgentPrepare(rootDir)
-    const contextContent = preparePlan.files.find((file) => file.relativePath === AGENT_CONTEXT_PATH)?.content ?? ''
-    const promptPlans = await Promise.all(
-      AGENT_PROMPT_KINDS.map((kind) => planAgentPrompt(rootDir, kind, { allowMissingContext: true })),
-    )
-    const promptContents = new Map<AgentPromptKind, string>(
-      promptPlans.map((plan) => [plan.kind, plan.files[0]?.content ?? '']),
-    )
-
-    const isMigratedBaseline = metadata.tools.length === 0
-
-    if (isMigratedBaseline) {
-      addCheck(checks, {
-        level: 'info',
-        code: 'eval-generated-scaffold-skipped',
-        title: 'Generated scaffold evals skipped for migrated baseline',
-        detail: 'This project has scaffold metadata but no MCP tool inventory, so file-level generated-section evals were skipped.',
-        fix: 'No action needed unless you want to rebuild the project around a fresh MCP-derived scaffold.',
-      })
     } else {
-      evaluateInstructions(rootDir, metadata, checks)
-      evaluateSkills(rootDir, metadata, checks)
-      evaluateCommands(rootDir, metadata, checks)
-      evaluateScaffoldArchitecture(metadata, checks)
+      const preparePlan = await planAgentPrepare(rootDir)
+      const contextContent = preparePlan.files.find((file) => file.relativePath === AGENT_CONTEXT_PATH)?.content ?? ''
+      const promptPlans = await Promise.all(
+        AGENT_PROMPT_KINDS.map((kind) => planAgentPrompt(rootDir, kind, { allowMissingContext: true })),
+      )
+      const promptContents = new Map<AgentPromptKind, string>(
+        promptPlans.map((plan) => [plan.kind, plan.files[0]?.content ?? '']),
+      )
+
+      const isMigratedBaseline = metadata.tools.length === 0
+
+      if (isMigratedBaseline) {
+        addCheck(checks, {
+          level: 'info',
+          code: 'eval-generated-scaffold-skipped',
+          title: 'Generated scaffold evals skipped for migrated baseline',
+          detail: 'This project has scaffold metadata but no MCP tool inventory, so file-level generated-section evals were skipped.',
+          fix: 'No action needed unless you want to rebuild the project around a fresh MCP-derived scaffold.',
+        })
+      } else {
+        evaluateInstructions(rootDir, metadata, checks)
+        evaluateSkills(rootDir, metadata, checks)
+        evaluateCommands(rootDir, metadata, checks)
+        evaluateScaffoldArchitecture(metadata, checks)
+      }
+
+      evaluateAgentContext(contextContent, metadata, checks)
+
+      for (const kind of AGENT_PROMPT_KINDS) {
+        evaluatePromptContent(kind, promptContents.get(kind) ?? '', metadata, checks)
+      }
     }
 
-    evaluateAgentContext(contextContent, metadata, checks)
-
-    for (const kind of AGENT_PROMPT_KINDS) {
-      evaluatePromptContent(kind, promptContents.get(kind) ?? '', metadata, checks)
+    const semantic = runSemanticEvaluation(rootDir, config, metadata)
+    for (const criterion of semantic.criteria) {
+      addCheck(checks, {
+        domain: 'semantic',
+        level: 'info',
+        code: `semantic-${criterion.id}`,
+        title: criterion.title,
+        detail: criterion.applicable
+          ? `Score ${criterion.score}/100. ${criterion.evidence.join(' ')}`
+          : `Not applicable. ${criterion.evidence.join(' ')}`,
+        fix: criterion.applicable && (criterion.score ?? 100) < semantic.warningThreshold
+          ? 'Strengthen the cited workflow evidence and rerun `pluxx eval`.'
+          : 'No action needed.',
+      })
     }
 
-    return summarizeChecks(checks)
+    const semanticLevel: EvalLevel = semantic.score < semantic.failureThreshold
+      ? 'error'
+      : semantic.score < semantic.warningThreshold
+        ? 'warning'
+        : 'success'
+    addCheck(checks, {
+      domain: 'semantic',
+      level: semanticLevel,
+      code: 'semantic-rubric-threshold',
+      title: 'Semantic rubric threshold',
+      detail: `Semantic score ${semantic.score}/100; warning below ${semantic.warningThreshold}, failure below ${semantic.failureThreshold}.`,
+      fix: semanticLevel === 'success'
+        ? 'No action needed.'
+        : 'Address the lowest-scoring semantic criteria or adjust project thresholds with an explicit rationale.',
+    })
+
+    return summarizeChecks(checks, semantic)
   } catch (error) {
     addCheck(checks, {
       level: 'error',
@@ -493,19 +528,25 @@ export async function runEvalSuite(options: EvalRunOptions = {}): Promise<EvalRe
       detail: error instanceof Error ? error.message : String(error),
       fix: 'Resolve the underlying project/config error, then rerun `pluxx eval`.',
     })
-    return summarizeChecks(checks)
+    return summarizeChecks(checks, {
+      score: 0,
+      warningThreshold: 80,
+      failureThreshold: 60,
+      criteria: [],
+    })
   }
 }
 
 export function printEvalReport(report: EvalReport): void {
   for (const check of report.checks) {
     const prefix = check.level.toUpperCase().padEnd(7, ' ')
+    const domain = check.domain.toUpperCase().padEnd(8, ' ')
     const pathLabel = check.path ? ` [${check.path}]` : ''
-    console.log(`${prefix} ${check.code}${pathLabel} ${check.title}`)
+    console.log(`${prefix} ${domain} ${check.code}${pathLabel} ${check.title}`)
     console.log(`         ${check.detail}`)
     console.log(`         Fix: ${check.fix}`)
   }
 
   console.log('')
-  console.log(`Eval summary: ${report.errors} error(s), ${report.warnings} warning(s), ${report.infos} info message(s)`)
+  console.log(`Eval summary: ${report.errors} error(s), ${report.warnings} warning(s), ${report.infos} info message(s); semantic ${report.semantic.score}/100`)
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3180,6 +3180,15 @@ async function runTestCommand() {
         for (const check of behavioralResult.checks) {
           const prefix = check.ok ? '  PASS' : '  FAIL'
           console.log(`${prefix} ${check.platform}/${check.caseName}: ${check.responsePreview || '(no response preview)'}`)
+          const workflowIds = [
+            check.commandId ? `command=${check.commandId}` : undefined,
+            check.skillId ? `skill=${check.skillId}` : undefined,
+            check.agentId ? `agent=${check.agentId}` : undefined,
+          ].filter(Boolean)
+          const assertionCount = check.receipt.assertions.requiredText.length
+            + check.receipt.assertions.forbiddenText.length
+            + 1
+          console.log(`    Receipt: target=${check.receipt.target}${workflowIds.length ? ` ${workflowIds.join(' ')}` : ''} assertions=${assertionCount} artifacts=${check.receipt.artifacts.length}`)
           if (!check.ok) {
             for (const failure of check.failures) {
               console.log(`    - ${failure}`)

--- a/src/cli/semantic-eval.ts
+++ b/src/cli/semantic-eval.ts
@@ -1,0 +1,352 @@
+import { existsSync, readFileSync } from 'fs'
+import { resolve } from 'path'
+import { readCanonicalAgentFiles } from '../agents'
+import { readCanonicalCommandFiles } from '../commands'
+import type { PluginConfig } from '../schema'
+import { readCanonicalSkillFiles } from '../skills'
+import type { McpScaffoldMetadata } from './init-from-mcp'
+
+export const SEMANTIC_RUBRIC_IDS = [
+  'tool-coverage',
+  'routing-correctness',
+  'taxonomy-coherence',
+  'realistic-examples',
+  'argument-guidance',
+  'delegation',
+  'setup-truth',
+  'cross-file-consistency',
+] as const
+
+export type SemanticRubricId = typeof SEMANTIC_RUBRIC_IDS[number]
+
+export interface SemanticCriterionResult {
+  id: SemanticRubricId
+  title: string
+  applicable: boolean
+  score?: number
+  evidence: string[]
+}
+
+export interface SemanticEvalSummary {
+  score: number
+  warningThreshold: number
+  failureThreshold: number
+  criteria: SemanticCriterionResult[]
+}
+
+const DEFAULT_WARNING_THRESHOLD = 80
+const DEFAULT_FAILURE_THRESHOLD = 60
+const GENERIC_LINES = [
+  /^use (the )?(plugin|workflow|tool)\.?$/i,
+  /^follow the instructions\.?$/i,
+  /^do the task\.?$/i,
+  /^example request\.?$/i,
+  /^todo\b/i,
+  /^placeholder\b/i,
+]
+
+function clampScore(score: number): number {
+  return Math.max(0, Math.min(100, Math.round(score)))
+}
+
+function ratioScore(passing: number, total: number): number {
+  return total === 0 ? 100 : clampScore((passing / total) * 100)
+}
+
+function words(value: string): Set<string> {
+  return new Set(
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, ' ')
+      .split(/\s+/)
+      .filter(word => word.length >= 4),
+  )
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function meaningfulLines(content: string): string[] {
+  return content
+    .split(/\r?\n/)
+    .map(line => line.replace(/^\s*(?:[-*]|\d+\.)\s*/, '').trim())
+    .filter(line => line.length >= 18)
+    .filter(line => !line.startsWith('#'))
+    .filter(line => !GENERIC_LINES.some(pattern => pattern.test(line)))
+}
+
+function normalizedBody(content: string): string {
+  return meaningfulLines(content)
+    .join(' ')
+    .toLowerCase()
+    .replace(/`[^`]+`/g, '<code>')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+}
+
+function readInstructions(rootDir: string, config: PluginConfig): string {
+  if (!config.instructions) return ''
+  const path = resolve(rootDir, config.instructions)
+  return existsSync(path) ? readFileSync(path, 'utf-8') : ''
+}
+
+function requiredToolArguments(metadata: McpScaffoldMetadata | null): Array<{ tool: string, argument: string }> {
+  if (!metadata) return []
+  return metadata.tools.flatMap((tool) => {
+    const required = Array.isArray(tool.inputSchema?.required) ? tool.inputSchema.required : []
+    return required.map(argument => ({ tool: tool.name, argument }))
+  })
+}
+
+export function runSemanticEvaluation(
+  rootDir: string,
+  config: PluginConfig,
+  metadata: McpScaffoldMetadata | null,
+): SemanticEvalSummary {
+  const skills = readCanonicalSkillFiles(resolve(rootDir, config.skills))
+  const commands = config.commands
+    ? readCanonicalCommandFiles(resolve(rootDir, config.commands))
+    : []
+  const agents = config.agents
+    ? readCanonicalAgentFiles(resolve(rootDir, config.agents))
+    : []
+  const instructions = readInstructions(rootDir, config)
+  const migratedBaseline = Boolean(metadata && metadata.tools.length === 0)
+  const minimalManualProject = !metadata && !instructions.trim() && commands.length === 0 && skills.length <= 1
+  const skillNames = new Set(skills.map(skill => skill.name ?? skill.dirName))
+  const authoredSkillIds = new Set(skills.flatMap(skill => [skill.dirName, skill.name].filter((value): value is string => Boolean(value))))
+  const allAuthoredContent = [
+    instructions,
+    ...skills.map(skill => `${skill.description ?? ''}\n${skill.body}`),
+    ...commands.map(command => `${command.description ?? ''}\n${command.body}`),
+  ].join('\n')
+  const criteria: SemanticCriterionResult[] = []
+
+  if (metadata?.tools.length) {
+    const coveredTools = new Set(
+      metadata.skills
+        .filter(skill => authoredSkillIds.has(skill.dirName))
+        .flatMap(skill => skill.toolNames ?? []),
+    )
+    const missing = metadata.tools.map(tool => tool.name).filter(tool => !coveredTools.has(tool))
+    criteria.push({
+      id: 'tool-coverage',
+      title: 'MCP tools are assigned to authored workflows',
+      applicable: true,
+      score: ratioScore(metadata.tools.length - missing.length, metadata.tools.length),
+      evidence: missing.length === 0
+        ? [`All ${metadata.tools.length} MCP tools are assigned to at least one skill.`]
+        : [`Unassigned tools: ${missing.join(', ')}`],
+    })
+  } else {
+    criteria.push({
+      id: 'tool-coverage',
+      title: 'MCP tools are assigned to authored workflows',
+      applicable: false,
+      evidence: ['No MCP tool inventory is present; manual projects are not penalized.'],
+    })
+  }
+
+  const routedCommands = commands.filter(command => {
+    const links = new Set([command.skill, ...command.skills].filter((value): value is string => Boolean(value)))
+    return [...links].some(link => skillNames.has(link))
+  })
+  const routingApplicable = commands.length > 0 && (!migratedBaseline || routedCommands.length > 0)
+  criteria.push({
+    id: 'routing-correctness',
+    title: 'Commands route to existing skills',
+    applicable: routingApplicable,
+    score: routingApplicable ? ratioScore(routedCommands.length, commands.length) : undefined,
+    evidence: commands.length === 0
+      ? ['No commands are configured.']
+      : migratedBaseline && routedCommands.length === 0
+        ? ['Legacy migrated commands do not carry canonical routing metadata; the migrated baseline is not penalized.']
+      : [`${routedCommands.length} of ${commands.length} commands route to an existing skill.`],
+  })
+
+  const skillBodies = skills.map(skill => normalizedBody(skill.body)).filter(Boolean)
+  const uniqueBodies = new Set(skillBodies)
+  const descriptiveSkills = skills.filter(skill => (skill.description?.trim().length ?? 0) >= 24)
+  const contradictorySkills = skills.filter((skill) => {
+    const vocabulary = words(`${skill.name ?? skill.dirName} ${skill.description ?? ''}`)
+    return meaningfulLines(skill.body).some(line => [...vocabulary].some(word =>
+      new RegExp(`\\b(?:must not|do not|never)(?:\\s+\\w+){0,2}\\s+${escapeRegExp(word)}\\b`, 'i').test(line),
+    ))
+  })
+  const alignedSkills = skills.length - contradictorySkills.length
+  const taxonomyScore = skills.length === 0
+    ? 0
+    : contradictorySkills.length > 0
+      ? ratioScore(alignedSkills, skills.length)
+    : Math.round((
+        ratioScore(uniqueBodies.size, skills.length)
+        + ratioScore(descriptiveSkills.length, skills.length)
+        + ratioScore(alignedSkills, skills.length)
+      ) / 3)
+  const minimalManualSkillValid = minimalManualProject
+    && skills.length === 1
+    && (skills[0]?.description?.trim().length ?? 0) >= 8
+    && Boolean(skills[0]?.firstHeading)
+    && !/\b(?:todo|placeholder|example skill)\b/i.test(skills[0]?.description ?? '')
+  criteria.push({
+    id: 'taxonomy-coherence',
+    title: 'Skills form distinct, product-shaped workflows',
+    applicable: !migratedBaseline,
+    score: migratedBaseline ? undefined : minimalManualProject ? (minimalManualSkillValid ? 100 : 0) : taxonomyScore,
+    evidence: minimalManualProject
+      ? [minimalManualSkillValid
+          ? 'The single manual skill has a valid identity, description, and workflow heading.'
+          : 'The single manual skill is missing a meaningful identity, description, or workflow heading.']
+      : migratedBaseline
+      ? ['Legacy migrated content is preserved for a later refinement pass; source brevity is not scored during baseline migration.']
+      : [`${uniqueBodies.size} distinct workflow bodies, ${descriptiveSkills.length} descriptive summaries, and ${alignedSkills} contradiction-free workflows across ${skills.length} skills.`],
+  })
+
+  const realisticSkills = skills.filter((skill) => {
+    const lines = meaningfulLines(skill.body)
+    const vocabulary = words(`${skill.name ?? skill.dirName} ${skill.description ?? ''}`)
+    const hasStructuredWorkflow = /^##\s+(?:Workflow|Typical flow|What To Do|Example Requests|Usage|Process)\b/im.test(skill.body)
+    return hasStructuredWorkflow
+      && lines.length >= 3
+      && lines.some(line => [...vocabulary].some(word => line.toLowerCase().includes(word)))
+      && !contradictorySkills.includes(skill)
+  })
+  criteria.push({
+    id: 'realistic-examples',
+    title: 'Workflow guidance contains concrete, product-shaped examples',
+    applicable: !migratedBaseline && !minimalManualProject && skills.length > 0,
+    score: !migratedBaseline && !minimalManualProject && skills.length > 0 ? ratioScore(realisticSkills.length, skills.length) : undefined,
+    evidence: minimalManualProject
+      ? ['The project has no command or instruction surface on which to judge workflow examples.']
+      : migratedBaseline
+      ? ['Legacy migrated examples are preserved for a later refinement pass and are not scored during baseline migration.']
+      : [`${realisticSkills.length} of ${skills.length} skills contain multiple concrete lines tied to their workflow vocabulary.`],
+  })
+
+  const requiredArguments = requiredToolArguments(metadata)
+  const commandsWithArguments = commands.filter(command =>
+    command.arguments.length > 0 || Boolean(command.argumentHint) || /\$ARGUMENTS/.test(command.body),
+  )
+  const documentedRequiredArguments = requiredArguments.filter(({ argument }) =>
+    allAuthoredContent.toLowerCase().includes(argument.toLowerCase()),
+  )
+  const argumentTotal = requiredArguments.length > 0 ? requiredArguments.length : commands.length
+  const argumentPassing = requiredArguments.length > 0 ? documentedRequiredArguments.length : commandsWithArguments.length
+  criteria.push({
+    id: 'argument-guidance',
+    title: 'Required inputs are carried into workflow guidance',
+    applicable: !migratedBaseline && argumentTotal > 0,
+    score: !migratedBaseline && argumentTotal > 0 ? ratioScore(argumentPassing, argumentTotal) : undefined,
+    evidence: migratedBaseline
+      ? ['Legacy migrated command arguments are preserved for later normalization and are not scored during baseline migration.']
+      : requiredArguments.length > 0
+      ? [`${documentedRequiredArguments.length} of ${requiredArguments.length} required MCP arguments appear in authored guidance.`]
+      : [`${commandsWithArguments.length} of ${commands.length} commands declare or consume arguments.`],
+  })
+
+  const delegatedSkills = skills.filter(skill => Boolean(skill.agent))
+  const delegatedCommands = commands.filter(command => Boolean(command.agent) || command.subtask === true)
+  const delegationSurfaces = delegatedSkills.length + delegatedCommands.length
+  const healthyAgents = agents.filter(agent =>
+    (agent.description?.trim().length ?? 0) >= 12 && meaningfulLines(agent.body).length >= 2,
+  )
+  const delegationApplicable = !migratedBaseline && (delegationSurfaces > 0 || Boolean(config.agents))
+  const configuredAgentIds = new Set(agents.flatMap(agent => [agent.name, agent.fileStem]))
+  const declaredAgentReferences = [
+    ...delegatedSkills.map(skill => skill.agent).filter((value): value is string => Boolean(value)),
+    ...delegatedCommands.map(command => command.agent).filter((value): value is string => Boolean(value)),
+  ]
+  const resolvedAgentReferences = config.agents
+    ? declaredAgentReferences.filter(agent => configuredAgentIds.has(agent))
+    : declaredAgentReferences
+  const genericSubtasks = delegatedCommands.filter(command => command.subtask === true && !command.agent).length
+  const delegationScore = !delegationApplicable
+    ? undefined
+    : config.agents
+      ? ratioScore(
+          healthyAgents.length + resolvedAgentReferences.length + genericSubtasks,
+          Math.max(agents.length + declaredAgentReferences.length + genericSubtasks, 1),
+        )
+      : 100
+  criteria.push({
+    id: 'delegation',
+    title: 'Delegated workflows identify their execution surface',
+    applicable: delegationApplicable,
+    score: delegationScore,
+    evidence: migratedBaseline
+      ? ['Legacy migrated agent files are preserved as source artifacts; missing frontmatter routing is not scored.']
+      : config.agents
+        ? [`${healthyAgents.length} of ${agents.length} configured agents are substantive; ${resolvedAgentReferences.length} of ${declaredAgentReferences.length} named delegation references resolve.`]
+      : delegationSurfaces > 0
+      ? [`${delegationSurfaces} skill or command surfaces declare delegation metadata.`]
+      : ['No delegated workflow surface is configured; the project is not penalized.'],
+  })
+
+  const setupTerms = new Set<string>()
+  for (const entry of config.userConfig ?? []) {
+    setupTerms.add(entry.key)
+    if (entry.envVar) setupTerms.add(entry.envVar)
+  }
+  for (const server of Object.values(config.mcp ?? {})) {
+    if (server.auth && server.auth.type !== 'none' && 'envVar' in server.auth) setupTerms.add(server.auth.envVar)
+  }
+  if (metadata?.source.auth && metadata.source.auth.type !== 'none' && 'envVar' in metadata.source.auth) {
+    setupTerms.add(metadata.source.auth.envVar)
+  }
+  const documentedSetupTerms = [...setupTerms].filter(term => allAuthoredContent.includes(term))
+  criteria.push({
+    id: 'setup-truth',
+    title: 'Setup guidance matches configured runtime inputs',
+    applicable: !migratedBaseline && setupTerms.size > 0,
+    score: !migratedBaseline && setupTerms.size > 0 ? ratioScore(documentedSetupTerms.length, setupTerms.size) : undefined,
+    evidence: migratedBaseline
+      ? ['Legacy migrated setup identifiers remain source truth and are not scored until refinement.']
+      : setupTerms.size > 0
+      ? [`${documentedSetupTerms.length} of ${setupTerms.size} configured setup identifiers appear in authored guidance.`]
+      : ['No configured runtime inputs require setup guidance.'],
+  })
+
+  const metadataSkillNames = new Set(metadata?.skills.map(skill => skill.dirName) ?? [])
+  const authoredDirNames = new Set(skills.map(skill => skill.dirName))
+  const missingAuthoredSkills = [...metadataSkillNames].filter(name => !authoredDirNames.has(name))
+  const commandTargets = commands.flatMap(command => [command.skill, ...command.skills].filter((value): value is string => Boolean(value)))
+  const missingCommandTargets = commandTargets.filter(name => !skillNames.has(name))
+  const missingAgentTargets = config.agents
+    ? declaredAgentReferences.filter(name => !configuredAgentIds.has(name))
+    : []
+  const configuredInstructionsMissing = config.instructions && !instructions.trim() ? 1 : 0
+  const consistencyProblems = missingAuthoredSkills.length + missingCommandTargets.length + missingAgentTargets.length + configuredInstructionsMissing
+  const consistencyTotal = metadataSkillNames.size + commandTargets.length + declaredAgentReferences.length + (config.instructions ? 1 : 0)
+  criteria.push({
+    id: 'cross-file-consistency',
+    title: 'Instructions, skills, commands, and metadata agree',
+    applicable: !minimalManualProject,
+    score: minimalManualProject ? undefined : ratioScore(Math.max(0, consistencyTotal - consistencyProblems), consistencyTotal),
+    evidence: minimalManualProject
+      ? ['The minimal manual project has no cross-file routing surface to compare.']
+      : consistencyProblems === 0
+      ? ['Instructions are present and all metadata/command skill references resolve.']
+      : [`Found ${consistencyProblems} missing or unresolved cross-file reference(s).`],
+  })
+
+  const applicable = criteria.filter(criterion => criterion.applicable && criterion.score !== undefined)
+  const weights: Partial<Record<SemanticRubricId, number>> = {
+    'taxonomy-coherence': 2,
+    'realistic-examples': 2,
+  }
+  const totalWeight = applicable.reduce((sum, criterion) => sum + (weights[criterion.id] ?? 1), 0)
+  const score = applicable.length === 0
+    ? 100
+    : clampScore(applicable.reduce(
+        (sum, criterion) => sum + (criterion.score ?? 0) * (weights[criterion.id] ?? 1),
+        0,
+      ) / totalWeight)
+
+  return {
+    score,
+    warningThreshold: config.eval?.warningThreshold ?? DEFAULT_WARNING_THRESHOLD,
+    failureThreshold: config.eval?.failureThreshold ?? DEFAULT_FAILURE_THRESHOLD,
+    criteria,
+  }
+}

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -418,6 +418,15 @@ export const PluginConfigSchema = z.object({
   agents: z.string().optional(),
   instructions: z.string().optional(),
 
+  // Deterministic semantic evaluation policy
+  eval: z.object({
+    warningThreshold: z.number().min(0).max(100).default(80),
+    failureThreshold: z.number().min(0).max(100).default(60),
+  }).refine(
+    policy => policy.failureThreshold <= policy.warningThreshold,
+    'eval.failureThreshold must be less than or equal to eval.warningThreshold',
+  ).optional(),
+
   // MCP servers
   mcp: z.record(z.string(), McpServerSchema).optional(),
 

--- a/tests/behavioral-smoke.test.ts
+++ b/tests/behavioral-smoke.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'bun:test'
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { resolve } from 'path'
 import type { PluginConfig } from '../src/schema'
@@ -184,6 +184,165 @@ describe('behavioral smoke suite', () => {
     expect(result.checks[0]?.ok).toBe(true)
     expect(result.checks[0]?.expectedExitCodes).toEqual([2])
     expect(result.checks[0]?.command).toContain('--model')
+  })
+
+  it('returns workflow receipts with factual artifact assertions', async () => {
+    const rootDir = makeTempDir('pluxx-behavioral-receipt-')
+    const binDir = resolve(rootDir, '.bin')
+    mkdirSync(binDir, { recursive: true })
+    mkdirSync(resolve(rootDir, '.pluxx'), { recursive: true })
+
+    writeFileSync(
+      resolve(rootDir, '.pluxx/behavioral-smoke.json'),
+      JSON.stringify({
+        cases: [
+          {
+            name: 'publish-dry-run',
+            commandId: 'publish-plugin',
+            skillId: 'pluxx-publish-plugin',
+            agentId: 'release-operator',
+            targets: {
+              opencode: {
+                prompt: 'Use command publish-plugin to create a dry-run publish receipt.',
+                require: ['Dry run complete'],
+                artifacts: [
+                  {
+                    path: 'proof/publish.json',
+                    state: 'created',
+                    require: ['"status":"dry-run"', '"published":false'],
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      }, null, 2),
+    )
+
+    makeStubExecutable(
+      resolve(binDir, 'opencode'),
+      '#!/bin/sh\nmkdir -p proof\nprintf \'{"status":"dry-run","published":false}\\n\' > proof/publish.json\nprintf "Dry run complete\\n"\n',
+    )
+    process.env.PATH = `${binDir}:${ORIGINAL_PATH}`
+
+    const config = { name: 'pluxx' } as PluginConfig
+    const result = await runBehavioralSuite(rootDir, config, ['opencode'])
+    const check = result.checks[0]!
+
+    expect(result.ok).toBe(true)
+    expect(check.receipt.target).toBe('opencode')
+    expect(check.receipt.commandId).toBe('publish-plugin')
+    expect(check.receipt.skillId).toBe('pluxx-publish-plugin')
+    expect(check.receipt.agentId).toBe('release-operator')
+    expect(check.receipt.assertions.requiredText).toEqual(['Dry run complete'])
+    expect(check.receipt.artifacts[0]).toMatchObject({
+      path: 'proof/publish.json',
+      state: 'created',
+      exists: true,
+      kind: 'file',
+      ok: true,
+    })
+  })
+
+  it('fails receipts when artifact facts do not match', async () => {
+    const rootDir = makeTempDir('pluxx-behavioral-artifact-fail-')
+    const binDir = resolve(rootDir, '.bin')
+    mkdirSync(binDir, { recursive: true })
+    mkdirSync(resolve(rootDir, '.pluxx'), { recursive: true })
+
+    writeFileSync(
+      resolve(rootDir, '.pluxx/behavioral-smoke.json'),
+      JSON.stringify({
+        cases: [{
+          name: 'publish-dry-run',
+          targets: {
+            opencode: {
+              prompt: 'Create a dry-run publish receipt.',
+              artifacts: [{ path: 'proof/publish.json', require: ['"published":false'] }],
+            },
+          },
+        }],
+      }, null, 2),
+    )
+    makeStubExecutable(resolve(binDir, 'opencode'), '#!/bin/sh\nprintf "Dry run complete\\n"\n')
+    process.env.PATH = `${binDir}:${ORIGINAL_PATH}`
+
+    const result = await runBehavioralSuite(rootDir, { name: 'pluxx' } as PluginConfig, ['opencode'])
+
+    expect(result.ok).toBe(false)
+    expect(result.checks[0]?.receipt.artifacts[0]?.ok).toBe(false)
+    expect(result.checks[0]?.failures).toContain('proof/publish.json: expected artifact to exist')
+  })
+
+  it('fails a changed assertion when the runner leaves a pre-existing artifact untouched', async () => {
+    const rootDir = makeTempDir('pluxx-behavioral-artifact-unchanged-')
+    const binDir = resolve(rootDir, '.bin')
+    mkdirSync(binDir, { recursive: true })
+    mkdirSync(resolve(rootDir, '.pluxx'), { recursive: true })
+    writeFileSync(resolve(rootDir, 'receipt.json'), '{"outcome":"old"}')
+    writeFileSync(
+      resolve(rootDir, '.pluxx/behavioral-smoke.json'),
+      JSON.stringify({ cases: [{ name: 'unchanged', targets: { opencode: {
+        prompt: 'Run the workflow.',
+        artifacts: [{ path: 'receipt.json', state: 'changed', require: ['"outcome"'] }],
+      } } }] }),
+    )
+    makeStubExecutable(resolve(binDir, 'opencode'), '#!/bin/sh\nprintf "done\\n"\n')
+    process.env.PATH = `${binDir}:${ORIGINAL_PATH}`
+
+    const result = await runBehavioralSuite(rootDir, { name: 'pluxx' } as PluginConfig, ['opencode'])
+
+    expect(result.ok).toBe(false)
+    expect(result.checks[0]?.failures).toContain('receipt.json: expected artifact to change during runner execution')
+  })
+
+  it('keeps declared artifact outcomes when the runner cannot start', async () => {
+    const rootDir = makeTempDir('pluxx-behavioral-runner-error-artifact-')
+    mkdirSync(resolve(rootDir, '.pluxx'), { recursive: true })
+    writeFileSync(
+      resolve(rootDir, '.pluxx/behavioral-smoke.json'),
+      JSON.stringify({ cases: [{ name: 'runner-error', targets: { opencode: {
+        prompt: 'Run the workflow.',
+        artifacts: [{ path: 'receipt.json', state: 'created' }],
+      } } }] }),
+    )
+    process.env.PATH = makeTempDir('pluxx-empty-path-')
+
+    const result = await runBehavioralSuite(rootDir, { name: 'pluxx' } as PluginConfig, ['opencode'])
+
+    expect(result.ok).toBe(false)
+    expect(result.checks[0]?.receipt.artifacts[0]).toMatchObject({
+      path: 'receipt.json',
+      state: 'created',
+      exists: false,
+      ok: false,
+    })
+  })
+
+  it('refuses artifact symlinks that resolve outside the project root', async () => {
+    const rootDir = makeTempDir('pluxx-behavioral-artifact-boundary-')
+    const outsideDir = makeTempDir('pluxx-behavioral-artifact-outside-')
+    const binDir = resolve(rootDir, '.bin')
+    mkdirSync(binDir, { recursive: true })
+    mkdirSync(resolve(rootDir, '.pluxx'), { recursive: true })
+    writeFileSync(resolve(outsideDir, 'outside.txt'), 'outside project')
+    symlinkSync(resolve(outsideDir, 'outside.txt'), resolve(rootDir, 'receipt.txt'))
+    writeFileSync(
+      resolve(rootDir, '.pluxx/behavioral-smoke.json'),
+      JSON.stringify({
+        cases: [{
+          name: 'boundary',
+          targets: { opencode: { prompt: 'Check the receipt.', artifacts: [{ path: 'receipt.txt', require: ['outside'] }] } },
+        }],
+      }),
+    )
+    makeStubExecutable(resolve(binDir, 'opencode'), '#!/bin/sh\nprintf "done\\n"\n')
+    process.env.PATH = `${binDir}:${ORIGINAL_PATH}`
+
+    const result = await runBehavioralSuite(rootDir, { name: 'pluxx' } as PluginConfig, ['opencode'])
+
+    expect(result.ok).toBe(false)
+    expect(result.checks[0]?.failures).toContain('receipt.txt: artifact path resolves outside the project root')
   })
 
   it('times out hanging runner commands instead of blocking indefinitely', async () => {

--- a/tests/eval.test.ts
+++ b/tests/eval.test.ts
@@ -180,6 +180,127 @@ describe('eval command', () => {
     expect(result.eval?.checks.some((check) => check.code === 'skill-quality-contract')).toBe(true)
   })
 
+  it('fails semantic evaluation for a heading-complete but incoherent scaffold', async () => {
+    const skillPath = resolve(TEST_DIR, 'skills/account-research/SKILL.md')
+    const skillFrontmatter = readFileSync(skillPath, 'utf-8').split('---').slice(0, 2).join('---')
+    writeFileSync(skillPath, `${skillFrontmatter}---\n\n# Account Research\n\n## Example Requests\n\n- Example request.\n\n## Related Resources\n\n- Resource.\n\n## Related Prompt Templates\n\n- Prompt.\n`)
+
+    const commandPath = resolve(TEST_DIR, 'commands/account-research.md')
+    writeFileSync(commandPath, `---\ndescription: Run account research\nargument-hint: "[input]"\n---\n\n# Account Research\n\nPrimary tools: generic.\nRelated resources: generic.\nRelated prompt templates: generic.\n`)
+
+    const instructionsPath = resolve(TEST_DIR, 'INSTRUCTIONS.md')
+    writeFileSync(instructionsPath, '# Sumble\n\n## Workflow Guidance\n\nUse the workflow.\n\n## Tool Routing\n\nUse the tool.\n\n## Resource Surfaces\n\nResource.\n\n## Prompt Templates\n\nPrompt.\n')
+
+    const report = await runEvalSuite({ rootDir: TEST_DIR })
+
+    expect(report.ok).toBe(false)
+    expect(report.semantic.score).toBeLessThan(report.semantic.failureThreshold)
+    expect(report.checks.some(check => check.code === 'instructions-quality-contract' && check.level === 'success')).toBe(true)
+    expect(report.checks.some(check => check.code === 'semantic-rubric-threshold' && check.level === 'error')).toBe(true)
+  })
+
+  it('fails keyword-stuffed workflow text that contradicts its own taxonomy', async () => {
+    const skillPath = resolve(TEST_DIR, 'skills/account-research/SKILL.md')
+    const original = readFileSync(skillPath, 'utf-8')
+    const frontmatter = original.split('---').slice(0, 2).join('---')
+    writeFileSync(skillPath, `${frontmatter}---\n\n# Account Research\n\n## Workflow\n\n1. Account research must not research accounts for a customer.\n2. Do not use account research to find organizations or evidence.\n3. Never route account research through the account research tools.\n\n## Example Requests\n\n- Research this account.\n\n## Related Resources\n\n- Resource.\n\n## Related Prompt Templates\n\n- Prompt.\n`)
+
+    const report = await runEvalSuite({ rootDir: TEST_DIR })
+
+    expect(report.checks.some(check => check.code === 'instructions-quality-contract' && check.level === 'success')).toBe(true)
+    expect(report.semantic.criteria.find(criterion => criterion.id === 'taxonomy-coherence')?.score).toBe(0)
+    expect(report.checks.find(check => check.code === 'semantic-rubric-threshold')?.level).toBe('error')
+  })
+
+  it('does not count tools assigned only to a deleted authored skill', async () => {
+    rmSync(resolve(TEST_DIR, 'skills/account-research'), { recursive: true, force: true })
+
+    const report = await runEvalSuite({ rootDir: TEST_DIR })
+
+    expect(report.semantic.criteria.find(criterion => criterion.id === 'tool-coverage')?.score).toBe(0)
+  })
+
+  it('scores unresolved configured delegation targets as inconsistent', async () => {
+    mkdirSync(resolve(TEST_DIR, 'agents'), { recursive: true })
+    writeFileSync(
+      resolve(TEST_DIR, 'agents/researcher.md'),
+      '---\nname: researcher\ndescription: Research account evidence\n---\n\n# Researcher\n\n## Workflow\n\n1. Gather account evidence.\n2. Return sourced findings.\n',
+    )
+    const configPath = resolve(TEST_DIR, 'pluxx.config.ts')
+    writeFileSync(
+      configPath,
+      readFileSync(configPath, 'utf-8').replace(/\n}\)\s*$/, '\n  agents: \'./agents/\',\n})\n'),
+    )
+    const skillPath = resolve(TEST_DIR, 'skills/account-research/SKILL.md')
+    writeFileSync(
+      skillPath,
+      readFileSync(skillPath, 'utf-8').replace('description:', 'agent: missing-reviewer\ndescription:'),
+    )
+
+    const report = await runEvalSuite({ rootDir: TEST_DIR })
+
+    expect(report.semantic.criteria.find(criterion => criterion.id === 'delegation')?.score).toBeLessThan(100)
+    expect(report.semantic.criteria.find(criterion => criterion.id === 'cross-file-consistency')?.score).toBeLessThan(100)
+  })
+
+  it('fails an empty manual project instead of assigning a perfect score', async () => {
+    rmSync(resolve(TEST_DIR, `.${'pluxx'}`), { recursive: true, force: true })
+    rmSync(resolve(TEST_DIR, 'skills'), { recursive: true, force: true })
+    rmSync(resolve(TEST_DIR, 'commands'), { recursive: true, force: true })
+    rmSync(resolve(TEST_DIR, 'INSTRUCTIONS.md'), { force: true })
+    rmSync(resolve(TEST_DIR, 'pluxx.config.ts'), { force: true })
+    writeFileSync(resolve(TEST_DIR, 'pluxx.config.json'), JSON.stringify({
+      name: 'empty-manual',
+      description: 'Empty manual project fixture.',
+      author: { name: 'Test Author' },
+      skills: './skills/',
+    }))
+
+    const report = await runEvalSuite({ rootDir: TEST_DIR })
+
+    expect(report.semantic.score).toBe(0)
+    expect(report.ok).toBe(false)
+  })
+
+  it('keeps maintained manual and docs-ingestion projects as passing regression inputs', async () => {
+    const maintainedProjects = [
+      'example/pluxx',
+      'example/docs-ops',
+      'example/firecrawl-plugin',
+      'example/sumble-plugin',
+    ]
+
+    for (const project of maintainedProjects) {
+      const report = await runEvalSuite({ rootDir: resolve(ROOT, project) })
+      expect(report.semantic.criteria).toHaveLength(8)
+      expect(report.checks.some(check => check.domain === 'semantic')).toBe(true)
+      expect(
+        report.checks.find(check => check.code === 'semantic-rubric-threshold')?.level,
+        project,
+      ).not.toBe('error')
+      if (project === 'example/pluxx' || project === 'example/docs-ops') {
+        expect(report.ok, project).toBe(true)
+      }
+    }
+  })
+
+  it('honors project-level semantic warning and failure thresholds', async () => {
+    const configPath = resolve(TEST_DIR, 'pluxx.config.ts')
+    const config = readFileSync(configPath, 'utf-8').replace(
+      /\n}\)\s*$/,
+      '\n  eval: { warningThreshold: 100, failureThreshold: 0 },\n})\n',
+    )
+    writeFileSync(configPath, config)
+
+    const report = await runEvalSuite({ rootDir: TEST_DIR })
+
+    expect(report.semantic.warningThreshold).toBe(100)
+    expect(report.semantic.failureThreshold).toBe(0)
+    expect(report.checks.find(check => check.code === 'semantic-rubric-threshold')?.level).toBe(
+      report.semantic.score < 100 ? 'warning' : 'success',
+    )
+  })
+
   it('supports CLI JSON output', async () => {
     const proc = Bun.spawn(['bun', resolve(ROOT, 'bin/pluxx.js'), 'eval', '--json'], {
       cwd: TEST_DIR,

--- a/tests/migrate.test.ts
+++ b/tests/migrate.test.ts
@@ -688,7 +688,7 @@ describe('migrate', () => {
       expect(preparePlan.skillCount).toBe(1)
 
       const evalReport = await runEvalSuite({ rootDir: outputDir })
-      expect(evalReport.ok).toBe(true)
+      expect(evalReport.ok, JSON.stringify(evalReport, null, 2)).toBe(true)
 
       const migratedConfig = await loadConfig(outputDir)
       await build(migratedConfig, outputDir)

--- a/tests/release-smoke.test.ts
+++ b/tests/release-smoke.test.ts
@@ -20,6 +20,13 @@ const COMMAND_BEHAVIORAL_PROOF_PROJECTS = [
   'example/docs-ops',
   'example/platform-change-ops',
 ]
+const PLUXX_CODEX_ONLY_WORKFLOWS = new Set([
+  'import-mcp',
+  'refine-plugin',
+  'prove-plugin',
+  'troubleshoot-install',
+  'publish-dry-run',
+])
 const RELEASE_SMOKE_PROJECT_ENV: Record<string, Record<string, string>> = {
   'examples/prospeo-mcp': {
     PROSPEO_API_KEY: 'pluxx-release-smoke-prospeo-api-key',
@@ -36,6 +43,8 @@ interface BehavioralSmokeTarget {
 interface BehavioralSmokeCase {
   name: string
   commandId?: string
+  skillId?: string
+  agentId?: string
   targets: Partial<Record<typeof CORE_FOUR[number], BehavioralSmokeTarget>>
 }
 
@@ -116,9 +125,12 @@ function expectExplicitCommandBehavioralProof(projectPath: string): void {
     expect(typeof behavioralCase.commandId).toBe('string')
     expect(behavioralCase.commandId?.length).toBeGreaterThan(0)
 
-    for (const platform of CORE_FOUR) {
+    const expectedPlatforms = projectPath === 'example/pluxx' && PLUXX_CODEX_ONLY_WORKFLOWS.has(behavioralCase.name)
+      ? ['codex']
+      : CORE_FOUR
+    expect(Object.keys(behavioralCase.targets).sort()).toEqual([...expectedPlatforms].sort())
+    for (const platform of expectedPlatforms) {
       const target = behavioralCase.targets[platform]
-      expect(target).toBeDefined()
       expect(typeof target?.prompt).toBe('string')
       expect(promptReferencesCommand(target!.prompt, behavioralCase.commandId!)).toBe(true)
       expect(Array.isArray(target?.require)).toBe(true)

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -11,6 +11,38 @@ import {
   getPluginCompilerBuckets,
 } from '../src/schema'
 
+const BASE_PLUGIN_CONFIG = {
+  name: 'semantic-eval-fixture',
+  version: '0.1.0',
+  description: 'Semantic eval schema fixture.',
+  author: { name: 'Test Author' },
+  skills: './skills/',
+}
+
+describe('PluginConfigSchema semantic eval policy', () => {
+  it('applies defaults and accepts ordered thresholds', () => {
+    expect(PluginConfigSchema.parse({ ...BASE_PLUGIN_CONFIG, eval: {} }).eval).toEqual({
+      warningThreshold: 80,
+      failureThreshold: 60,
+    })
+    expect(PluginConfigSchema.parse({
+      ...BASE_PLUGIN_CONFIG,
+      eval: { warningThreshold: 90, failureThreshold: 70 },
+    }).eval).toEqual({ warningThreshold: 90, failureThreshold: 70 })
+  })
+
+  it('rejects out-of-range or inverted thresholds', () => {
+    expect(PluginConfigSchema.safeParse({
+      ...BASE_PLUGIN_CONFIG,
+      eval: { warningThreshold: 101, failureThreshold: 60 },
+    }).success).toBe(false)
+    expect(PluginConfigSchema.safeParse({
+      ...BASE_PLUGIN_CONFIG,
+      eval: { warningThreshold: 60, failureThreshold: 80 },
+    }).success).toBe(false)
+  })
+})
+
 describe('McpServerSchema transport validation', () => {
   it('requires command and forbids url for stdio transport', () => {
     expect(


### PR DESCRIPTION
## Summary

`pluxx eval` can now reject projects that are structurally complete but semantically incoherent, while preserving deterministic behavior for legitimate manual and migrated projects.

The evaluator reports exact scaffold contracts separately from an evidence-bearing semantic rubric covering tool coverage, routing, taxonomy, examples, arguments, delegation, setup truth, and cross-file consistency. Projects can set validated warning and failure thresholds in their Pluxx config.

Behavioral proof now emits receipts that identify the host target, command, skill or agent, response assertions, and project-relative artifact outcomes. Outcome assertions can require artifacts to be created or changed by the runner, and artifact resolution cannot escape the project root.

The self-hosted Pluxx fixture now maintains import, refine, prove, translate, troubleshoot, and publish-dry-run cases. Publish proof remains explicitly separate from a real release.

## Review notes

- Deterministic scoring remains the release gate; no model-backed grader was introduced.
- Empty or placeholder manual projects fail, but minimal valid projects and legacy migration baselines are not falsely rejected.
- Existing core-four behavioral fixture coverage remains mandatory; the five new PLUXX-316 workflow cases are intentionally Codex-only.
- CE plan and resolved review are committed under `docs/orchid/`.

## Validation

- `npm run build`
- `npm run typecheck`
- Targeted eval, behavioral, release-smoke, schema, Phase 2 CLI, and migration tests: 85/85
- Official `npm test`: 598/598 across 53 test files

Fixes #406
Fixes PLUXX-316

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
