### PR TITLE
fix(cli): make authoring and build mutations atomic

### DIFF
--- a/docs/plans/2026-07-12-001-fix-atomic-authoring-mutations-plan.md
+++ b/docs/plans/2026-07-12-001-fix-atomic-authoring-mutations-plan.md
@@ -1,0 +1,182 @@
+---
+title: "fix: Make authoring and build mutations atomic"
+date: 2026-07-12
+type: fix
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: linear-pluxx-318
+execution: code
+origin: https://linear.app/orchid-automation/issue/PLUXX-318/make-authoring-and-build-mutations-atomic
+---
+
+# fix: Make authoring and build mutations atomic
+
+## Goal Capsule
+
+- **Objective:** Make `init`, `sync`, `migrate`, and `build` publish only fully staged and validated mutations while preserving existing source and distribution state on failure.
+- **Authority:** PLUXX-318 acceptance criteria, then repo `AGENTS.md`, then current CLI compatibility and local implementation patterns.
+- **Execution profile:** Reliability-first implementation with injected-failure coverage before closeout.
+- **Stop condition:** Stop rather than weakening atomicity if a platform cannot provide the required replace/rollback guarantees; document a precise bound instead.
+- **Tail ownership:** The PLUXX-318 branch owns implementation, tests, docs, PR/CI repair, and Linear closeout without merging.
+
+---
+
+## Product Contract
+
+### Summary
+
+Authoring and build commands must separate planning from mutation. Each command stages its complete intended result, validates that staged state, publishes it as one recoverable transaction, and reports the same create/update/delete/conflict truth in dry-run and apply modes.
+
+### Problem Frame
+
+The current paths write final files or delete final output before the full operation is known to succeed. A generator, copy, lint, rename, or filesystem failure can therefore leave a source project or `dist` tree only partly updated. Existing dry-run behavior is also inconsistent: init and sync expose partial summaries, migrate has no manifest, and ambiguous sync renames are not a first-class conflict.
+
+### Requirements
+
+- R1. A shared transaction layer stages planned filesystem changes, validates them, and either applies all changes or restores the exact pre-operation state.
+- R2. `build` generates into a same-filesystem staging directory and publishes the completed output only after bundle validation succeeds.
+- R3. `init`, `sync`, and `migrate` expose deterministic manifests covering creates, updates, deletes, renames, and conflicts as applicable.
+- R4. Injected failures during staging, validation, or publication leave original source and distribution paths intact.
+- R5. Sync preserves user/custom content and refuses ambiguous rename/collision plans instead of guessing.
+- R6. Cross-device replacement is avoided by same-parent staging; unsupported rename behavior is recovered through backup-and-restore and surfaced clearly.
+- R7. Interrupted apply phases leave actionable recovery metadata until publication completes or rollback succeeds.
+- R8. Existing CLI JSON fields remain compatible; new manifest and recovery fields are additive.
+
+### Scope Boundaries
+
+In scope are the four PLUXX-318 mutation paths and their shared filesystem transaction seam. Install, publish, upgrade, Codex companion ownership, and broader release recovery remain owned by sibling audit issues.
+
+### Acceptance Examples
+
+- AE1. Given an existing `dist`, when a generator or bundle validator fails, then every byte under the existing `dist` remains unchanged.
+- AE2. Given an existing MCP-authored project, when sync fails after staging or during publication, then managed files, custom sections, and saved agent artifacts match their pre-sync state.
+- AE3. Given two equally plausible tool renames, when sync is planned, then dry-run reports a conflict and apply refuses to mutate.
+- AE4. Given a migration or init dry-run, then the reported manifest matches the subsequent successful apply without writing final paths.
+- AE5. Given a publication rename failure, then the backup is restored and the error names the recovery state or location.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. Use same-parent temporary directories for directory publication so staging and final output are on the same filesystem by construction.
+- KTD2. Use a backup-then-rename directory publish sequence with immediate restoration on failure; never delete the original before the replacement is ready.
+- KTD3. Represent source mutations as an ordered manifest and apply them through one rollback-capable file transaction rather than letting command-specific loops write final paths.
+- KTD4. Keep recovery journals outside the user-authored payload but adjacent enough to make interrupted operations diagnosable; remove them only after commit or successful rollback.
+- KTD5. Preserve current top-level JSON summary fields and add a versioned `mutation` object for richer creates/updates/deletes/renames/conflicts/recovery truth.
+- KTD6. Treat multiple high-confidence rename candidates or destination collisions as conflicts requiring user resolution, not as heuristic winners.
+
+### High-Level Technical Design
+
+```mermaid
+flowchart TB
+  A[Plan intended mutation] --> B[Stage under final path parent]
+  B --> C[Validate staged state]
+  C -->|failure| D[Discard stage; final unchanged]
+  C -->|success| E[Write recovery journal]
+  E --> F[Move current state to backup]
+  F --> G[Publish staged state]
+  G -->|success| H[Remove backup and journal]
+  G -->|failure| I[Restore backup]
+  I --> J[Keep actionable recovery detail if restore fails]
+```
+
+### Assumptions
+
+- Node 18 filesystem primitives are the compatibility floor.
+- Full process-crash recovery can be made actionable through a durable journal and backup location, while normal thrown failures are rolled back automatically.
+- Existing command summaries are consumed externally, so compatibility is additive rather than a wholesale schema replacement.
+
+### Sequencing
+
+Build the shared transaction seam first, integrate directory publication for build, then source-file transactions for init/sync/migrate, and finally align CLI manifests and docs.
+
+---
+
+## Implementation Units
+
+### U1. Shared filesystem transaction and recovery contract
+
+- **Goal:** Provide reusable staged directory publication, file-manifest application, rollback, recovery journaling, and failure-injection seams.
+- **Requirements:** R1, R4, R6, R7.
+- **Dependencies:** None.
+- **Files:** `src/fs-transaction.ts`, `tests/fs-transaction.test.ts`.
+- **Approach:** Stage beside the destination, validate before commit, move existing state to a unique backup, publish by rename, restore on any thrown publish error, and retain a versioned journal only when automatic recovery cannot finish.
+- **Execution note:** Start with failure tests for pre-publish, post-backup, and restore paths.
+- **Patterns to follow:** Conservative path validation in `src/generators/index.ts`; plan/apply separation in `src/cli/agent.ts` and `src/cli/codex-apply.ts`.
+- **Test scenarios:** New destination publish; existing destination replacement; validation failure; failure after backup move; rollback failure retaining journal; same-parent staging guarantee; no stale temporary state after success.
+- **Verification:** The helper proves exact before/after trees and recovery metadata under injected failures.
+
+### U2. Atomic staged build publication
+
+- **Goal:** Keep existing `dist` untouched until every selected generator and bundle validation succeeds.
+- **Requirements:** R2, R4, R6, R8; AE1, AE5.
+- **Dependencies:** U1.
+- **Files:** `src/generators/index.ts`, `tests/build.test.ts`, `tests/build-cli.test.ts`.
+- **Approach:** Generate against a staging `outDir`, validate that staged tree using the existing bundle checker, then publish it through U1. Preserve `clean: false` semantics by seeding the stage from current output.
+- **Execution note:** Add characterization for selected targets and `clean: false` before changing publication.
+- **Patterns to follow:** Existing generator fan-out and `assertGeneratedBundlesCurrent` validation.
+- **Test scenarios:** Generator failure preserves prior dist; validator failure preserves prior dist; successful build replaces stale files; selected targets and clean behavior remain compatible; publication failure restores prior dist.
+- **Verification:** Targeted build suites pass and byte-level tree snapshots prove failure atomicity.
+
+### U3. Atomic init and sync manifests
+
+- **Goal:** Apply scaffold and refresh mutations through staged validation and one rollback-capable manifest while preserving custom content and refusing ambiguous renames.
+- **Requirements:** R1, R3, R4, R5, R7, R8; AE2, AE3, AE4.
+- **Dependencies:** U1.
+- **Files:** `src/cli/init-from-mcp.ts`, `src/cli/sync-from-mcp.ts`, `src/cli/index.ts`, `tests/init-from-mcp.test.ts`, `tests/sync-from-mcp.test.ts`, `tests/cli-phase2.test.ts`, `tests/cli-init-json.test.ts`, `tests/cli-sync.test.ts`.
+- **Approach:** Extend scaffold plans with deletes/conflicts where relevant, validate the staged project before final apply, apply through U1, and share one additive mutation-summary shape between dry-run and apply. Detect rename ties and occupied destinations before any final write.
+- **Execution note:** Preserve current JSON keys exactly and test new fields as additive.
+- **Patterns to follow:** Existing `planMcpScaffold`, mixed-content markers, managed-file metadata, and sync dry-run clone.
+- **Test scenarios:** Mid-write failure rollback; lint/validation failure before apply; dry-run/apply manifest parity; custom-section preservation; delete/rename reporting; ambiguous rename refusal; collision with user-owned destination; saved-agent invalidation rollback.
+- **Verification:** Init/sync targeted suites prove both compatibility and exact failure-state preservation.
+
+### U4. Atomic migrate planning and apply
+
+- **Goal:** Give migrate a dry-run/conflict manifest and prevent partial canonical projects when parsing, copying, sanitizing, or metadata generation fails.
+- **Requirements:** R1, R3, R4, R5, R7, R8; AE4, AE5.
+- **Dependencies:** U1.
+- **Files:** `src/cli/migrate.ts`, `src/cli/index.ts`, `tests/migrate.test.ts`.
+- **Approach:** Split migrate into plan/stage and apply phases, record every destination action, surface occupied-path conflicts conservatively, validate staged config/metadata, then publish the manifest through U1.
+- **Execution note:** Characterize existing migration output before extraction because this module carries many host-specific preservation rules.
+- **Patterns to follow:** Current detection/parsing helpers and existing migration fixture matrix.
+- **Test scenarios:** Dry-run writes nothing; dry-run/apply parity; config collision; nested destination collision; injected copy/sanitize/metadata failure; publication rollback; current host-specific migration fixtures remain unchanged.
+- **Verification:** The migrate suite passes with new transaction cases and rebuilt migrated output remains loadable/buildable.
+
+### U5. CLI/docs truth and recovery guidance
+
+- **Goal:** Keep public command contracts, planning truth, and recovery instructions aligned with the shipped behavior.
+- **Requirements:** R3, R7, R8.
+- **Dependencies:** U2, U3, U4.
+- **Files:** `src/cli/index.ts`, `docs/start-here.md`, `docs/todo/queue.md`, `docs/todo/master-backlog.md`, `docs/roadmap.md`.
+- **Approach:** Document atomic authoring/build guarantees and explicit interruption bounds; update only current-truth sections and avoid unrelated roadmap reprioritization.
+- **Test scenarios:** CLI JSON snapshots/expectations retain existing fields and include the versioned additive mutation object; human output names conflicts and recovery actions.
+- **Verification:** Docs agree with tested behavior and Linear closeout links the plan, PR, validation, and residual risks.
+
+---
+
+## Verification Contract
+
+| Gate | Coverage | Done signal |
+|---|---|---|
+| Atomic helper tests | U1 | Failure phases restore exact original trees and success leaves no recovery residue. |
+| Build tests | U2 | Generator, validation, and publication failures preserve prior `dist`; normal output remains compatible. |
+| Init/sync/migrate tests | U3, U4 | Dry-run parity, conflicts, custom preservation, and rollback scenarios pass. |
+| `npm run typecheck` | U1-U5 | No TypeScript errors. |
+| `npm run build` | U1-U5 | Runtime bundle and declarations build successfully. |
+| Serial `npm test` | U1-U5 | Full official suite passes under the worktree lock with no concurrent fixture-heavy run. |
+| CE reliability and code review | U1-U5 | All actionable findings are fixed and validation reruns green. |
+
+---
+
+## Definition of Done
+
+- All four PLUXX-318 command paths stage before publishing and preserve original final paths on injected failure.
+- Dry-run manifests accurately predict apply actions and surface conflicts without writing.
+- Ambiguous renames and destination collisions never silently overwrite user content.
+- Existing JSON summaries remain compatible with additive versioned mutation detail.
+- Cross-device behavior is avoided or explicitly bounded, and interrupted-operation recovery information is actionable.
+- Targeted suites, typecheck, build, and the full serial `npm test` pass.
+- Repo docs and PLUXX-318/PLUXX-312 Linear truth are updated.
+- A focused PR is pushed, linked, labeled `ai:autofix-enabled`, and has green CI with actionable review feedback resolved.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Last updated: 2026-06-27
+Last updated: 2026-07-12
 
 ## Doc Links
 
@@ -75,6 +75,8 @@ The current next ship decision is to make Codex companion apply and verify first
 See [docs/orchid/decisions/2026-06-26-pluxx-next-ship-review.md](./orchid/decisions/2026-06-26-pluxx-next-ship-review.md).
 
 The follow-on slice is install ownership tracking for conservative uninstall, prune, reinstall, and "what did Pluxx touch?" diagnostics.
+
+The v0.1.31 audit remediation also closes a core authoring-safety gap: `init`, `sync`, `migrate`, and `build` now stage and validate mutations before publication, restore prior state after thrown apply failures, retain recovery metadata for unresolved interruptions, and expose additive versioned mutation/conflict manifests.
 
 ## Current Priority Order
 

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -1,6 +1,6 @@
 # Start Here
 
-Last updated: 2026-06-27
+Last updated: 2026-07-12
 
 ## Doc Links
 
@@ -164,6 +164,11 @@ The repo already proves a lot.
   - `docs/core-four-primitive-proof-ledger.md`
 - the core-four compiler work is materially shipped
 - `pluxx build` checks generated manifests and package outputs for source version drift and missing referenced bundle files before publish
+- authoring and build mutations now stage before publication:
+  - `build` validates a same-filesystem staged output tree before replacing `dist`, restoring the prior tree if publication fails
+  - `init`, `sync`, and `migrate` apply versioned create/update/delete/rename/conflict manifests through rollback-capable file transactions
+  - dry-run JSON remains backward compatible and adds a versioned `mutation` object; ambiguous sync renames and occupied init/migrate destinations are reported as conflicts instead of guessed or overwritten
+  - hard process interruptions retain recovery journals/backups when automatic rollback cannot finish
 - `verify-install` exists and is tested
 - consumer-side `doctor --consumer` exists and is tested
 - `migrate`, `eval`, and `mcp proxy --record/--replay` are shipped

--- a/docs/todo/master-backlog.md
+++ b/docs/todo/master-backlog.md
@@ -1,6 +1,6 @@
 # Master Backlog
 
-Last updated: 2026-06-27
+Last updated: 2026-07-12
 
 This is the most complete repo-native backlog for Pluxx.
 
@@ -83,6 +83,10 @@ Any person or agent should be able to enter the repo and answer:
 ### 1. Product clarity and front-door coherence
 
 - [~] Keep [start-here.md](../start-here.md), [queue.md](./queue.md), this file, and Linear aligned
+- [x] Make `init`, `sync`, `migrate`, and `build` mutations atomic and recoverable:
+  - stage and validate before publishing final source or `dist` paths
+  - roll back thrown mid-apply failures and retain actionable recovery metadata for unresolved interruptions
+  - expose additive versioned mutation manifests and refuse ambiguous rename or occupied-destination conflicts
 - [~] Keep [docs/release-distribution-proof-map.md](../release-distribution-proof-map.md) current as the short ship-today vs release-gap source of truth:
   - primary release-smoked fronts are Claude Code, Cursor, Codex, and OpenCode
   - Gemini CLI remains a beta generator target until it has release-smoke and installer parity

--- a/docs/todo/queue.md
+++ b/docs/todo/queue.md
@@ -1,6 +1,6 @@
 # Pluxx Queue
 
-Last updated: 2026-06-27
+Last updated: 2026-07-12
 
 ## Doc Links
 
@@ -76,6 +76,11 @@ The initial author-once hardening tranche is also materially done.
   - installed-bundle regression coverage now explicitly catches missing OpenCode host entry files, missing synced OpenCode skills, and stale installed OpenCode package versions
 - `pluxx test --install` verifies installed consumer bundle state after install, not just `dist/`
 - `pluxx build` now checks generated manifests and package outputs for source version drift and missing referenced bundle files before release
+- atomic authoring/build publication is now implemented for `init`, `sync`, `migrate`, and `build`:
+  - staged validation keeps final source and `dist` paths unchanged until commit
+  - thrown apply failures restore the prior state; unresolved hard-interruption recovery retains a journal and backup location
+  - additive versioned mutation manifests cover creates, updates, deletes, renames, and conflicts without removing existing JSON summary fields
+  - ambiguous sync renames and occupied init/migrate destinations fail conservatively
 - OpenCode translation is now more honestly native:
   - agent output prefers `permission` over deprecated legacy `tools`
   - native `skill` / `task` permission keys are modeled as real host surfaces

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -90,6 +90,7 @@ import {
   type InstalledMcpHost,
 } from './discover-installed-mcp'
 import { buildHostTargetSelection, detectHostFamilies } from '../host-detection'
+import { applyFileMutations, createMutationManifest } from '../fs-transaction'
 
 const CLI_PACKAGE_NAME = '@orchid-labs/pluxx'
 const rawArgs = process.argv.slice(2)
@@ -160,6 +161,7 @@ interface InitFromMcpSummary {
   notes: string[]
   nextSteps: string[]
   dryRun?: boolean
+  mutation: ReturnType<typeof createMutationManifest>
 }
 
 interface AutopilotSummary {
@@ -1228,6 +1230,7 @@ function buildInitSummary(input: {
   ingestion?: AgentContextIngestionArtifact
   approveMcpTools?: boolean
   dryRun?: boolean
+  conflicts?: Array<{ path: string; reason: string }>
 }): InitFromMcpSummary {
   const installTarget = input.targets[0]
   const installCommand = input.hookMode === 'safe'
@@ -1290,6 +1293,13 @@ function buildInitSummary(input: {
     notes,
     nextSteps,
     dryRun: input.dryRun,
+    mutation: createMutationManifest({
+      files: [
+        ...input.createdFiles.map((path) => ({ path, action: 'create' as const })),
+        ...input.updatedFiles.map((path) => ({ path, action: 'update' as const })),
+      ],
+      conflicts: input.conflicts,
+    }),
   }
 }
 
@@ -1563,13 +1573,8 @@ ${mcpBlock}${brandBlock}
 })
 `
 
-    // Write config
-    await writeTextFile(resolve(process.cwd(), 'pluxx.config.ts'), template)
-
-    // Create skills directory with a starter SKILL.md
+    // Create the starter skill content, then publish both files as one transaction.
     const skillDir = `skills/${skillName}`
-    await mkdir(skillDir, { recursive: true })
-
     const skillContent = `---
 name: ${JSON.stringify(skillName)}
 description: ${JSON.stringify(description || `A starter skill for ${skillName}`)}
@@ -1589,8 +1594,23 @@ Describe how agents should use this skill.
 Example prompt or command here
 \`\`\`
 `
-
-    await writeTextFile(resolve(process.cwd(), `${skillDir}/SKILL.md`), skillContent)
+    const initDestinations = ['pluxx.config.ts', `${skillDir}/SKILL.md`]
+    const occupied = initDestinations.filter((path) => existsSync(resolve(process.cwd(), path)))
+    if (occupied.length > 0) {
+      throw new Error(`Init conflicts require resolution before apply: ${occupied.join(', ')}`)
+    }
+    applyFileMutations(process.cwd(), [
+      {
+        path: 'pluxx.config.ts',
+        action: 'create',
+        content: template,
+      },
+      {
+        path: `${skillDir}/SKILL.md`,
+        action: 'create',
+        content: skillContent,
+      },
+    ])
 
     console.log('')
     console.log('  Created:')
@@ -1940,12 +1960,16 @@ ${formatAuthRequiredMessage('init', retryError, source)}`)
     const contextArtifactFiles = await planInitContextArtifactFiles(process.cwd(), sourcedContextPack)
     createdFiles.push(...contextArtifactFiles.filter((file) => file.action === 'create').map((file) => file.relativePath))
     updatedFiles.push(...contextArtifactFiles.filter((file) => file.action === 'update').map((file) => file.relativePath))
+    const initConflicts = [...plan.files, ...contextArtifactFiles]
+      .filter((file) => file.action === 'update')
+      .filter((file) => !file.relativePath.endsWith('.md') && !file.relativePath.startsWith('.pluxx/'))
+      .map((file) => ({ path: file.relativePath, reason: 'destination-exists' }))
 
     if (!runtime.dryRun) {
-      await applyMcpScaffoldPlan(process.cwd(), plan)
-      for (const file of contextArtifactFiles) {
-        await writeTextFile(resolve(process.cwd(), file.relativePath), file.content)
+      if (initConflicts.length > 0) {
+        throw new Error(`Init conflicts require resolution before apply: ${initConflicts.map((conflict) => conflict.path).join(', ')}`)
       }
+      await applyMcpScaffoldPlan(process.cwd(), plan, {}, contextArtifactFiles)
     }
 
     const lintResult = runtime.dryRun
@@ -1973,6 +1997,7 @@ ${formatAuthRequiredMessage('init', retryError, source)}`)
       ingestion: sourcedContextPack?.ingestion,
       approveMcpTools: options.approveMcpTools,
       dryRun: runtime.dryRun,
+      conflicts: initConflicts,
     })
 
     if (options.jsonOutput) {
@@ -1991,6 +2016,9 @@ ${formatAuthRequiredMessage('init', retryError, source)}`)
     }
     if (summary.updatedFiles.length > 0) {
       clack.log.info(`Update: ${summary.updatedFiles.join(', ')}`)
+    }
+    if (summary.mutation.conflicts.length > 0) {
+      clack.log.warn(`Conflicts: ${summary.mutation.conflicts.map((conflict) => `${conflict.path} (${conflict.reason})`).join(', ')}`)
     }
 
     if (!runtime.dryRun) {
@@ -2134,6 +2162,15 @@ async function runSync() {
     printJson({
       ...result,
       dryRun: runtime.dryRun,
+      mutation: createMutationManifest({
+        files: [
+          ...result.addedFiles.map((path) => ({ path, action: 'create' as const })),
+          ...result.updatedFiles.map((path) => ({ path, action: 'update' as const })),
+          ...result.removedFiles.map((path) => ({ path, action: 'delete' as const })),
+        ],
+        renames: result.renamedFiles,
+        conflicts: result.conflicts,
+      }),
     })
     return
   }
@@ -3466,14 +3503,29 @@ async function runUninstall() {
 async function runMigrate() {
   const inputPath = args[1]
   if (!inputPath) {
-    console.error('Usage: pluxx migrate <path>')
+    console.error('Usage: pluxx migrate <path> [--dry-run] [--json]')
     console.error('')
     console.error('  Import an existing single-platform plugin into a pluxx.config.ts.')
     console.error('  Pass the path to a plugin directory containing .claude-plugin/,')
     console.error('  .cursor-plugin/, .codex-plugin/, or a package.json with @opencode-ai/plugin.')
     process.exit(1)
   }
-  await migrate(inputPath)
+  const summary = await migrate(inputPath, {
+    dryRun: runtime.dryRun,
+    quiet: runtime.jsonOutput || runtime.quiet,
+  })
+  if (runtime.jsonOutput) {
+    printJson(summary)
+  } else if (runtime.dryRun && !runtime.quiet) {
+    console.log('Dry run: planned migration changes')
+    console.log(`  Create: ${summary.mutation.creates.length}`)
+    console.log(`  Update: ${summary.mutation.updates.length}`)
+    console.log(`  Delete: ${summary.mutation.deletes.length}`)
+    console.log(`  Conflicts: ${summary.mutation.conflicts.length}`)
+    for (const conflict of summary.mutation.conflicts) {
+      console.log(`    ! ${conflict.path}: ${conflict.reason}`)
+    }
+  }
 }
 
 async function runMcp() {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2162,15 +2162,6 @@ async function runSync() {
     printJson({
       ...result,
       dryRun: runtime.dryRun,
-      mutation: createMutationManifest({
-        files: [
-          ...result.addedFiles.map((path) => ({ path, action: 'create' as const })),
-          ...result.updatedFiles.map((path) => ({ path, action: 'update' as const })),
-          ...result.removedFiles.map((path) => ({ path, action: 'delete' as const })),
-        ],
-        renames: result.renamedFiles,
-        conflicts: result.conflicts,
-      }),
     })
     return
   }

--- a/src/cli/init-from-mcp.ts
+++ b/src/cli/init-from-mcp.ts
@@ -12,6 +12,7 @@ import type {
 import { collectUserConfigEntries } from '../user-config'
 import { collectNativeMcpAuthUserConfigEntries } from '../mcp-native-overrides'
 import { planTextFileAction, readTextFileIfExists, writeTextFile } from '../text-files'
+import { applyFileMutations, type MutationHooks } from '../fs-transaction'
 
 export interface McpScaffoldOptions {
   rootDir: string
@@ -345,15 +346,23 @@ export async function writeMcpScaffold(options: McpScaffoldOptions): Promise<Mcp
   }
 }
 
-export async function applyMcpScaffoldPlan(rootDir: string, plan: McpScaffoldPlan): Promise<void> {
-  for (const file of plan.files) {
-    const filePath = resolve(rootDir, file.relativePath)
-    const parentDir = file.relativePath.split('/').slice(0, -1).join('/')
-    if (parentDir) {
-      await mkdir(resolve(rootDir, parentDir), { recursive: true })
-    }
-    await writeTextFile(filePath, file.content)
-  }
+export async function applyMcpScaffoldPlan(
+  rootDir: string,
+  plan: McpScaffoldPlan,
+  hooks: MutationHooks = {},
+  additionalFiles: McpScaffoldPlannedFile[] = [],
+): Promise<void> {
+  applyFileMutations(
+    rootDir,
+    [...plan.files, ...additionalFiles]
+      .filter((file) => file.action !== 'unchanged')
+      .map((file) => ({
+        path: file.relativePath,
+        action: file.action as 'create' | 'update',
+        content: file.content,
+      })),
+    hooks,
+  )
 }
 
 export async function planMcpScaffold(options: McpScaffoldOptions): Promise<McpScaffoldPlan> {

--- a/src/cli/migrate.ts
+++ b/src/cli/migrate.ts
@@ -1,5 +1,6 @@
 import { basename, dirname, relative, resolve } from 'path'
-import { existsSync, readdirSync, mkdirSync, cpSync, readFileSync, writeFileSync } from 'fs'
+import { existsSync, readdirSync, mkdirSync, mkdtempSync, cpSync, readFileSync, readlinkSync, rmSync, statSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
 import {
   MCP_SCAFFOLD_METADATA_PATH,
   MCP_TAXONOMY_PATH,
@@ -16,6 +17,15 @@ import { getCanonicalSkillMetadata, parseSkillMarkdown, readCanonicalSkillFiles,
 import { buildNativeMcpPlatformOverrides } from '../mcp-native-overrides'
 import { parseTomlValue, stripTomlComment } from '../toml-lite'
 import { writeTextFile } from '../text-files'
+import {
+  applyFileMutations,
+  copyProjectForStaging,
+  createMutationManifest,
+  readFileMutation,
+  type FileMutation,
+  type MutationHooks,
+  type MutationManifest,
+} from '../fs-transaction'
 
 type DetectedPlatform = 'claude-code' | 'cursor' | 'codex' | 'opencode'
 
@@ -1731,6 +1741,7 @@ function copyDirectories(
   outputDir: string,
   sourcePaths: CanonicalSourcePaths,
   passthrough: string[],
+  log: (message: string) => void,
 ): string[] {
   const copied: string[] = []
   const toCopy = ['skills', 'commands', 'agents', 'scripts', 'assets'] as const
@@ -1742,7 +1753,7 @@ function copyDirectories(
     const src = resolve(pluginDir, normalizedSource)
     const dest = resolve(outputDir, dir)
     if (existsSync(dest)) {
-      console.log(`  skip ./${dir}/ (already exists)`)
+      log(`  skip ./${dir}/ (already exists)`)
       continue
     }
     const copiedCodexAgents = dir === 'agents' && normalizedSource === '.codex/agents'
@@ -1762,7 +1773,7 @@ function copyDirectories(
     const src = resolve(pluginDir, normalized)
     const dest = resolve(outputDir, normalized)
     if (existsSync(dest)) {
-      console.log(`  skip ./${normalized}/ (already exists)`)
+      log(`  skip ./${normalized}/ (already exists)`)
       continue
     }
     cpSync(src, dest, { recursive: true })
@@ -2048,57 +2059,173 @@ function mergePlatformOverrideMaps(
 
 // ── Main Migrate Function ───────────────────────────────────────
 
-export async function migrate(inputPath: string): Promise<void> {
-  const pluginDir = resolve(inputPath)
-  const outputDir = process.cwd()
+export interface MigrateOptions {
+  dryRun?: boolean
+  quiet?: boolean
+  mutationHooks?: MutationHooks
+}
 
-  if (!existsSync(pluginDir)) {
-    console.error(`Error: Path does not exist: ${pluginDir}`)
-    process.exit(1)
+export interface MigrateSummary {
+  platform?: DetectedPlatform
+  warnings: string[]
+  dryRun: boolean
+  mutation: MutationManifest
+}
+
+const MIGRATE_SNAPSHOT_IGNORES = new Set(['.git', 'node_modules', 'dist'])
+
+function snapshotFiles(rootDir: string, currentDir = rootDir): string[] {
+  if (!existsSync(currentDir)) return []
+  const files: string[] = []
+  for (const entry of readdirSync(currentDir, { withFileTypes: true })) {
+    if (currentDir === rootDir && MIGRATE_SNAPSHOT_IGNORES.has(entry.name)) continue
+    const absolutePath = resolve(currentDir, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...snapshotFiles(rootDir, absolutePath))
+    } else if (entry.isFile()) {
+      files.push(relative(rootDir, absolutePath))
+    }
+  }
+  return files.sort()
+}
+
+function snapshotSymlinks(rootDir: string, currentDir = rootDir): Map<string, string> {
+  if (!existsSync(currentDir)) return new Map()
+  const links = new Map<string, string>()
+  for (const entry of readdirSync(currentDir, { withFileTypes: true })) {
+    if (currentDir === rootDir && MIGRATE_SNAPSHOT_IGNORES.has(entry.name)) continue
+    const absolutePath = resolve(currentDir, entry.name)
+    if (entry.isDirectory()) {
+      for (const [path, target] of snapshotSymlinks(rootDir, absolutePath)) links.set(path, target)
+    } else if (entry.isSymbolicLink()) {
+      links.set(relative(rootDir, absolutePath), readlinkSync(absolutePath))
+    }
+  }
+  return links
+}
+
+function planStagedFileMutations(rootDir: string, stagedRoot: string): FileMutation[] {
+  const candidates = new Set([...snapshotFiles(rootDir), ...snapshotFiles(stagedRoot)])
+  return [...candidates].flatMap((path) => {
+    const currentPath = resolve(rootDir, path)
+    const stagedPath = resolve(stagedRoot, path)
+    const currentExists = existsSync(currentPath)
+    const stagedExists = existsSync(stagedPath)
+    if (!currentExists && !stagedExists) return []
+    if (currentExists && stagedExists) {
+      if (!statSync(currentPath).isFile() || !statSync(stagedPath).isFile()) return []
+      if (readFileSync(currentPath).equals(readFileSync(stagedPath))) return []
+    }
+    return [readFileMutation(rootDir, stagedRoot, path)]
+  })
+}
+
+export async function migrate(inputPath: string, options: MigrateOptions = {}): Promise<MigrateSummary> {
+  const outputDir = process.cwd()
+  const configPath = resolve(outputDir, 'pluxx.config.ts')
+  if (existsSync(configPath)) {
+    const conflict = { path: 'pluxx.config.ts', reason: 'destination-exists' }
+    if (options.dryRun) {
+      return {
+        warnings: [],
+        dryRun: true,
+        mutation: createMutationManifest({ conflicts: [conflict] }),
+      }
+    }
+    throw new Error(`pluxx.config.ts already exists in ${outputDir}. Remove it first or run from a different directory.`)
   }
 
-  console.log(`Scanning ${pluginDir} ...`)
+  const tempRoot = mkdtempSync(resolve(tmpdir(), 'pluxx-migrate-stage-'))
+  const stagedRoot = resolve(tempRoot, 'project')
+  try {
+    if (existsSync(outputDir)) {
+      copyProjectForStaging(outputDir, stagedRoot)
+    } else {
+      mkdirSync(stagedRoot, { recursive: true })
+    }
+    const messages: string[] = []
+    const log = (message: string) => {
+      messages.push(message)
+      if (!options.quiet) console.log(message)
+    }
+    const result = await migrateInPlace(inputPath, stagedRoot, log)
+    const mutations = planStagedFileMutations(outputDir, stagedRoot)
+    const destinationConflicts = messages.flatMap((message) => {
+      const match = message.match(/^\s*skip \.\/(.+?)(?:\/)? \(already exists\)$/)
+      if (!match) return []
+      const path = match[1].replace(/^\.\//, '')
+      return existsSync(resolve(outputDir, path)) ? [{ path, reason: 'destination-exists' }] : []
+    })
+    const currentLinks = snapshotSymlinks(outputDir)
+    const stagedLinks = snapshotSymlinks(stagedRoot)
+    const symlinkConflicts = [...new Set([...currentLinks.keys(), ...stagedLinks.keys()])]
+      .filter((path) => currentLinks.get(path) !== stagedLinks.get(path))
+      .map((path) => ({ path, reason: 'symbolic-link-mutation-not-supported' }))
+    const conflicts = [...destinationConflicts, ...symlinkConflicts]
+    const mutation = createMutationManifest({ files: mutations, conflicts })
+    if (conflicts.length > 0 && !options.dryRun) {
+      throw new Error(`Migration conflicts require resolution before apply: ${conflicts.map((conflict) => conflict.path).join(', ')}`)
+    }
+    if (!options.dryRun) {
+      applyFileMutations(outputDir, mutations, options.mutationHooks)
+    }
+    return {
+      platform: result.platform,
+      warnings: result.warnings,
+      dryRun: options.dryRun ?? false,
+      mutation,
+    }
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+}
+
+async function migrateInPlace(
+  inputPath: string,
+  outputDir: string,
+  log: (message: string) => void,
+): Promise<MigrateResult> {
+  const pluginDir = resolve(inputPath)
+
+  if (!existsSync(pluginDir)) {
+    throw new Error(`Path does not exist: ${pluginDir}`)
+  }
+
+  log(`Scanning ${pluginDir} ...`)
 
   // 1. Detect platform
   const detection = detectPlatform(pluginDir)
   if (!detection) {
-    console.error('Error: Could not detect plugin platform.')
-    console.error('Expected one of:')
-    console.error('  .claude-plugin/plugin.json')
-    console.error('  or a manifest-less Claude plugin with CLAUDE.md')
-    console.error('  .cursor-plugin/plugin.json')
-    console.error('  .codex-plugin/plugin.json')
-    console.error('  package.json with @opencode-ai/plugin dependency')
-    process.exit(1)
+    throw new Error('Could not detect plugin platform. Expected .claude-plugin/plugin.json, CLAUDE.md, .cursor-plugin/plugin.json, .codex-plugin/plugin.json, or package.json with @opencode-ai/plugin.')
   }
 
-  console.log(`Detected: ${detection.platform} plugin`)
+  log(`Detected: ${detection.platform} plugin`)
 
   // 2. Parse manifest
   const manifest = parseManifest(detection)
-  console.log(`  name: ${manifest.name ?? '(none)'}`)
-  console.log(`  version: ${manifest.version ?? '(none)'}`)
+  log(`  name: ${manifest.name ?? '(none)'}`)
+  log(`  version: ${manifest.version ?? '(none)'}`)
 
   // 3. Parse MCP
   const parsedMcp = parseMcp(pluginDir, detection)
   const mcp = parsedMcp.servers
   const mcpCount = Object.keys(mcp).length
   if (mcpCount > 0) {
-    console.log(`  mcp servers: ${Object.keys(mcp).join(', ')}`)
+    log(`  mcp servers: ${Object.keys(mcp).join(', ')}`)
   }
 
   // 4. Parse hooks
   const hooks = parseHooks(pluginDir, detection)
   const hookCount = Object.keys(hooks).length
   if (hookCount > 0) {
-    console.log(`  hooks: ${Object.keys(hooks).join(', ')}`)
+    log(`  hooks: ${Object.keys(hooks).join(', ')}`)
   }
 
   // 5. Find instructions
   const instructionSources = findInstructionSources(pluginDir, detection)
   const instructions = instructionSources.primary
   if (instructions) {
-    console.log(`  instructions: ${instructions}`)
+    log(`  instructions: ${instructions}`)
   }
   if (instructionSources.platformOverrides) {
     manifest.platforms = mergePlatformOverrideMaps(manifest.platforms, instructionSources.platformOverrides)
@@ -2113,7 +2240,7 @@ export async function migrate(inputPath: string): Promise<void> {
         rules: cursorRules,
       },
     }
-    console.log(`  cursor rules: ${cursorRules.length}`)
+    log(`  cursor rules: ${cursorRules.length}`)
   }
   if (openCodeDistributionSources.platformOverrides) {
     manifest.platforms = mergePlatformOverrideMaps(manifest.platforms, openCodeDistributionSources.platformOverrides)
@@ -2132,13 +2259,13 @@ export async function migrate(inputPath: string): Promise<void> {
     .map(([, sourcePath]) => stripRelativePrefix(sourcePath!))
     .concat(passthrough.map((entry) => entry.replace(/^\.\//, '').replace(/\/$/, '')))
   if (dirNames.length > 0) {
-    console.log(`  directories: ${dirNames.join(', ')}`)
+    log(`  directories: ${dirNames.join(', ')}`)
   }
   if (persistedSkills.length > 0) {
-    console.log(`  migrated skills: ${persistedSkills.map((skill) => skill.dirName).join(', ')}`)
+    log(`  migrated skills: ${persistedSkills.map((skill) => skill.dirName).join(', ')}`)
   }
   if (inferredPermissions.permissions?.allow?.length) {
-    console.log(`  inferred permissions: ${inferredPermissions.permissions.allow.join(', ')}`)
+    log(`  inferred permissions: ${inferredPermissions.permissions.allow.join(', ')}`)
   }
 
   const codexAgentWarnings = sourcePaths.agents
@@ -2181,18 +2308,16 @@ export async function migrate(inputPath: string): Promise<void> {
   const configPath = resolve(outputDir, 'pluxx.config.ts')
 
   if (existsSync(configPath)) {
-    console.error(`\nError: pluxx.config.ts already exists in ${outputDir}`)
-    console.error('Remove it first or run from a different directory.')
-    process.exit(1)
+    throw new Error(`pluxx.config.ts already exists in ${outputDir}. Remove it first or run from a different directory.`)
   }
 
   await writeTextFile(configPath, configContent)
-  console.log(`\nGenerated pluxx.config.ts`)
+  log(`\nGenerated pluxx.config.ts`)
 
   // 9. Copy directories
-  const copied = copyDirectories(pluginDir, outputDir, sourcePaths, passthrough)
+  const copied = copyDirectories(pluginDir, outputDir, sourcePaths, passthrough, log)
   if (copied.length > 0) {
-    console.log(`Copied: ${copied.map(d => `./${d}/`).join(', ')}`)
+    log(`Copied: ${copied.map(d => `./${d}/`).join(', ')}`)
   }
 
   sanitizeMigratedSkillFrontmatter(outputDir)
@@ -2204,16 +2329,21 @@ export async function migrate(inputPath: string): Promise<void> {
     if (!existsSync(destInstr)) {
       const content = readFileSync(srcInstr, 'utf-8')
       await writeTextFile(destInstr, content)
-      console.log(`Copied: ${instructions}`)
+      log(`Copied: ${instructions}`)
+    } else {
+      log(`  skip ./${instructions} (already exists)`)
     }
   }
   for (const copiedPath of result.extraCopyPaths) {
     const srcPath = resolve(pluginDir, copiedPath)
     const destPath = resolve(outputDir, copiedPath)
-    if (existsSync(destPath)) continue
+    if (existsSync(destPath)) {
+      log(`  skip ./${copiedPath} (already exists)`)
+      continue
+    }
     const content = readFileSync(srcPath, 'utf-8')
     await writeTextFile(destPath, content)
-    console.log(`Copied: ${copiedPath}`)
+    log(`Copied: ${copiedPath}`)
   }
 
   // 11. Create synthetic migration metadata/taxonomy so Agent Mode and evals work.
@@ -2233,20 +2363,21 @@ export async function migrate(inputPath: string): Promise<void> {
     ...(result.compilerIntent ? [PLUXX_COMPILER_INTENT_PATH] : []),
     MCP_SCAFFOLD_METADATA_PATH,
   ]
-  console.log(`Generated: ${generatedPluxxFiles.join(', ')}`)
+  log(`Generated: ${generatedPluxxFiles.join(', ')}`)
 
   if (result.warnings.length > 0) {
-    console.log('')
-    console.log('Migration warnings:')
+    log('')
+    log('Migration warnings:')
     for (const warning of result.warnings) {
-      console.log(`  - ${warning}`)
+      log(`  - ${warning}`)
     }
   }
 
-  console.log('')
-  console.log('Migration complete! Next steps:')
-  console.log('  1. Review pluxx.config.ts and fill in any TODOs')
-  console.log('  2. Run: pluxx doctor')
-  console.log('  3. Run: pluxx eval')
-  console.log('  4. Run: pluxx build')
+  log('')
+  log('Migration complete! Next steps:')
+  log('  1. Review pluxx.config.ts and fill in any TODOs')
+  log('  2. Run: pluxx doctor')
+  log('  3. Run: pluxx eval')
+  log('  4. Run: pluxx build')
+  return result
 }

--- a/src/cli/sync-from-mcp.ts
+++ b/src/cli/sync-from-mcp.ts
@@ -1,7 +1,16 @@
-import { cpSync, existsSync, mkdtempSync, readFileSync, rmSync, readdirSync, rmdirSync, writeFileSync } from 'fs'
+import { existsSync, mkdtempSync, readFileSync, rmSync, readdirSync, rmdirSync, writeFileSync } from 'fs'
 import { dirname, isAbsolute, relative, resolve } from 'path'
 import { z } from 'zod'
 import { tmpdir } from 'os'
+import {
+  applyFileMutations,
+  copyProjectForStaging,
+  createMutationManifest,
+  readFileMutation,
+  type MutationConflict,
+  type MutationHooks,
+  type MutationManifest,
+} from '../fs-transaction'
 import { loadConfig } from '../config/load'
 import { introspectMcpServer, type IntrospectedMcpTool } from '../mcp/introspect'
 import { McpServerSchema, UserConfigEntrySchema, type McpServer } from '../schema'
@@ -23,6 +32,7 @@ import {
 export interface SyncFromMcpOptions {
   rootDir: string
   source?: McpServer
+  mutationHooks?: MutationHooks
 }
 
 export interface SyncFromMcpResult {
@@ -33,6 +43,8 @@ export interface SyncFromMcpResult {
   removedFiles: string[]
   preservedFiles: string[]
   renamedFiles: Array<{ from: string; to: string }>
+  conflicts: MutationConflict[]
+  mutation: MutationManifest
 }
 
 export async function readMcpScaffoldMetadata(rootDir: string): Promise<McpScaffoldMetadata> {
@@ -137,6 +149,51 @@ const McpScaffoldMetadataSchema = z.object({
 
 export async function syncFromMcp(options: SyncFromMcpOptions): Promise<SyncFromMcpResult> {
   const metadata = await readMcpScaffoldMetadata(options.rootDir)
+  const tempRoot = mkdtempSync(resolve(tmpdir(), 'pluxx-sync-stage-'))
+  const stagedRoot = resolve(tempRoot, 'project')
+
+  try {
+    copyProjectForStaging(options.rootDir, stagedRoot)
+    const result = await syncFromMcpInPlace({
+      rootDir: stagedRoot,
+      source: options.source,
+    })
+    if (result.conflicts.length > 0) return result
+
+    const stagedMetadata = await readMcpScaffoldMetadata(stagedRoot)
+    const candidatePaths = new Set([
+      ...metadata.managedFiles,
+      ...stagedMetadata.managedFiles,
+      ...AGENT_PACK_FILES,
+    ])
+    const mutations = [...candidatePaths].flatMap((path) => {
+      const currentPath = resolveWithinRoot(options.rootDir, path)
+      const stagedPath = resolveWithinRoot(stagedRoot, path)
+      const currentExists = existsSync(currentPath)
+      const stagedExists = existsSync(stagedPath)
+      if (!currentExists && !stagedExists) return []
+      if (currentExists && stagedExists) {
+        if (readFileSync(currentPath, 'utf-8') === readFileSync(stagedPath, 'utf-8')) return []
+      }
+      return [readFileMutation(options.rootDir, stagedRoot, path)]
+    })
+
+    applyFileMutations(options.rootDir, mutations, options.mutationHooks)
+    return {
+      ...result,
+      mutation: createMutationManifest({
+        files: mutations,
+        renames: result.renamedFiles,
+        conflicts: result.conflicts,
+      }),
+    }
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+}
+
+async function syncFromMcpInPlace(options: SyncFromMcpOptions): Promise<SyncFromMcpResult> {
+  const metadata = await readMcpScaffoldMetadata(options.rootDir)
   const config = await loadConfig(options.rootDir)
   const source = options.source ?? metadata.source
   const introspection = await introspectMcpServer(source)
@@ -144,6 +201,16 @@ export async function syncFromMcp(options: SyncFromMcpOptions): Promise<SyncFrom
 
   // Step 1: Detect renames between old and new tool lists
   const toolRenames = detectToolRenames(metadata.tools, introspection.tools)
+  const conflicts = detectToolRenameConflicts(metadata.tools, introspection.tools)
+  const conflictedToolNames = new Set(conflicts.flatMap((conflict) => [
+    conflict.path.replace(/^tools\//, ''),
+    ...(conflict.candidates ?? []),
+  ]))
+  for (const [oldName, newName] of toolRenames) {
+    if (conflictedToolNames.has(oldName) || conflictedToolNames.has(newName)) {
+      toolRenames.delete(oldName)
+    }
+  }
   const persistedSkills = readPersistedSkills(options.rootDir, metadata)
 
   // Step 3: Generate new scaffold
@@ -252,6 +319,16 @@ export async function syncFromMcp(options: SyncFromMcpOptions): Promise<SyncFrom
     removedFiles: removedFiles.sort(),
     preservedFiles: preservedFiles.sort(),
     renamedFiles: renamedFiles.sort((a, b) => a.from.localeCompare(b.from)),
+    conflicts,
+    mutation: createMutationManifest({
+      files: [
+        ...addedFiles.map((path) => ({ path, action: 'create' as const })),
+        ...updatedFiles.map((path) => ({ path, action: 'update' as const })),
+        ...removedFiles.map((path) => ({ path, action: 'delete' as const })),
+      ],
+      renames: renamedFiles,
+      conflicts,
+    }),
   }
 }
 
@@ -327,14 +404,55 @@ export async function planSyncFromMcp(options: SyncFromMcpOptions): Promise<Sync
   const projectDir = resolve(tempRoot, 'project')
 
   try {
-    cpSync(options.rootDir, projectDir, { recursive: true })
-    return await syncFromMcp({
+    copyProjectForStaging(options.rootDir, projectDir)
+    return await syncFromMcpInPlace({
       rootDir: projectDir,
       source: options.source,
     })
   } finally {
     rmSync(tempRoot, { recursive: true, force: true })
   }
+}
+
+export function detectToolRenameConflicts(
+  oldTools: IntrospectedMcpTool[],
+  newTools: IntrospectedMcpTool[],
+): MutationConflict[] {
+  const oldNames = new Set(oldTools.map((tool) => tool.name))
+  const newNames = new Set(newTools.map((tool) => tool.name))
+  const removedTools = oldTools.filter((tool) => !newNames.has(tool.name))
+  const addedTools = newTools.filter((tool) => !oldNames.has(tool.name))
+  const conflicts: MutationConflict[] = []
+
+  for (const oldTool of removedTools) {
+    const candidates = addedTools
+      .map((newTool) => ({ name: newTool.name, score: computeRenameScore(oldTool, newTool) }))
+      .filter((candidate) => candidate.score >= RENAME_SCORE_THRESHOLD)
+      .sort((a, b) => b.score - a.score || a.name.localeCompare(b.name))
+    if (candidates.length > 1 && candidates[0].score === candidates[1].score) {
+      conflicts.push({
+        path: `tools/${oldTool.name}`,
+        reason: 'ambiguous-rename',
+        candidates: candidates.filter((candidate) => candidate.score === candidates[0].score).map((candidate) => candidate.name),
+      })
+    }
+  }
+
+  for (const newTool of addedTools) {
+    const candidates = removedTools
+      .map((oldTool) => ({ name: oldTool.name, score: computeRenameScore(oldTool, newTool) }))
+      .filter((candidate) => candidate.score >= RENAME_SCORE_THRESHOLD)
+      .sort((a, b) => b.score - a.score || a.name.localeCompare(b.name))
+    if (candidates.length > 1 && candidates[0].score === candidates[1].score) {
+      conflicts.push({
+        path: `tools/${newTool.name}`,
+        reason: 'rename-destination-collision',
+        candidates: candidates.filter((candidate) => candidate.score === candidates[0].score).map((candidate) => candidate.name),
+      })
+    }
+  }
+
+  return conflicts.sort((a, b) => a.path.localeCompare(b.path))
 }
 
 function readPersistedSkills(rootDir: string, metadata: McpScaffoldMetadata): PersistedSkill[] {
@@ -667,6 +785,13 @@ export function formatSyncSummary(result: SyncFromMcpResult, rootDir: string): s
   if (result.renamedFiles.length > 0) {
     lines.push(`Renamed: ${result.renamedFiles.length}`)
     result.renamedFiles.forEach((rename) => lines.push(`  → ${rename.from} → ${rename.to}`))
+  }
+  if (result.conflicts.length > 0) {
+    lines.push(`Conflicts: ${result.conflicts.length}`)
+    result.conflicts.forEach((conflict) => {
+      const candidates = conflict.candidates?.length ? ` (${conflict.candidates.join(', ')})` : ''
+      lines.push(`  ! ${conflict.path}: ${conflict.reason}${candidates}`)
+    })
   }
   lines.push(`Added: ${result.addedFiles.length}`)
   result.addedFiles.forEach((file) => lines.push(`  + ${relative(rootDir, resolve(rootDir, file))}`))

--- a/src/fs-transaction.ts
+++ b/src/fs-transaction.ts
@@ -1,0 +1,379 @@
+import {
+  copyFileSync,
+  chmodSync,
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'fs'
+import { basename, dirname, isAbsolute, relative, resolve } from 'path'
+import { randomUUID } from 'crypto'
+
+export const MUTATION_MANIFEST_VERSION = 1 as const
+
+export type MutationPhase =
+  | 'staged'
+  | 'journaled'
+  | 'backup-created'
+  | 'entry-applied'
+  | 'published'
+  | 'rolled-back'
+
+export interface FileMutation {
+  path: string
+  action: 'create' | 'update' | 'delete'
+  content?: string | Uint8Array
+  mode?: number
+}
+
+export interface MutationConflict {
+  path: string
+  reason: string
+  candidates?: string[]
+}
+
+export interface MutationManifest {
+  version: typeof MUTATION_MANIFEST_VERSION
+  creates: string[]
+  updates: string[]
+  deletes: string[]
+  renames: Array<{ from: string; to: string }>
+  conflicts: MutationConflict[]
+}
+
+export interface MutationHooks {
+  injectFailure?: (phase: MutationPhase, detail?: string) => void
+}
+
+export function createMutationManifest(input: {
+  files?: FileMutation[]
+  renames?: Array<{ from: string; to: string }>
+  conflicts?: MutationConflict[]
+}): MutationManifest {
+  const files = input.files ?? []
+  return {
+    version: MUTATION_MANIFEST_VERSION,
+    creates: files.filter((entry) => entry.action === 'create').map((entry) => entry.path).sort(),
+    updates: files.filter((entry) => entry.action === 'update').map((entry) => entry.path).sort(),
+    deletes: files.filter((entry) => entry.action === 'delete').map((entry) => entry.path).sort(),
+    renames: [...(input.renames ?? [])].sort((a, b) => a.from.localeCompare(b.from)),
+    conflicts: [...(input.conflicts ?? [])].sort((a, b) => a.path.localeCompare(b.path)),
+  }
+}
+
+function resolveWithinRoot(rootDir: string, relativePath: string): string {
+  if (isAbsolute(relativePath)) {
+    throw new Error(`Mutation path must be relative to the project root: ${relativePath}`)
+  }
+  const root = resolve(rootDir)
+  const target = resolve(root, relativePath)
+  const rel = relative(root, target)
+  if (rel === '..' || rel.startsWith(`..${process.platform === 'win32' ? '\\' : '/'}`)) {
+    throw new Error(`Mutation path "${relativePath}" resolves outside the project root.`)
+  }
+  return target
+}
+
+function assertNoSymlinkComponents(rootDir: string, relativePath: string): void {
+  const root = resolve(rootDir)
+  const target = resolveWithinRoot(root, relativePath)
+  const rel = relative(root, target)
+  let current = root
+  for (const segment of rel.split(/[\\/]/).filter(Boolean)) {
+    current = resolve(current, segment)
+    if (!existsSync(current)) return
+    if (lstatSync(current).isSymbolicLink()) {
+      throw new Error(`Atomic file mutation does not support symbolic-link paths: ${relativePath}`)
+    }
+  }
+}
+
+function pruneEmptyTransactionRoot(transactionRoot: string): void {
+  const parent = dirname(transactionRoot)
+  rmSync(transactionRoot, { recursive: true, force: true })
+  try {
+    if (existsSync(parent) && statSync(parent).isDirectory()) {
+      rmdirSync(parent)
+    }
+  } catch {
+    // Another transaction or recovery record still owns the parent.
+  }
+}
+
+function pruneEmptyParents(rootDir: string, startDir: string): void {
+  const root = resolve(rootDir)
+  let current = resolve(startDir)
+  while (current !== root && relative(root, current) && !relative(root, current).startsWith('..')) {
+    if (!existsSync(current) || readdirSync(current).length > 0) return
+    rmdirSync(current)
+    current = dirname(current)
+  }
+}
+
+function assertNoPendingFileTransaction(rootDir: string): void {
+  const transactionParent = resolve(rootDir, '.pluxx', 'transactions')
+  if (!existsSync(transactionParent)) return
+  const journals = readdirSync(transactionParent, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => resolve(transactionParent, entry.name, 'journal.json'))
+    .filter(existsSync)
+  if (journals.length > 0) {
+    throw new Error(`Unfinished Pluxx mutation found. Inspect ${journals.join(', ')} and restore files from its backup directory before retrying.`)
+  }
+}
+
+export function applyFileMutations(
+  rootDir: string,
+  files: FileMutation[],
+  hooks: MutationHooks = {},
+): void {
+  if (files.length === 0) return
+
+  assertNoPendingFileTransaction(rootDir)
+
+  const seenPaths = new Set<string>()
+  for (const entry of files) {
+    assertNoSymlinkComponents(rootDir, entry.path)
+    const targetPath = resolveWithinRoot(rootDir, entry.path)
+    if (seenPaths.has(targetPath)) {
+      throw new Error(`Duplicate mutation path: ${entry.path}`)
+    }
+    seenPaths.add(targetPath)
+    const exists = existsSync(targetPath)
+    if (entry.action === 'create' && exists) {
+      throw new Error(`Create mutation destination already exists: ${entry.path}`)
+    }
+    if ((entry.action === 'update' || entry.action === 'delete') && !exists) {
+      throw new Error(`${entry.action} mutation destination does not exist: ${entry.path}`)
+    }
+    if (entry.action !== 'delete' && entry.content === undefined) {
+      throw new Error(`Missing content for ${entry.action} mutation: ${entry.path}`)
+    }
+  }
+
+  const transactionId = randomUUID()
+  const transactionRoot = resolve(rootDir, '.pluxx', 'transactions', transactionId)
+  const backupRoot = resolve(transactionRoot, 'backup')
+  const journalPath = resolve(transactionRoot, 'journal.json')
+  const applied: Array<{ entry: FileMutation; existed: boolean; backupPath?: string; originalMode?: number }> = []
+
+  assertNoSymlinkComponents(rootDir, '.pluxx/transactions')
+  mkdirSync(backupRoot, { recursive: true })
+  writeFileSync(journalPath, `${JSON.stringify({
+    version: MUTATION_MANIFEST_VERSION,
+    id: transactionId,
+    rootDir: resolve(rootDir),
+    state: 'applying',
+    backupRoot,
+    recovery: 'If this process is interrupted, restore original files from backup/ before retrying the mutation.',
+    files: files.map(({ content: _content, ...entry }) => entry),
+  }, null, 2)}\n`, 'utf-8')
+
+  try {
+    hooks.injectFailure?.('journaled', journalPath)
+    for (const entry of files) {
+      const targetPath = resolveWithinRoot(rootDir, entry.path)
+      const existed = existsSync(targetPath)
+      let backupPath: string | undefined
+      let originalMode: number | undefined
+
+      if (existed) {
+        const targetStat = lstatSync(targetPath)
+        if (!targetStat.isFile()) {
+          throw new Error(`Atomic file mutation only supports files: ${entry.path}`)
+        }
+        originalMode = targetStat.mode
+        backupPath = resolve(backupRoot, relative(resolve(rootDir), targetPath))
+        mkdirSync(dirname(backupPath), { recursive: true })
+        copyFileSync(targetPath, backupPath)
+      }
+
+      applied.push({ entry, existed, backupPath, originalMode })
+      hooks.injectFailure?.('backup-created', entry.path)
+
+      if (entry.action === 'delete') {
+        rmSync(targetPath, { force: true })
+        pruneEmptyParents(rootDir, dirname(targetPath))
+      } else {
+        mkdirSync(dirname(targetPath), { recursive: true })
+        const stagedPath = resolve(dirname(targetPath), `.${basename(targetPath)}.pluxx-${transactionId}.tmp`)
+        try {
+          writeFileSync(stagedPath, entry.content!)
+          if (entry.mode !== undefined) chmodSync(stagedPath, entry.mode)
+          hooks.injectFailure?.('staged', entry.path)
+          rmSync(targetPath, { force: true })
+          renameSync(stagedPath, targetPath)
+        } finally {
+          rmSync(stagedPath, { force: true })
+        }
+      }
+
+      hooks.injectFailure?.('entry-applied', entry.path)
+    }
+
+    pruneEmptyTransactionRoot(transactionRoot)
+  } catch (error) {
+    let rollbackError: unknown
+    try {
+      for (const item of [...applied].reverse()) {
+        const targetPath = resolveWithinRoot(rootDir, item.entry.path)
+        if (item.existed && item.backupPath) {
+          mkdirSync(dirname(targetPath), { recursive: true })
+          copyFileSync(item.backupPath, targetPath)
+          if (item.originalMode !== undefined) chmodSync(targetPath, item.originalMode)
+        } else {
+          rmSync(targetPath, { force: true })
+          pruneEmptyParents(rootDir, dirname(targetPath))
+        }
+      }
+      hooks.injectFailure?.('rolled-back')
+      pruneEmptyTransactionRoot(transactionRoot)
+    } catch (caught) {
+      rollbackError = caught
+      writeFileSync(journalPath, `${JSON.stringify({
+        version: MUTATION_MANIFEST_VERSION,
+        id: transactionId,
+        rootDir: resolve(rootDir),
+        state: 'recovery-required',
+        backupRoot,
+        failure: error instanceof Error ? error.message : String(error),
+        rollbackFailure: caught instanceof Error ? caught.message : String(caught),
+        files: files.map(({ content: _content, ...entry }) => entry),
+      }, null, 2)}\n`, 'utf-8')
+    }
+
+    const detail = rollbackError
+      ? ` Automatic rollback failed; recover from ${journalPath}.`
+      : ' Original files were restored.'
+    throw new Error(`Atomic mutation failed.${detail}`, { cause: error })
+  }
+}
+
+export function publishStagedDirectory(
+  destinationPath: string,
+  stagedPath: string,
+  hooks: MutationHooks = {},
+): void {
+  const destination = resolve(destinationPath)
+  const staged = resolve(stagedPath)
+  if (dirname(destination) !== dirname(staged)) {
+    throw new Error('Staged directory must share the destination parent to avoid cross-device publication.')
+  }
+  if (!existsSync(staged) || !statSync(staged).isDirectory()) {
+    throw new Error(`Staged directory does not exist: ${staged}`)
+  }
+
+  const pendingJournals = readdirSync(dirname(destination))
+    .filter((entry) => entry.startsWith(`.${basename(destination)}.pluxx-transaction-`) && entry.endsWith('.json'))
+    .map((entry) => resolve(dirname(destination), entry))
+  if (pendingJournals.length > 0) {
+    throw new Error(`Unfinished Pluxx directory publication found. Inspect ${pendingJournals.join(', ')} and restore its backup directory before retrying.`)
+  }
+
+  const transactionId = randomUUID()
+  const backupPath = resolve(dirname(destination), `.${basename(destination)}.pluxx-backup-${transactionId}`)
+  const journalPath = resolve(dirname(destination), `.${basename(destination)}.pluxx-transaction-${transactionId}.json`)
+  const hadDestination = existsSync(destination)
+
+  writeFileSync(journalPath, `${JSON.stringify({
+    version: MUTATION_MANIFEST_VERSION,
+    id: transactionId,
+    state: 'publishing',
+    destination,
+    staged,
+    backup: hadDestination ? backupPath : null,
+    recovery: 'If this process is interrupted, restore backup to destination before retrying publication.',
+  }, null, 2)}\n`, 'utf-8')
+
+  try {
+    hooks.injectFailure?.('journaled', journalPath)
+    if (hadDestination) {
+      renameSync(destination, backupPath)
+    }
+    hooks.injectFailure?.('backup-created', backupPath)
+    renameSync(staged, destination)
+    hooks.injectFailure?.('published', destination)
+    rmSync(backupPath, { recursive: true, force: true })
+    rmSync(journalPath, { force: true })
+  } catch (error) {
+    let rollbackError: unknown
+    try {
+      if (existsSync(destination)) {
+        rmSync(destination, { recursive: true, force: true })
+      }
+      if (hadDestination && existsSync(backupPath)) {
+        renameSync(backupPath, destination)
+      }
+      hooks.injectFailure?.('rolled-back')
+      if (existsSync(staged)) {
+        rmSync(staged, { recursive: true, force: true })
+      }
+      rmSync(journalPath, { force: true })
+    } catch (caught) {
+      rollbackError = caught
+      writeFileSync(journalPath, `${JSON.stringify({
+        version: MUTATION_MANIFEST_VERSION,
+        id: transactionId,
+        state: 'recovery-required',
+        destination,
+        staged,
+        backup: hadDestination ? backupPath : null,
+        failure: error instanceof Error ? error.message : String(error),
+        rollbackFailure: caught instanceof Error ? caught.message : String(caught),
+      }, null, 2)}\n`, 'utf-8')
+    }
+
+    const detail = rollbackError
+      ? ` Automatic rollback failed; recover using ${journalPath}.`
+      : ' Original directory was restored.'
+    throw new Error(`Atomic directory publication failed.${detail}`, { cause: error })
+  }
+}
+
+export function copyDirectoryForStaging(sourcePath: string, stagedPath: string): void {
+  if (!existsSync(sourcePath)) {
+    mkdirSync(stagedPath, { recursive: true })
+    return
+  }
+  cpSync(sourcePath, stagedPath, { recursive: true })
+}
+
+const PROJECT_STAGE_IGNORES = new Set(['.git', 'node_modules', 'dist'])
+
+export function copyProjectForStaging(sourcePath: string, stagedPath: string): void {
+  const source = resolve(sourcePath)
+  cpSync(source, stagedPath, {
+    recursive: true,
+    filter(path) {
+      const rel = relative(source, path)
+      if (rel === '') return true
+      const [topLevel] = rel.split(/[\\/]/)
+      if (PROJECT_STAGE_IGNORES.has(topLevel)) return false
+      return !rel.startsWith(`.pluxx${process.platform === 'win32' ? '\\' : '/'}transactions`)
+    },
+  })
+}
+
+export function readFileMutation(rootDir: string, stagedRoot: string, path: string): FileMutation {
+  const currentPath = resolveWithinRoot(rootDir, path)
+  const stagedPath = resolveWithinRoot(stagedRoot, path)
+  const currentExists = existsSync(currentPath)
+  const stagedExists = existsSync(stagedPath)
+  if (!stagedExists) {
+    return { path, action: 'delete' }
+  }
+  const content = readFileSync(stagedPath)
+  return {
+    path,
+    action: currentExists ? 'update' : 'create',
+    content,
+    mode: statSync(stagedPath).mode,
+  }
+}

--- a/src/generators/index.ts
+++ b/src/generators/index.ts
@@ -1,5 +1,5 @@
-import { rmSync, mkdirSync } from 'fs'
-import { resolve, relative } from 'path'
+import { rmSync, mkdirSync, mkdtempSync } from 'fs'
+import { basename, dirname, resolve, relative } from 'path'
 import type { PluginConfig, TargetPlatform } from '../schema'
 import { assertGeneratedBundlesCurrent } from '../bundle-check'
 import { Generator } from './base'
@@ -14,6 +14,7 @@ import { GeminiCliGenerator } from './gemini-cli'
 import { RooCodeGenerator } from './roo-code'
 import { ClineGenerator } from './cline'
 import { AmpGenerator } from './amp'
+import { copyDirectoryForStaging, publishStagedDirectory, type MutationHooks } from '../fs-transaction'
 
 const GENERATORS: Record<TargetPlatform, new (config: PluginConfig, rootDir: string) => Generator> = {
   'claude-code': ClaudeCodeGenerator,
@@ -34,6 +35,8 @@ export interface BuildOptions {
   targets?: TargetPlatform[]
   /** Clean output directory before building */
   clean?: boolean
+  /** Internal reliability seam used to inject publication failures in tests. */
+  mutationHooks?: MutationHooks
 }
 
 function assertPathWithinRoot(rootDir: string, configPath: string, configKey: string): void {
@@ -98,22 +101,34 @@ export async function build(
 
   validateConfiguredPaths(config, rootDir)
 
-  if (options.clean !== false) {
-    rmSync(outDir, { recursive: true, force: true })
+  mkdirSync(dirname(outDir), { recursive: true })
+  const stageDir = mkdtempSync(resolve(dirname(outDir), `.${basename(outDir)}.pluxx-stage-`))
+  if (options.clean === false) {
+    rmSync(stageDir, { recursive: true, force: true })
+    copyDirectoryForStaging(outDir, stageDir)
   }
-  mkdirSync(outDir, { recursive: true })
+  mkdirSync(stageDir, { recursive: true })
+  const stagedConfig: PluginConfig = {
+    ...config,
+    outDir: relative(rootDir, stageDir),
+  }
 
-  const generators = targets.map(target => {
-    const GeneratorClass = GENERATORS[target]
-    if (!GeneratorClass) {
-      throw new Error(`Unknown target platform: ${target}`)
-    }
-    return new GeneratorClass(config, rootDir)
-  })
-
-  // Build all targets in parallel
-  await Promise.all(generators.map(g => g.generate()))
-  assertGeneratedBundlesCurrent(config, rootDir, targets)
+  try {
+    const generators = targets.map(target => {
+      const GeneratorClass = GENERATORS[target]
+      if (!GeneratorClass) {
+        throw new Error(`Unknown target platform: ${target}`)
+      }
+      return new GeneratorClass(stagedConfig, rootDir)
+    })
+    // Build all targets in parallel, validate the complete staged tree, then publish.
+    await Promise.all(generators.map(g => g.generate()))
+    assertGeneratedBundlesCurrent(stagedConfig, rootDir, targets)
+    publishStagedDirectory(outDir, stageDir, options.mutationHooks)
+  } catch (error) {
+    rmSync(stageDir, { recursive: true, force: true })
+    throw error
+  }
 }
 
 export { Generator }

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -405,9 +405,35 @@ describe('build', () => {
       outDir: './missing-asset-dist',
     }
 
+    mkdirSync(resolve(TEST_DIR, 'missing-asset-dist'), { recursive: true })
+    writeFileSync(resolve(TEST_DIR, 'missing-asset-dist/original.txt'), 'keep me\n')
+
     await expect(build(missingAssetConfig, TEST_DIR)).rejects.toThrow(
       'Generated codex manifest references missing bundle path: ./assets/missing.svg.',
     )
+    expect(readFileSync(resolve(TEST_DIR, 'missing-asset-dist/original.txt'), 'utf-8')).toBe('keep me\n')
+    expect(existsSync(resolve(TEST_DIR, 'missing-asset-dist/codex'))).toBe(false)
+  })
+
+  it('restores the previous dist when publication fails after backup', async () => {
+    const atomicConfig: PluginConfig = {
+      ...testConfig,
+      targets: ['codex'],
+      outDir: './atomic-dist',
+    }
+    mkdirSync(resolve(TEST_DIR, 'atomic-dist'), { recursive: true })
+    writeFileSync(resolve(TEST_DIR, 'atomic-dist/original.txt'), 'keep me\n')
+
+    await expect(build(atomicConfig, TEST_DIR, {
+      mutationHooks: {
+        injectFailure(phase) {
+          if (phase === 'backup-created') throw new Error('injected publication failure')
+        },
+      },
+    })).rejects.toThrow('Original directory was restored')
+
+    expect(readFileSync(resolve(TEST_DIR, 'atomic-dist/original.txt'), 'utf-8')).toBe('keep me\n')
+    expect(existsSync(resolve(TEST_DIR, 'atomic-dist/codex'))).toBe(false)
   })
 
   it('requires generated brand asset references even when assets copying is not configured', async () => {

--- a/tests/cli-init-json.test.ts
+++ b/tests/cli-init-json.test.ts
@@ -68,6 +68,45 @@ afterEach(() => {
 })
 
 describe('CLI init JSON summary', () => {
+  it('reports existing non-managed init destinations as dry-run conflicts', async () => {
+    const cwd = mkdtempSync(resolve(tmpdir(), 'pluxx-cli-init-conflict-'))
+    writeFileSync(resolve(cwd, 'pluxx.config.ts'), 'user config\n')
+    try {
+      const proc = Bun.spawn([
+        'bun',
+        resolve(ROOT, 'bin/pluxx.js'),
+        'init',
+        '--from-mcp',
+        `bun ${stubServerPath}`,
+        '--yes',
+        '--name',
+        'stub-server',
+        '--display-name',
+        'Stub Server',
+        '--author',
+        'Test Author',
+        '--targets',
+        'codex',
+        '--dry-run',
+        '--json',
+      ], { cwd, stdout: 'pipe', stderr: 'pipe' })
+      const stdout = await new Response(proc.stdout).text()
+      const stderr = await new Response(proc.stderr).text()
+      expect(await proc.exited, stderr).toBe(0)
+      const summary = JSON.parse(stdout) as {
+        mutation: { version: number; conflicts: Array<{ path: string; reason: string }> }
+      }
+      expect(summary.mutation.version).toBe(1)
+      expect(summary.mutation.conflicts).toContainEqual({
+        path: 'pluxx.config.ts',
+        reason: 'destination-exists',
+      })
+      expect(readFileSync(resolve(cwd, 'pluxx.config.ts'), 'utf-8')).toBe('user config\n')
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
   it('reports the applied hook mode instead of the requested no-op safe mode', async () => {
     const cwd = mkdtempSync(resolve(tmpdir(), 'pluxx-cli-init-'))
 

--- a/tests/cli-sync.test.ts
+++ b/tests/cli-sync.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { resolve } from 'path'
 import { introspectMcpServer } from '../src/mcp/introspect'
 import { writeMcpScaffold } from '../src/cli/init-from-mcp'
+import { AGENT_CONTEXT_PATH } from '../src/cli/agent'
 
 const ROOT = resolve(import.meta.dir, '..')
 let testDir = ''
@@ -122,6 +123,8 @@ describe('CLI sync command', () => {
         'Keep this custom follow-up note.',
       ),
     )
+    mkdirSync(resolve(testDir, '.pluxx/agent'), { recursive: true })
+    writeFileSync(resolve(testDir, AGENT_CONTEXT_PATH), '# stale agent context\n')
 
     writeFileSync(
       statePath,
@@ -167,11 +170,14 @@ describe('CLI sync command', () => {
       updatedFiles: string[]
       removedFiles: string[]
       preservedFiles: string[]
+      mutation: { deletes: string[] }
     }
 
     expect(summary.addedFiles).toContain('skills/search-technologies/SKILL.md')
     expect(summary.preservedFiles).toContain('skills/find-people/SKILL.md')
     expect(summary.updatedFiles).toContain('./INSTRUCTIONS.md')
     expect(summary.removedFiles).toEqual(['commands/find-people.md'])
+    expect(summary.mutation.deletes).toContain(AGENT_CONTEXT_PATH)
+    expect(existsSync(resolve(testDir, AGENT_CONTEXT_PATH))).toBe(false)
   })
 })

--- a/tests/fs-transaction.test.ts
+++ b/tests/fs-transaction.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { chmodSync, existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, symlinkSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { resolve } from 'path'
+import { applyFileMutations, publishStagedDirectory } from '../src/fs-transaction'
+
+let rootDir = ''
+
+beforeEach(() => {
+  rootDir = mkdtempSync(resolve(tmpdir(), 'pluxx-fs-transaction-'))
+})
+
+afterEach(() => {
+  rmSync(rootDir, { recursive: true, force: true })
+})
+
+describe('filesystem transactions', () => {
+  it('rolls back every file when an injected apply failure occurs', () => {
+    writeFileSync(resolve(rootDir, 'existing.txt'), 'before\n')
+
+    expect(() => applyFileMutations(rootDir, [
+      { path: 'existing.txt', action: 'update', content: 'after\n' },
+      { path: 'created.txt', action: 'create', content: 'created\n' },
+    ], {
+      injectFailure(phase, detail) {
+        if (phase === 'entry-applied' && detail === 'created.txt') {
+          throw new Error('injected failure')
+        }
+      },
+    })).toThrow('Original files were restored')
+
+    expect(readFileSync(resolve(rootDir, 'existing.txt'), 'utf-8')).toBe('before\n')
+    expect(existsSync(resolve(rootDir, 'created.txt'))).toBe(false)
+    expect(existsSync(resolve(rootDir, '.pluxx/transactions'))).toBe(false)
+  })
+
+  it('cleans the journal when failure is injected before the first file mutation', () => {
+    writeFileSync(resolve(rootDir, 'existing.txt'), 'before\n')
+    expect(() => applyFileMutations(rootDir, [
+      { path: 'existing.txt', action: 'update', content: 'after\n' },
+    ], {
+      injectFailure(phase) {
+        if (phase === 'journaled') throw new Error('injected pre-apply failure')
+      },
+    })).toThrow('Original files were restored')
+    expect(readFileSync(resolve(rootDir, 'existing.txt'), 'utf-8')).toBe('before\n')
+    expect(existsSync(resolve(rootDir, '.pluxx/transactions'))).toBe(false)
+  })
+
+  it('restores mode bits and removes staged residue when an update fails', () => {
+    const target = resolve(rootDir, 'script.sh')
+    writeFileSync(target, '#!/bin/sh\nexit 0\n')
+    chmodSync(target, 0o755)
+
+    expect(() => applyFileMutations(rootDir, [
+      { path: 'script.sh', action: 'update', content: '#!/bin/sh\nexit 1\n', mode: 0o644 },
+    ], {
+      injectFailure(phase) {
+        if (phase === 'staged') throw new Error('injected staged failure')
+      },
+    })).toThrow('Original files were restored')
+
+    expect(readFileSync(target, 'utf-8')).toBe('#!/bin/sh\nexit 0\n')
+    expect(statSync(target).mode & 0o777).toBe(0o755)
+    expect(readdirSync(rootDir).filter((entry) => entry.includes('.pluxx-'))).toEqual([])
+  })
+
+  it('rejects symbolic-link destinations before writing a journal', () => {
+    const target = resolve(rootDir, 'target.txt')
+    const link = resolve(rootDir, 'link.txt')
+    writeFileSync(target, 'before\n')
+    symlinkSync(target, link)
+
+    expect(() => applyFileMutations(rootDir, [
+      { path: 'link.txt', action: 'update', content: 'after\n' },
+    ])).toThrow('does not support symbolic-link paths')
+
+    expect(lstatSync(link).isSymbolicLink()).toBe(true)
+    expect(readFileSync(target, 'utf-8')).toBe('before\n')
+    expect(existsSync(resolve(rootDir, '.pluxx/transactions'))).toBe(false)
+  })
+
+  it('rejects a symlinked parent without writing outside the project root', () => {
+    const outside = mkdtempSync(resolve(tmpdir(), 'pluxx-fs-outside-'))
+    symlinkSync(outside, resolve(rootDir, 'redirect'))
+    try {
+      expect(() => applyFileMutations(rootDir, [
+        { path: 'redirect/created.txt', action: 'create', content: 'unsafe\n' },
+      ])).toThrow('does not support symbolic-link paths')
+      expect(existsSync(resolve(outside, 'created.txt'))).toBe(false)
+      expect(existsSync(resolve(rootDir, '.pluxx/transactions'))).toBe(false)
+    } finally {
+      rmSync(outside, { recursive: true, force: true })
+    }
+  })
+
+  it('refuses to mutate over an unfinished file transaction', () => {
+    const target = resolve(rootDir, 'existing.txt')
+    const journalDir = resolve(rootDir, '.pluxx/transactions/unfinished')
+    writeFileSync(target, 'before\n')
+    mkdirSync(journalDir, { recursive: true })
+    writeFileSync(resolve(journalDir, 'journal.json'), '{"state":"applying"}\n')
+
+    expect(() => applyFileMutations(rootDir, [
+      { path: 'existing.txt', action: 'update', content: 'after\n' },
+    ])).toThrow('Unfinished Pluxx mutation found')
+    expect(readFileSync(target, 'utf-8')).toBe('before\n')
+  })
+
+  it('rejects stale create plans before writing a journal', () => {
+    writeFileSync(resolve(rootDir, 'existing.txt'), 'before\n')
+    expect(() => applyFileMutations(rootDir, [
+      { path: 'existing.txt', action: 'create', content: 'after\n' },
+    ])).toThrow('Create mutation destination already exists')
+    expect(readFileSync(resolve(rootDir, 'existing.txt'), 'utf-8')).toBe('before\n')
+    expect(existsSync(resolve(rootDir, '.pluxx/transactions'))).toBe(false)
+  })
+
+  it('rejects absolute manifest paths before writing a journal', () => {
+    const target = resolve(rootDir, 'existing.txt')
+    writeFileSync(target, 'before\n')
+    expect(() => applyFileMutations(rootDir, [
+      { path: target, action: 'update', content: 'after\n' },
+    ])).toThrow('must be relative to the project root')
+    expect(readFileSync(target, 'utf-8')).toBe('before\n')
+    expect(existsSync(resolve(rootDir, '.pluxx/transactions'))).toBe(false)
+  })
+
+  it('publishes a staged directory and removes transaction residue', () => {
+    const destination = resolve(rootDir, 'dist')
+    const staged = resolve(rootDir, '.dist-stage')
+    mkdirSync(destination)
+    mkdirSync(staged)
+    writeFileSync(resolve(destination, 'old.txt'), 'old\n')
+    writeFileSync(resolve(staged, 'new.txt'), 'new\n')
+
+    publishStagedDirectory(destination, staged)
+
+    expect(existsSync(resolve(destination, 'old.txt'))).toBe(false)
+    expect(readFileSync(resolve(destination, 'new.txt'), 'utf-8')).toBe('new\n')
+    expect(readdirSync(rootDir).filter((entry) => entry.includes('pluxx-transaction'))).toEqual([])
+  })
+
+  it('restores the original directory when publication fails after backup', () => {
+    const destination = resolve(rootDir, 'dist')
+    const staged = resolve(rootDir, '.dist-stage')
+    mkdirSync(destination)
+    mkdirSync(staged)
+    writeFileSync(resolve(destination, 'old.txt'), 'old\n')
+    writeFileSync(resolve(staged, 'new.txt'), 'new\n')
+
+    expect(() => publishStagedDirectory(destination, staged, {
+      injectFailure(phase) {
+        if (phase === 'backup-created') throw new Error('injected failure')
+      },
+    })).toThrow('Original directory was restored')
+
+    expect(readFileSync(resolve(destination, 'old.txt'), 'utf-8')).toBe('old\n')
+    expect(existsSync(resolve(destination, 'new.txt'))).toBe(false)
+  })
+
+  it('rejects staging on a different parent before mutation', () => {
+    const otherRoot = mkdtempSync(resolve(tmpdir(), 'pluxx-fs-other-'))
+    mkdirSync(resolve(otherRoot, 'stage'))
+    try {
+      expect(() => publishStagedDirectory(resolve(rootDir, 'dist'), resolve(otherRoot, 'stage')))
+        .toThrow('avoid cross-device publication')
+      expect(existsSync(resolve(rootDir, 'dist'))).toBe(false)
+    } finally {
+      rmSync(otherRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('refuses to publish over an unfinished directory transaction', () => {
+    const destination = resolve(rootDir, 'dist')
+    const staged = resolve(rootDir, '.dist-stage')
+    mkdirSync(destination)
+    mkdirSync(staged)
+    writeFileSync(resolve(destination, 'old.txt'), 'old\n')
+    writeFileSync(resolve(staged, 'new.txt'), 'new\n')
+    writeFileSync(resolve(rootDir, '.dist.pluxx-transaction-unfinished.json'), '{"state":"publishing"}\n')
+
+    expect(() => publishStagedDirectory(destination, staged)).toThrow('Unfinished Pluxx directory publication found')
+    expect(readFileSync(resolve(destination, 'old.txt'), 'utf-8')).toBe('old\n')
+    expect(readFileSync(resolve(staged, 'new.txt'), 'utf-8')).toBe('new\n')
+  })
+})

--- a/tests/migrate.test.ts
+++ b/tests/migrate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
-import { mkdirSync, rmSync, existsSync, readFileSync } from 'fs'
+import { mkdirSync, rmSync, existsSync, readFileSync, symlinkSync, writeFileSync } from 'fs'
 import { resolve } from 'path'
 import { migrate } from '../src/cli/migrate'
 import { planAgentPrepare } from '../src/cli/agent'
@@ -643,6 +643,111 @@ async function runMigrate(sourceDir: string, outputDir: string): Promise<void> {
 }
 
 describe('migrate', () => {
+  it('dry-run predicts migration creates without writing final paths', async () => {
+    const sourceDir = await setupCodexHeaderSource()
+    const outputDir = resolve(TEST_DIR, 'out-migrate-dry-run')
+    mkdirSync(outputDir, { recursive: true })
+    const previousCwd = process.cwd()
+    process.chdir(outputDir)
+    try {
+      const dryRun = await migrate(sourceDir, { dryRun: true, quiet: true })
+      expect(dryRun.mutation.creates).toContain('pluxx.config.ts')
+      expect(dryRun.mutation.conflicts).toEqual([])
+      expect(existsSync(resolve(outputDir, 'pluxx.config.ts'))).toBe(false)
+
+      const applied = await migrate(sourceDir, { quiet: true })
+      expect(applied.mutation.creates).toEqual(dryRun.mutation.creates)
+      expect(existsSync(resolve(outputDir, 'pluxx.config.ts'))).toBe(true)
+    } finally {
+      process.chdir(previousCwd)
+    }
+  })
+
+  it('reports an existing config as a dry-run conflict', async () => {
+    const sourceDir = await setupCodexHeaderSource()
+    const outputDir = resolve(TEST_DIR, 'out-migrate-conflict')
+    mkdirSync(outputDir, { recursive: true })
+    writeFileSync(resolve(outputDir, 'pluxx.config.ts'), 'user config\n')
+    const previousCwd = process.cwd()
+    process.chdir(outputDir)
+    try {
+      const result = await migrate(sourceDir, { dryRun: true, quiet: true })
+      expect(result.mutation.conflicts).toEqual([{
+        path: 'pluxx.config.ts',
+        reason: 'destination-exists',
+      }])
+      expect(readFileSync(resolve(outputDir, 'pluxx.config.ts'), 'utf-8')).toBe('user config\n')
+    } finally {
+      process.chdir(previousCwd)
+    }
+  })
+
+  it('surfaces occupied migration destinations instead of silently merging them', async () => {
+    const sourceDir = await setupCodexHeaderSource()
+    const outputDir = resolve(TEST_DIR, 'out-migrate-dir-conflict')
+    mkdirSync(resolve(outputDir, 'skills/custom'), { recursive: true })
+    writeFileSync(resolve(outputDir, 'skills/custom/SKILL.md'), 'user skill\n')
+    const previousCwd = process.cwd()
+    process.chdir(outputDir)
+    try {
+      const result = await migrate(sourceDir, { dryRun: true, quiet: true })
+      expect(result.mutation.conflicts).toContainEqual({
+        path: 'skills',
+        reason: 'destination-exists',
+      })
+      expect(readFileSync(resolve(outputDir, 'skills/custom/SKILL.md'), 'utf-8')).toBe('user skill\n')
+    } finally {
+      process.chdir(previousCwd)
+    }
+  })
+
+  it('bounds symbolic-link migration as an explicit dry-run conflict', async () => {
+    const sourceDir = await setupClaudeReadmeSource()
+    const passthroughDir = resolve(sourceDir, 'mcp-server')
+    writeFileSync(resolve(passthroughDir, 'linked-target.txt'), 'linked content\n')
+    symlinkSync('linked-target.txt', resolve(passthroughDir, 'linked-file.txt'))
+    const outputDir = resolve(TEST_DIR, 'out-migrate-symlink-conflict')
+    mkdirSync(outputDir, { recursive: true })
+    const previousCwd = process.cwd()
+    process.chdir(outputDir)
+    try {
+      const result = await migrate(sourceDir, { dryRun: true, quiet: true })
+      expect(result.mutation.conflicts).toContainEqual({
+        path: 'mcp-server/linked-file.txt',
+        reason: 'symbolic-link-mutation-not-supported',
+      })
+      expect(existsSync(resolve(outputDir, 'mcp-server/linked-file.txt'))).toBe(false)
+    } finally {
+      process.chdir(previousCwd)
+    }
+  })
+
+  it('rolls back every migrated file when final application fails', async () => {
+    const sourceDir = await setupCodexHeaderSource()
+    const outputDir = resolve(TEST_DIR, 'out-migrate-rollback')
+    mkdirSync(outputDir, { recursive: true })
+    writeFileSync(resolve(outputDir, 'user-notes.md'), 'keep me\n')
+    const previousCwd = process.cwd()
+    process.chdir(outputDir)
+    try {
+      await expect(migrate(sourceDir, {
+        quiet: true,
+        mutationHooks: {
+          injectFailure(phase, detail) {
+            if (phase === 'entry-applied' && detail === 'pluxx.config.ts') {
+              throw new Error('injected migrate failure')
+            }
+          },
+        },
+      })).rejects.toThrow('Original files were restored')
+      expect(readFileSync(resolve(outputDir, 'user-notes.md'), 'utf-8')).toBe('keep me\n')
+      expect(existsSync(resolve(outputDir, 'pluxx.config.ts'))).toBe(false)
+      expect(existsSync(resolve(outputDir, '.pluxx/mcp.json'))).toBe(false)
+    } finally {
+      process.chdir(previousCwd)
+    }
+  })
+
   for (const platform of ['claude', 'cursor', 'codex', 'opencode'] as const) {
     it(`migrates Megamind ${platform} example into pluxx config`, async () => {
       const sourceDir = await setupMegamindSource(platform)

--- a/tests/sync-from-mcp.test.ts
+++ b/tests/sync-from-mcp.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { resolve } from 'path'
 import { introspectMcpServer } from '../src/mcp/introspect'
-import { applyPersistedTaxonomy, detectSkillRenames, detectToolRenames, readMcpScaffoldMetadata, syncFromMcp } from '../src/cli/sync-from-mcp'
+import { applyPersistedTaxonomy, detectSkillRenames, detectToolRenameConflicts, detectToolRenames, planSyncFromMcp, readMcpScaffoldMetadata, syncFromMcp } from '../src/cli/sync-from-mcp'
 import { MCP_SCAFFOLD_METADATA_PATH, writeMcpScaffold } from '../src/cli/init-from-mcp'
 import { AGENT_CONTEXT_PATH, AGENT_PLAN_PATH } from '../src/cli/agent'
 
@@ -139,6 +139,120 @@ describe('sync-from-mcp', () => {
     )
 
     expect(renames.size).toBe(0)
+  })
+
+  it('surfaces equally plausible tool renames as conflicts instead of guessing', () => {
+    const conflicts = detectToolRenameConflicts(
+      [{
+        name: 'FindAccount',
+        description: 'Find an account record.',
+        inputSchema: { required: ['accountId'] },
+      }],
+      [
+        {
+          name: 'FindAccounts',
+          description: 'Find account records.',
+          inputSchema: { required: ['accountId'] },
+        },
+        {
+          name: 'FindAccounte',
+          description: 'Find account entries.',
+          inputSchema: { required: ['accountId'] },
+        },
+      ],
+    )
+
+    expect(conflicts).toEqual([{
+      path: 'tools/FindAccount',
+      reason: 'ambiguous-rename',
+      candidates: ['FindAccounte', 'FindAccounts'],
+    }])
+  })
+
+  it('reports file actions alongside ambiguous rename conflicts', async () => {
+    writeFileSync(STATE_PATH, JSON.stringify({
+      serverInfo: { name: 'stub-server', title: 'Stub Server', version: '1.0.0' },
+      tools: [{
+        name: 'FindAccount',
+        description: 'Find an account record.',
+        inputSchema: { required: ['accountId'] },
+      }],
+    }, null, 2))
+    const source = { transport: 'stdio' as const, command: 'bun', args: [STUB_SERVER_PATH, STATE_PATH] }
+    await writeMcpScaffold({
+      rootDir: TEST_DIR,
+      pluginName: 'stub-server',
+      authorName: 'Test Author',
+      displayName: 'Stub Server',
+      targets: ['codex'],
+      source,
+      introspection: await introspectMcpServer(source),
+      skillGrouping: 'tool',
+      hookMode: 'none',
+    })
+
+    writeFileSync(STATE_PATH, JSON.stringify({
+      serverInfo: { name: 'stub-server', title: 'Stub Server', version: '1.1.0' },
+      tools: [
+        { name: 'FindAccounts', description: 'Find account records.', inputSchema: { required: ['accountId'] } },
+        { name: 'FindAccounte', description: 'Find account entries.', inputSchema: { required: ['accountId'] } },
+      ],
+    }, null, 2))
+
+    const result = await planSyncFromMcp({ rootDir: TEST_DIR })
+    expect(result.mutation.conflicts).toContainEqual({
+      path: 'tools/FindAccount',
+      reason: 'ambiguous-rename',
+      candidates: ['FindAccounte', 'FindAccounts'],
+    })
+    expect(result.mutation.creates.length).toBeGreaterThan(0)
+    expect(result.mutation.deletes.length).toBeGreaterThan(0)
+    expect(existsSync(resolve(TEST_DIR, 'skills/find-accounts/SKILL.md'))).toBe(false)
+  })
+
+  it('restores the original project when final sync application fails', async () => {
+    writeFileSync(STATE_PATH, JSON.stringify({
+      serverInfo: { name: 'stub-server', title: 'Stub Server', version: '1.0.0' },
+      instructions: 'Initial instructions.',
+      tools: [{ name: 'FindOrganizations', description: 'Search organizations.' }],
+    }, null, 2))
+    const source = { transport: 'stdio' as const, command: 'bun', args: [STUB_SERVER_PATH, STATE_PATH] }
+    const introspection = await introspectMcpServer(source)
+    await writeMcpScaffold({
+      rootDir: TEST_DIR,
+      pluginName: 'stub-server',
+      authorName: 'Test Author',
+      displayName: 'Stub Server',
+      targets: ['codex'],
+      source,
+      introspection,
+      skillGrouping: 'tool',
+      hookMode: 'none',
+    })
+    const beforeInstructions = readFileSync(resolve(TEST_DIR, 'INSTRUCTIONS.md'), 'utf-8')
+
+    writeFileSync(STATE_PATH, JSON.stringify({
+      serverInfo: { name: 'stub-server', title: 'Stub Server', version: '1.1.0' },
+      instructions: 'Updated instructions.',
+      tools: [
+        { name: 'FindOrganizations', description: 'Search organizations with filters.' },
+        { name: 'SearchTechnologies', description: 'Search technologies.' },
+      ],
+    }, null, 2))
+
+    await expect(syncFromMcp({
+      rootDir: TEST_DIR,
+      mutationHooks: {
+        injectFailure(phase, detail) {
+          if (phase === 'entry-applied' && detail === './INSTRUCTIONS.md') {
+            throw new Error('injected sync failure')
+          }
+        },
+      },
+    })).rejects.toThrow('Original files were restored')
+
+    expect(readFileSync(resolve(TEST_DIR, 'INSTRUCTIONS.md'), 'utf-8')).toBe(beforeInstructions)
+    expect(existsSync(resolve(TEST_DIR, 'skills/search-technologies/SKILL.md'))).toBe(false)
   })
 
   it('matches skills 1:1 before transferring custom content', () => {


### PR DESCRIPTION
## Summary

A failed `init`, `sync`, `migrate`, or `build` could previously leave source files or `dist` only partly updated. These workflows now plan and stage their complete result before publication, restore prior state after thrown failures, refuse ambiguous or occupied destinations, and stop on unfinished recovery journals instead of mutating uncertain state.

JSON consumers keep their existing fields and receive an additive, versioned `mutation` manifest covering creates, updates, deletes, renames, and conflicts. Build publication is bounded to a same-parent staging directory so it cannot cross filesystems during the final rename sequence.

Fixes #408.
Fixes PLUXX-318.

## Validation

- `npm run build`
- `npm run typecheck`
- `npm test` — 54 files, 606 tests passed serially
- CE correctness, testing, maintainability, project-standards, agent-native, reliability, security, API-contract, and adversarial review; all actionable findings resolved

## New concepts

### Recoverable filesystem transactions

Multi-file authoring cannot be made a single operating-system rename, so this change separates planning from commit and records enough state to reverse a failed commit. Each changed file is backed up before replacement; a thrown failure rolls applied entries back in reverse order, while a hard interruption leaves a journal that blocks later mutations until recovery.

Build output is different: the complete directory can be staged beside `dist`, validated, and then published with rename-based backup and restore. The same-parent constraint avoids cross-device rename failures. This approach is appropriate for local authoring state; it is not a substitute for concurrent multi-writer locking or a database transaction.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)