### PR TITLE
Add transactional install ownership

### DIFF
--- a/docs/orchid/plans/2026-07-12-pluxx-319-transactional-installs.md
+++ b/docs/orchid/plans/2026-07-12-pluxx-319-transactional-installs.md
@@ -1,0 +1,204 @@
+---
+title: PLUXX-319 Transactional installs and universal ownership
+date: 2026-07-12
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+origin: Linear PLUXX-319
+---
+
+# PLUXX-319 Transactional installs and universal ownership
+
+## Goal Capsule
+
+- **Objective:** Make core-four installs recoverable, ownership-aware, content-verifiable, and conservative when users modify installed files or Codex config.
+- **Authority:** Linear PLUXX-319 acceptance criteria, repo `AGENTS.md`, then existing install and Codex companion contracts.
+- **Execution profile:** Reliability and supply-chain hardening on `codex/pluxx-319-transactional-installs` in the visible task worktree.
+- **Stop conditions:** Do not delete or overwrite an unowned or modified file; restore the previous bundle when staging, replacement, or post-install verification fails.
+- **Tail ownership:** Run targeted lifecycle tests, build, typecheck, full serial `npm test`, CE review with security/reliability lenses, then PR and CI closeout without merging.
+
+---
+
+## Product Contract
+
+### Summary
+
+Pluxx will stage and validate core-four local installs before swapping them into host-visible paths, record hashes for owned files and config mutations, preserve user modifications during reinstall and uninstall, and treat same-version content drift as a verification failure.
+
+### Problem Frame
+
+Current copied installs delete the live directory before copying the replacement, so a failed copy or materialization can destroy a working install. Uninstall removes complete directories without knowing which files still match Pluxx output. Codex companion apply merges hook and MCP approval settings without an ownership record or inverse operation. Non-Codex verification usually compares only versions, allowing same-version content drift to pass.
+
+### Requirements
+
+**Transactional bundle lifecycle**
+
+- R1. A local core-four install must stage and validate the candidate before replacing the live bundle.
+- R2. Replacement must retain a recoverable sibling backup until post-install verification succeeds and must restore it on failure.
+- R3. Reinstall must refuse to overwrite unowned or user-modified installed content.
+
+**Ownership lifecycle**
+
+- R4. Pluxx must record hashes and paths for installed files and host-adjacent mutations it owns.
+- R5. Uninstall and prune behavior must delete only content whose current hash still matches its ownership record and preserve modified or unowned content.
+- R6. Ownership records and mutation paths must reject traversal, malformed hashes, and plugin/platform identity mismatches.
+
+**Codex config lifecycle**
+
+- R7. Codex apply must record the exact hook and MCP approval additions it owns without claiming pre-existing settings.
+- R8. Codex unapply must be idempotent, remove only unchanged Pluxx-owned additions, and preserve unrelated or user-modified config.
+
+**Verification**
+
+- R9. `verify-install` must distinguish version equality from content equality for copied core-four installs.
+- R10. Generated core-four release installers must use the same stage, backup, rollback, ownership, and modification-preservation contract.
+
+### Acceptance Examples
+
+- AE1. Given a working copied bundle, when candidate validation throws, the old bundle remains at the live path and no ownership record advances.
+- AE2. Given a working bundle, when post-swap verification throws, the candidate is removed and the backup is restored atomically.
+- AE3. Given an owned file edited by a user, reinstall and uninstall preserve it and report the preservation instead of silently deleting it.
+- AE4. Given equal manifest versions but different copied bytes, `verify-install` reports content drift.
+- AE5. Given Codex config with unrelated edits after apply, unapply removes unchanged marked Pluxx additions and leaves unrelated edits byte-for-byte intact.
+- AE6. Given a Pluxx-added Codex line that the user changes, unapply preserves it and reports that it is no longer safely owned.
+
+### Scope Boundaries
+
+- In scope: local CLI installs, generated GitHub Release installers, core-four bundle paths and host-adjacent files, Codex hook/MCP config apply/unapply, verification and docs.
+- Out of scope: publish recovery owned by PLUXX-320, new host generators, remote trust/distribution services, and migration of arbitrary legacy host installs that lack enough evidence to claim ownership safely.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. Store a versioned per-plugin/per-platform ownership ledger outside the installed bundle so replacement cannot erase the evidence needed for conservative reinstall and uninstall.
+- KTD2. Hash deterministic relative paths, file bytes, and symlink targets; exclude transaction scratch paths and the external ledger itself.
+- KTD3. Use sibling stage and backup paths plus same-filesystem rename for the commit point. Candidate materialization and integrity checks run against the stage path.
+- KTD4. Treat an existing copied bundle without a valid ownership record as unowned. Refuse destructive replacement rather than silently adopting or deleting unknown content.
+- KTD5. Remove owned files individually during uninstall, then prune only empty owned directories. A preserved file keeps its directory and the residual ownership evidence needed for later diagnosis.
+- KTD6. Mark Codex config additions with stable Pluxx ownership comments and ledger the exact normalized additions. Unapply matches those markers and expected values instead of restoring a whole-file snapshot.
+- KTD7. Reuse the same content-signature algorithm in install ownership and `verify-install` so equality has one definition.
+- KTD8. Embed equivalent transaction and ownership helpers into generated shell installers because release consumers do not necessarily have the Pluxx CLI installed.
+
+### High-Level Technical Design
+
+```mermaid
+flowchart TB
+  A[Inspect existing install and ownership] --> B{Safe to replace?}
+  B -->|no| C[Preserve live state and fail]
+  B -->|yes| D[Create sibling stage]
+  D --> E[Copy or link and materialize]
+  E --> F[Validate staged bundle]
+  F -->|fail| G[Delete stage; keep live bundle]
+  F -->|pass| H[Rename live bundle to backup]
+  H --> I[Rename stage to live]
+  I --> J[Verify host-visible consumer state]
+  J -->|fail| K[Restore backup]
+  J -->|pass| L[Write ownership; delete backup]
+```
+
+### Sequencing
+
+1. Build and test the shared ownership/signature and transaction primitive.
+2. Integrate local core-four install and uninstall paths, including host-adjacent files.
+3. Add Codex config apply ownership and unapply.
+4. Extend verification and generated release installers.
+5. Update product truth and run the complete validation/review/PR lifecycle.
+
+### Risks and Mitigations
+
+- Cross-platform rename semantics: keep stage and backup siblings on the same filesystem and restore in a guarded failure path.
+- Legacy installs lack ownership: fail safely with an actionable move/remove instruction rather than guessing.
+- Ownership ledger tampering: validate schema, identities, relative paths, root containment, and SHA-256 format before mutation.
+- Generated shell drift: test generated scripts by executing fixture installs and failure/reinstall cases, not only string snapshots.
+- Codex TOML formatting variants: own only generated marker/value pairs and preserve anything not matched exactly.
+
+---
+
+## Implementation Units
+
+### U1. Shared install ownership and transaction primitive
+
+- **Goal:** Provide deterministic bundle signatures, validated ownership records, conservative diffing/removal, and rollback-safe stage/swap operations.
+- **Requirements:** R1-R6, R9; AE1-AE4.
+- **Files:** `src/install-ownership.ts`, `tests/install-ownership.test.ts`.
+- **Patterns:** Follow path validation and hash ownership patterns in `src/codex-agent-install.ts`; keep filesystem mutations injectable enough to prove rollback failures.
+- **Test Scenarios:** fresh install; owned unchanged reinstall; modified file; extra unowned file; malformed/traversal ledger; stage failure; post-swap failure; successful backup cleanup; symlink target ownership.
+- **Verification:** Targeted ownership tests pass under Vitest.
+
+### U2. Local core-four install and uninstall integration
+
+- **Goal:** Route CLI install paths through the transaction primitive and make uninstall remove only still-owned content.
+- **Requirements:** R1-R6; AE1-AE3.
+- **Files:** `src/cli/install.ts`, `tests/install.test.ts`, `tests/distribution-lifecycle.test.ts`.
+- **Patterns:** Preserve native Claude command behavior while transactionally preparing Pluxx-managed marketplace content; include OpenCode wrapper/skills and Codex marketplace/cache/agent sequencing in rollback boundaries where Pluxx mutates them.
+- **Test Scenarios:** all four hosts install; replacement failure restores prior bundle; unowned legacy copy refusal; edited file preservation on reinstall/uninstall; idempotent reinstall/uninstall; user config materialization validated before commit.
+- **Verification:** Install and distribution lifecycle suites pass serially.
+
+### U3. Codex config ownership and conservative unapply
+
+- **Goal:** Ledger Pluxx-added hook/MCP settings and expose an idempotent `pluxx codex unapply` command.
+- **Requirements:** R4, R6-R8; AE5-AE6.
+- **Files:** `src/cli/codex-apply.ts`, `src/cli/index.ts`, `src/index.ts`, `tests/codex-apply.test.ts`, `tests/meta-cli.test.ts`.
+- **Patterns:** Reuse Codex agent ownership validation; do not claim pre-existing approved settings; write config and ledger atomically with rollback on either write failure.
+- **Test Scenarios:** apply twice; unapply twice; unrelated edits preserved; user-changed owned value preserved; malformed ledger rejected; hooks-only and approvals-only ownership; dry-run and JSON output.
+- **Verification:** Codex apply and CLI suites pass.
+
+### U4. Content-aware install verification
+
+- **Goal:** Report copied-bundle content drift even when versions match and surface ownership problems distinctly.
+- **Requirements:** R4, R9; AE4.
+- **Files:** `src/cli/verify-install.ts`, `tests/verify-install.test.ts`.
+- **Patterns:** Reuse the shared signature rather than maintaining a second traversal implementation; retain Codex active-cache diagnostics as an additional layer.
+- **Test Scenarios:** same version/same bytes passes; same version/different bytes fails for Cursor, Claude, Codex, and OpenCode copied installs; symlink target mismatch remains precise; missing or invalid ownership is actionable.
+- **Verification:** Verify-install suite passes.
+
+### U5. Generated release installer parity
+
+- **Goal:** Make generated core-four shell installers transactional and ownership-aware without requiring an installed Pluxx CLI.
+- **Requirements:** R1-R6, R10; AE1-AE3.
+- **Files:** `src/cli/publish.ts`, `tests/publish.test.ts`, `tests/release-workflow.test.ts`.
+- **Patterns:** Generate one shared shell helper block consumed by each core-four template; preserve current config prompts, runtime bootstrap, marketplace, and agent registration ordering.
+- **Test Scenarios:** successful fresh install; failed extraction/materialization leaves old bundle; successful update cleans backup; edited installed file blocks replacement; ownership ledger hashes installed output; repeat install is idempotent.
+- **Verification:** Publish and release workflow suites pass.
+
+### U6. Product truth and closeout
+
+- **Goal:** Align public planning/docs and Linear with shipped behavior and validation evidence.
+- **Requirements:** R1-R10.
+- **Files:** `docs/start-here.md`, `docs/todo/queue.md`, `docs/todo/master-backlog.md`, `docs/roadmap.md`, and narrower lifecycle docs if their claims change.
+- **Test Scenarios:** Doc Links relationships remain aligned; no stale claim says ownership is only a follow-on; proof statements cite current validation only.
+- **Verification:** Documentation review plus final diff review.
+
+---
+
+## Verification Contract
+
+| Gate | Command | Proves |
+|---|---|---|
+| Shared mechanics | `npx vitest run tests/install-ownership.test.ts tests/install.test.ts tests/codex-apply.test.ts tests/verify-install.test.ts` | Transaction, ownership, config inverse, and content drift |
+| Distribution | `npx vitest run tests/distribution-lifecycle.test.ts tests/publish.test.ts tests/release-workflow.test.ts` | Core-four and generated-installer lifecycle |
+| Type safety | `npm run typecheck` | Public and internal contracts compile |
+| Build | `npm run build` | Published CLI/package builds |
+| Official full suite | `npm test` | Current repository regression baseline, run serially in this worktree |
+| Review | CE code review with security, reliability, adversarial, and supply-chain lenses | Unsafe mutation, rollback, traversal, and lifecycle gaps |
+
+Do not run fixture-heavy suites concurrently in this worktree. Any validation count reported in closeout must come from this branch after the final fixes.
+
+---
+
+## Definition of Done
+
+- Every R-ID is implemented and covered by a named test scenario.
+- A failed install cannot displace the previous working bundle.
+- Reinstall and uninstall preserve modified or unowned user content.
+- Codex apply/unapply is idempotent and leaves unrelated config intact.
+- Verification fails on same-version content drift.
+- Generated core-four installers implement the same safety contract as local CLI installs.
+- Build, typecheck, targeted suites, and the full official `npm test` pass serially after final review fixes.
+- Repo docs and PLUXX-319/PLUXX-312 Linear truth are updated with current evidence.
+- The focused PR links PLUXX-319 and GitHub issue #409, carries `ai:autofix-enabled`, and has no unresolved actionable CI or review feedback.
+- Experimental or abandoned code is removed from the final diff.

--- a/docs/orchid/reviews/2026-07-12-pluxx-319-code-security-review.md
+++ b/docs/orchid/reviews/2026-07-12-pluxx-319-code-security-review.md
@@ -23,6 +23,10 @@ Atomic temp files initially used default creation permissions even though the ow
 
 The first implementation treated failure to delete a post-verification backup as transaction failure, which could restore the old bundle after the new ownership record had committed. Backup cleanup is now best effort after the new bundle and ledger are valid; a cleanup failure leaves the recoverable backup instead of rolling state backward inconsistently.
 
+### P1. OpenCode companion files were outside the ownership transaction
+
+PR review identified that the OpenCode wrapper and globally exported skill directories were still overwritten and removed independently of the primary bundle. Local installs now stage the bundle, wrapper, and every skill as one transaction with separate hash-bound ownership surfaces; a failure restores every prior path and ledger. Uninstall removes only unchanged owned companions and preserves modified or unowned paths. The generated release installer now applies the same preflight, journaled backup, rollback, and ownership behavior. Tests cover unowned companion refusal, cross-surface rollback, and conservative uninstall.
+
 ## Residual Risk
 
 - Generated installers embed the transaction helper because consumers may not have Pluxx installed. The helper is covered by executed installer fixtures, but it intentionally duplicates a narrow subset of `src/install-ownership.ts`; future schema changes must update both paths together.

--- a/docs/orchid/reviews/2026-07-12-pluxx-319-code-security-review.md
+++ b/docs/orchid/reviews/2026-07-12-pluxx-319-code-security-review.md
@@ -1,0 +1,35 @@
+# PLUXX-319 Code, Security, and Reliability Review
+
+Reviewed the working diff against `origin/main` after the first complete targeted and full-suite validation pass.
+
+## Coverage
+
+- Correctness and acceptance criteria: install staging, swap, rollback, ownership drift, conservative removal, Codex apply/unapply, generated installer parity, and verification semantics.
+- Reliability: failure before swap, failure after swap, ownership-write ordering, backup lifecycle, idempotency, legacy/unowned state, and host-adjacent post-install failures.
+- Security and supply chain: archive-to-stage boundary, path traversal, ownership-ledger tampering, symlink handling, config overwrite targets, file permissions, and secret-bearing config backups.
+- Tests and docs: targeted failure-mode coverage, current serial full-suite proof, CLI help, and canonical planning truth.
+
+## Actionable Findings Resolved
+
+### P1. Codex config ownership could redirect unapply to an arbitrary path
+
+The first implementation trusted `configPath` from the ownership record. A same-user tamper could redirect conservative restore to another file. Unapply now requires the recorded path to equal the path resolved from the current command options, and a sentinel test proves tampering cannot overwrite another file.
+
+### P1. Codex config rewrite and ownership backup permissions were too broad
+
+Atomic temp files initially used default creation permissions even though the ownership record contains a recoverable copy of active config that may include secrets. Config rewrites now preserve the existing mode or default to `0600`; config and install ownership records are created with `0600`.
+
+### P2. Backup cleanup could invalidate a successful transaction
+
+The first implementation treated failure to delete a post-verification backup as transaction failure, which could restore the old bundle after the new ownership record had committed. Backup cleanup is now best effort after the new bundle and ledger are valid; a cleanup failure leaves the recoverable backup instead of rolling state backward inconsistently.
+
+## Residual Risk
+
+- Generated installers embed the transaction helper because consumers may not have Pluxx installed. The helper is covered by executed installer fixtures, but it intentionally duplicates a narrow subset of `src/install-ownership.ts`; future schema changes must update both paths together.
+- Existing copied installs without a valid ownership record are not silently adopted. Reinstall fails with an instruction to move or remove the legacy directory, which favors preservation over seamless migration.
+- Codex unapply restores automatically only when the active config still matches the applied state. Later user edits are preserved and require manual reconciliation; this is intentionally conservative.
+- Archive checksum/signature verification and release recovery remain outside this issue and belong to PLUXX-320.
+
+## Verdict
+
+No unresolved P0-P2 correctness, security, reliability, or supply-chain finding remains in the PLUXX-319 diff. The branch is ready for final serial validation and PR review.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -74,7 +74,7 @@ The current next ship decision is to make Codex companion apply and verify first
 
 See [docs/orchid/decisions/2026-06-26-pluxx-next-ship-review.md](./orchid/decisions/2026-06-26-pluxx-next-ship-review.md).
 
-The follow-on slice is install ownership tracking for conservative uninstall, prune, reinstall, and "what did Pluxx touch?" diagnostics.
+The transactional install-ownership slice is now implemented across the core-four local and generated release-installer paths. It stages and validates candidate bundles, retains rollback backups through post-install work, hashes owned files, preserves modified/unowned content, adds conservative Codex config unapply, and makes verification content-aware even when versions match.
 
 ## Current Priority Order
 
@@ -113,7 +113,7 @@ The closure plan is now narrower than it was before:
 - the next concrete OSS-authoring robustness slice is Codex companion apply/verify:
   - make generated readiness, hook, MCP approval, and companion config artifacts operational and verifiable instead of advisory only
   - keep the work aligned with `PLUXX-226`, `PLUXX-264`, `PLUXX-248`, and [docs/orchid/decisions/2026-06-26-pluxx-next-ship-review.md](./orchid/decisions/2026-06-26-pluxx-next-ship-review.md)
-  - treat install ownership tracking as the follow-on slice
+  - transactional install ownership now covers conservative reinstall/uninstall, rollback, and content drift across the core four
 - local stdio import quality is now stronger for the common "I already have an MCP" path:
   - `init --from-mcp` auto-recovers `passthrough` for project-relative runtimes such as `./build/index.js`
   - `lint` catches unbundled stdio runtime payloads earlier

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -1,6 +1,6 @@
 # Start Here
 
-Last updated: 2026-06-27
+Last updated: 2026-07-12
 
 ## Doc Links
 
@@ -131,7 +131,9 @@ Generated Codex companion artifacts should become operational rather than only a
 
 The decision note is [docs/orchid/decisions/2026-06-26-pluxx-next-ship-review.md](./orchid/decisions/2026-06-26-pluxx-next-ship-review.md).
 
-The Codex agent-registration slice uses a narrow host-specific ownership record. General cross-host install ownership tracking remains the follow-on because it supports conservative uninstall, prune, reinstall, and diagnostics beyond this one companion surface.
+Core-four local installs now use a shared transactional ownership layer. Copied bundles are staged and validated before an atomic sibling swap, the previous bundle stays recoverable until post-install work succeeds, ownership records hash installed files, reinstall refuses modified or unowned content, uninstall removes only unchanged owned files, and `verify-install` reports same-version content drift. Generated GitHub Release installers use the same stage/backup/rollback and ownership contract.
+
+Codex companion config now has a conservative inverse too: `pluxx codex apply` records the exact before/after config state it owns, and `pluxx codex unapply` restores the prior state only while the applied config remains unchanged. If the user edits active config after apply, unapply preserves it and asks for manual reconciliation instead of overwriting unrelated changes.
 
 ## Who Pluxx Is For Right Now
 

--- a/docs/todo/master-backlog.md
+++ b/docs/todo/master-backlog.md
@@ -110,7 +110,12 @@ Any person or agent should be able to enter the repo and answer:
   - cover idempotency, stale config, malformed companion artifacts, and absent companion files
   - keep execution aligned with `PLUXX-226`, `PLUXX-264`, and `PLUXX-248`
   - see [docs/orchid/decisions/2026-06-26-pluxx-next-ship-review.md](../orchid/decisions/2026-06-26-pluxx-next-ship-review.md)
-- [ ] Follow Codex companion apply/verify with install ownership tracking so uninstall, prune, reinstall, and "what did Pluxx touch?" diagnostics can stay conservative
+- [x] Add transactional install ownership so reinstall, uninstall, and "what did Pluxx touch?" diagnostics stay conservative:
+  - shared core-four ownership records hash installed files and validate paths before mutation
+  - copied installs and generated release installers use stage, backup, atomic swap, and rollback
+  - modified and unowned files block replacement and survive uninstall
+  - non-Codex verification catches same-version content drift
+  - Codex config apply/unapply restores only unchanged owned state and preserves later user edits
 - [~] Keep OpenClaw in the documented beta-target lane until native generator, doctor, and smoke proof exist:
   - [docs/openclaw-target-evaluation.md](../openclaw-target-evaluation.md)
 - [~] Turn the provider and branding audits into an explicit closure tracker for every mapped cross-host feature:

--- a/docs/todo/queue.md
+++ b/docs/todo/queue.md
@@ -1,6 +1,6 @@
 # Pluxx Queue
 
-Last updated: 2026-06-27
+Last updated: 2026-07-12
 
 ## Doc Links
 
@@ -234,7 +234,12 @@ Open work:
   - cover hooks, readiness, MCP approval stanzas, companion config diffs/backups, idempotency, stale config, malformed companion artifacts, and no-op behavior when companion files are absent
   - keep this aligned with `PLUXX-226`, `PLUXX-264`, and `PLUXX-248`
   - use [docs/orchid/decisions/2026-06-26-pluxx-next-ship-review.md](../orchid/decisions/2026-06-26-pluxx-next-ship-review.md) as the decision note
-- after Codex companion apply/verify, ship install ownership tracking for conservative uninstall, prune, reinstall, and "what did Pluxx touch?" diagnostics
+- [x] Ship transactional core-four install ownership for conservative reinstall, uninstall, and content diagnostics:
+  - local copied installs and generated release installers stage and validate before a sibling swap
+  - the prior bundle remains available for rollback until post-install work succeeds
+  - modified or unowned installed files are preserved instead of silently replaced or deleted
+  - `verify-install` distinguishes version equality from content equality
+  - Codex config apply/unapply is ownership-backed and conservative
 - keep GTM-sensitive material out of the public repo
 - continue reconciling stale planning artifacts that still describe already-shipped work as future work
 - close the remaining Linear drift where shipped work like installed-MCP discovery is still marked as backlog

--- a/src/cli/codex-apply.ts
+++ b/src/cli/codex-apply.ts
@@ -1,4 +1,5 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { createHash, randomBytes } from 'crypto'
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from 'fs'
 import { homedir } from 'os'
 import { dirname, resolve } from 'path'
 import {
@@ -34,6 +35,26 @@ export interface CodexCompanionApplyResult {
   configPath: string
   changed: boolean
   actions: CodexCompanionApplyAction[]
+}
+
+export interface CodexCompanionUnapplyResult {
+  ok: boolean
+  dryRun: boolean
+  consumerRoot: string
+  configPath: string
+  ownershipPath: string
+  changed: boolean
+  preserved: boolean
+  detail: string
+}
+
+interface CodexConfigOwnership {
+  schema: 'pluxx.codex-config-apply.v1'
+  pluginName: string
+  configPath: string
+  beforeSha256: string
+  afterSha256: string
+  beforeText: string
 }
 
 interface MergeResult {
@@ -182,8 +203,26 @@ function buildCodexCompanionApplyPlan(options: CodexCompanionApplyOptions): Inte
 export function applyCodexCompanion(options: CodexCompanionApplyOptions): CodexCompanionApplyResult {
   const planned = buildCodexCompanionApplyPlan(options)
   if (planned.changed && !options.dryRun && planned.nextText !== undefined) {
-    mkdirSync(dirname(planned.configPath), { recursive: true })
-    writeFileSync(planned.configPath, planned.nextText)
+    const beforeText = existsSync(planned.configPath) ? readFileSync(planned.configPath, 'utf-8') : ''
+    const pluginName = readCodexPluginName(planned.consumerRoot)
+    const ownershipPath = getCodexConfigOwnershipPath(pluginName, options.codexHome)
+    const ownership: CodexConfigOwnership = {
+      schema: 'pluxx.codex-config-apply.v1',
+      pluginName,
+      configPath: planned.configPath,
+      beforeSha256: hashText(beforeText),
+      afterSha256: hashText(planned.nextText),
+      beforeText,
+    }
+    const configMode = existsSync(planned.configPath) ? statSync(planned.configPath).mode & 0o777 : 0o600
+    try {
+      atomicWrite(planned.configPath, planned.nextText, configMode)
+      atomicWrite(ownershipPath, `${JSON.stringify(ownership, null, 2)}\n`, 0o600)
+    } catch (error) {
+      atomicWrite(planned.configPath, beforeText, configMode)
+      rmSync(ownershipPath, { force: true })
+      throw error
+    }
   }
   if ((options.includeAgents ?? true) && !options.dryRun) {
     syncCodexAgentRegistration({
@@ -193,6 +232,101 @@ export function applyCodexCompanion(options: CodexCompanionApplyOptions): CodexC
   }
 
   return stripInternalApplyResult(planned)
+}
+
+export function unapplyCodexCompanion(options: CodexCompanionApplyOptions): CodexCompanionUnapplyResult {
+  const consumerRoot = resolve(options.consumerRoot)
+  const pluginName = readCodexPluginName(consumerRoot)
+  const ownershipPath = getCodexConfigOwnershipPath(pluginName, options.codexHome)
+  if (!existsSync(ownershipPath)) {
+    return {
+      ok: true,
+      dryRun: options.dryRun ?? false,
+      consumerRoot,
+      configPath: resolveCodexApplyConfigPath(options),
+      ownershipPath,
+      changed: false,
+      preserved: false,
+      detail: 'No Pluxx-owned Codex config apply record exists.',
+    }
+  }
+  const expectedConfigPath = resolveCodexApplyConfigPath(options)
+  const ownership = readCodexConfigOwnership(ownershipPath, pluginName, expectedConfigPath)
+  const currentText = existsSync(ownership.configPath) ? readFileSync(ownership.configPath, 'utf-8') : ''
+  if (hashText(currentText) !== ownership.afterSha256) {
+    return {
+      ok: true,
+      dryRun: options.dryRun ?? false,
+      consumerRoot,
+      configPath: ownership.configPath,
+      ownershipPath,
+      changed: false,
+      preserved: true,
+      detail: 'Preserved active Codex config because it changed after Pluxx apply; remove the owned settings manually after reviewing the diff.',
+    }
+  }
+  if (!options.dryRun) {
+    const configMode = existsSync(ownership.configPath) ? statSync(ownership.configPath).mode & 0o777 : 0o600
+    atomicWrite(ownership.configPath, ownership.beforeText, configMode)
+    rmSync(ownershipPath, { force: true })
+  }
+  return {
+    ok: true,
+    dryRun: options.dryRun ?? false,
+    consumerRoot,
+    configPath: ownership.configPath,
+    ownershipPath,
+    changed: true,
+    preserved: false,
+    detail: 'Removed the unchanged Codex config state owned by Pluxx and restored the previous config.',
+  }
+}
+
+function hashText(value: string): string {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+function atomicWrite(path: string, content: string, mode = 0o600): void {
+  mkdirSync(dirname(path), { recursive: true })
+  const temporary = `${path}.tmp-${process.pid}-${randomBytes(4).toString('hex')}`
+  writeFileSync(temporary, content, { mode })
+  renameSync(temporary, path)
+}
+
+function readCodexPluginName(consumerRoot: string): string {
+  const manifestPath = resolve(consumerRoot, '.codex-plugin/plugin.json')
+  try {
+    const parsed = JSON.parse(readFileSync(manifestPath, 'utf-8')) as { name?: unknown }
+    if (typeof parsed.name !== 'string' || !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(parsed.name)) throw new Error('invalid plugin name')
+    return parsed.name
+  } catch (error) {
+    throw new Error(`Cannot identify Codex plugin from ${manifestPath}: ${String(error)}`)
+  }
+}
+
+function getCodexConfigOwnershipPath(pluginName: string, codexHome?: string): string {
+  const homeDir = process.env.HOME?.trim() || homedir()
+  const root = resolve(codexHome ?? process.env.CODEX_HOME?.trim() ?? resolve(homeDir, '.codex'))
+  return resolve(root, 'pluxx/config-applies', `${pluginName}.json`)
+}
+
+function readCodexConfigOwnership(path: string, pluginName: string, expectedConfigPath: string): CodexConfigOwnership {
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8')) as Partial<CodexConfigOwnership>
+    if (
+      parsed.schema !== 'pluxx.codex-config-apply.v1'
+      || parsed.pluginName !== pluginName
+      || typeof parsed.configPath !== 'string'
+      || resolve(parsed.configPath) !== resolve(expectedConfigPath)
+      || typeof parsed.beforeText !== 'string'
+      || parsed.beforeSha256 !== hashText(parsed.beforeText)
+      || typeof parsed.afterSha256 !== 'string'
+      || !/^[a-f0-9]{64}$/.test(parsed.afterSha256)
+    ) throw new Error('unexpected ownership schema, identity, or hashes')
+    return parsed as CodexConfigOwnership
+  } catch (error) {
+    throw new Error(`Cannot use Codex config ownership record ${path}: ${String(error)}`)
+  }
 }
 
 export function ensureCodexHooksFeature(source: string): MergeResult {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -79,7 +79,7 @@ import { printVerifyInstallResult, verifyInstall } from './verify-install'
 import { runBehavioralSuite } from './behavioral'
 import type { BehavioralSuiteResult } from './behavioral'
 import { planTextFileAction, writeTextFile } from '../text-files'
-import { applyCodexCompanion, renderCodexCompanionApplyLines } from './codex-apply'
+import { applyCodexCompanion, renderCodexCompanionApplyLines, unapplyCodexCompanion } from './codex-apply'
 import {
   discoverInstalledMcpServers,
   formatInstalledMcpSource,
@@ -3409,11 +3409,24 @@ async function runVerifyInstall() {
 
 async function runCodex() {
   const subcommand = args[1]
-  if (subcommand === 'apply') {
+  if (subcommand === 'apply' || subcommand === 'unapply') {
     const consumerRoot = readOption(args, '--consumer') ?? args[2]
     if (!consumerRoot || consumerRoot.startsWith('-')) {
-      console.error('Usage: pluxx codex apply --consumer <installed-codex-bundle> [--config <config.toml>|--project-root <path>|--user] [--agents-only|--hooks-only|--mcp-approvals-only] [--dry-run] [--json]')
+      console.error(`Usage: pluxx codex ${subcommand} --consumer <installed-codex-bundle> [--config <config.toml>|--project-root <path>|--user] [--agents-only|--hooks-only|--mcp-approvals-only] [--dry-run] [--json]`)
       process.exit(1)
+    }
+
+    if (subcommand === 'unapply') {
+      const result = unapplyCodexCompanion({
+        consumerRoot,
+        configPath: readOption(args, '--config'),
+        projectRoot: readOption(args, '--project-root'),
+        userConfig: readFlag(args, '--user'),
+        dryRun: runtime.dryRun,
+      })
+      if (runtime.jsonOutput) printJson(result)
+      else if (!runtime.quiet) console.log(`${runtime.dryRun ? 'Dry run: ' : ''}${result.detail}`)
+      return
     }
 
     const hooksOnly = readFlag(args, '--hooks-only')
@@ -3448,7 +3461,7 @@ async function runCodex() {
     return
   }
 
-  console.error('Usage: pluxx codex apply --consumer <installed-codex-bundle> [--config <config.toml>|--project-root <path>|--user] [--agents-only|--hooks-only|--mcp-approvals-only] [--dry-run] [--json]')
+  console.error('Usage: pluxx codex <apply|unapply> --consumer <installed-codex-bundle> [--config <config.toml>|--project-root <path>|--user] [--agents-only|--hooks-only|--mcp-approvals-only] [--dry-run] [--json]')
   process.exit(1)
 }
 
@@ -3510,6 +3523,7 @@ Usage:
   pluxx agent prompt <kind>               Generate a prompt pack (taxonomy, instructions, review)
   pluxx agent run <kind> --runner <id>    Execute a prompt pack via Claude, Cursor, Codex, or OpenCode headlessly
   pluxx codex apply --consumer <path>     Register custom agents and merge generated Codex companion prerequisites
+  pluxx codex unapply --consumer <path>   Conservatively restore unchanged Codex config owned by the last apply
   pluxx discover-mcp [--host <hosts...>] List installed MCP servers from local host configs
   pluxx mcp proxy ...                     Run a local MCP proxy with optional record/replay tapes
   pluxx autopilot --from-mcp ...          Run import + agent refinement + verification in one command
@@ -3574,6 +3588,7 @@ Examples:
   pluxx agent run taxonomy --runner codex --verbose-runner
   pluxx agent run review --runner opencode --attach http://localhost:4096 --no-verify
   pluxx codex apply --consumer ./dist/codex --project-root . --dry-run
+  pluxx codex unapply --consumer ./dist/codex --project-root . --dry-run
   pluxx autopilot --from-mcp https://example.com/mcp --runner codex --website https://example.com --docs https://docs.example.com --ingest-provider auto
   pluxx mcp proxy --from-mcp "node ./server.js" --record .pluxx/tapes/dev.json
   pluxx mcp proxy --replay .pluxx/tapes/dev.json

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -35,7 +35,12 @@ import {
   removeCodexAgentRegistration,
   syncCodexAgentRegistration,
 } from '../codex-agent-install'
-import { removeOwnedInstall, transactionalInstall } from '../install-ownership'
+import {
+  listInstallOwnership,
+  removeOwnedInstall,
+  transactionalInstall,
+  transactionalInstallGroup,
+} from '../install-ownership'
 
 interface InstallTarget {
   platform: TargetPlatform
@@ -373,13 +378,9 @@ function toPascalCase(value: string): string {
     .join('')
 }
 
-function writeOpenCodeEntryFile(pluginDir: string, pluginName: string): void {
-  const entryPath = getOpenCodeEntryPath(pluginDir)
+function buildOpenCodeEntryFile(pluginName: string): string {
   const exportName = toPascalCase(pluginName)
-
-  writeFileSync(
-    entryPath,
-    [
+  return [
       'import type { Plugin } from "@opencode-ai/plugin"',
       'import { join } from "path"',
       '',
@@ -399,8 +400,7 @@ function writeOpenCodeEntryFile(pluginDir: string, pluginName: string): void {
       `    directory: join(context.directory, "${pluginName}"),`,
       '  })',
       '',
-    ].join('\n'),
-  )
+    ].join('\n')
 }
 
 function getOpenCodeSkillRoot(): string {
@@ -432,28 +432,21 @@ function namespaceOpenCodeSkill(content: string, pluginName: string, fallbackNam
   return `${content.slice(0, frontmatterMatch.index)}---\n${nextFrontmatter}\n---\n${content.slice(frontmatterMatch[0].length)}`
 }
 
-function syncOpenCodeSkills(pluginDir: string, pluginName: string): void {
-  const sourceSkillsDir = resolve(pluginDir, 'skills')
-  if (!existsSync(sourceSkillsDir)) return
-
-  mkdirSync(getOpenCodeSkillRoot(), { recursive: true })
-
-  for (const entry of readdirSync(sourceSkillsDir, { withFileTypes: true })) {
-    if (!entry.isDirectory()) continue
-
-    const skillSourceDir = resolve(sourceSkillsDir, entry.name)
-    if (!existsSync(resolve(skillSourceDir, 'SKILL.md'))) continue
-
-    const installedSkillDir = getOpenCodeInstalledSkillDir(pluginName, entry.name)
-    rmSync(installedSkillDir, { recursive: true, force: true })
-    cpSync(skillSourceDir, installedSkillDir, { recursive: true })
-
-    const skillPath = resolve(installedSkillDir, 'SKILL.md')
-    writeFileSync(
-      skillPath,
-      namespaceOpenCodeSkill(readFileSync(skillPath, 'utf-8'), pluginName, entry.name),
-    )
-  }
+function getOpenCodeSkillInstallTargets(sourcePluginDir: string, pluginName: string) {
+  const sourceSkillsDir = resolve(sourcePluginDir, 'skills')
+  if (!existsSync(sourceSkillsDir)) return []
+  return readdirSync(sourceSkillsDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && existsSync(resolve(sourceSkillsDir, entry.name, 'SKILL.md')))
+    .map((entry) => ({
+      sourcePath: resolve(sourceSkillsDir, entry.name),
+      installPath: getOpenCodeInstalledSkillDir(pluginName, entry.name),
+      kind: 'copy' as const,
+      surface: `skill-${entry.name}`,
+      prepare: (stagePath: string): void => {
+        const skillPath = resolve(stagePath, 'SKILL.md')
+        writeFileSync(skillPath, namespaceOpenCodeSkill(readFileSync(skillPath, 'utf-8'), pluginName, entry.name))
+      },
+    }))
 }
 
 function verifyOpenCodeInstall(pluginDir: string, pluginName: string): void {
@@ -494,20 +487,6 @@ function verifyOpenCodeInstall(pluginDir: string, pluginName: string): void {
   }
 }
 
-function removeOpenCodeSkills(pluginName: string): boolean {
-  const root = getOpenCodeSkillRoot()
-  if (!existsSync(root)) return false
-
-  let removed = false
-  for (const entry of readdirSync(root, { withFileTypes: true })) {
-    if (!entry.name.startsWith(`${pluginName}-`)) continue
-    rmSync(resolve(root, entry.name), { recursive: true, force: true })
-    removed = true
-  }
-
-  return removed
-}
-
 export function getInstallFollowupNotes(platforms: TargetPlatform[]): string[] {
   return getDistributionInstallFollowupNotes(platforms)
 }
@@ -535,10 +514,35 @@ function createSymlinkInstall(target: PlannedInstallTarget, pluginName: string):
   })
 }
 
-function createOpenCodeSymlinkInstall(target: PlannedInstallTarget, pluginName: string): void {
-  createSymlinkInstall(target, pluginName)
-  writeOpenCodeEntryFile(target.pluginDir, pluginName)
-  syncOpenCodeSkills(target.pluginDir, pluginName)
+function createOpenCodeInstall(
+  target: PlannedInstallTarget,
+  pluginName: string,
+  kind: 'copy' | 'symlink',
+  prepare?: (stagePath: string) => void,
+): void {
+  const manifestPath = manifestPathForPlatform(target.platform)
+  transactionalInstallGroup({
+    pluginName,
+    platform: 'opencode',
+    targets: [
+      {
+        sourcePath: target.sourceDir,
+        installPath: target.pluginDir,
+        kind,
+        prepare,
+        validate: manifestPath && existsSync(resolve(target.sourceDir, manifestPath))
+          ? path => assertInstalledBundleIntegrity(path, target.platform, 'Staged opencode plugin bundle')
+          : undefined,
+      },
+      {
+        installPath: getOpenCodeEntryPath(target.pluginDir),
+        kind: 'file',
+        surface: 'entry',
+        content: buildOpenCodeEntryFile(pluginName),
+      },
+      ...getOpenCodeSkillInstallTargets(target.sourceDir, pluginName),
+    ],
+  })
 }
 
 function getCodexMarketplacePath(): string {
@@ -658,12 +662,6 @@ function createCopiedInstall(
     prepare,
     validate: validateBundle,
   })
-}
-
-function createOpenCodeCopiedInstall(target: PlannedInstallTarget, pluginName: string): void {
-  createCopiedInstall(target, pluginName)
-  writeOpenCodeEntryFile(target.pluginDir, pluginName)
-  syncOpenCodeSkills(target.pluginDir, pluginName)
 }
 
 function materializeTemplateValue(value: string, env: Record<string, string>, secretEnvVars = new Set<string>()): string {
@@ -1566,15 +1564,14 @@ export async function installPlugin(
           : undefined,
       )
     } else if (target.platform === 'opencode' && shouldMaterialize) {
-      createCopiedInstall(
+      createOpenCodeInstall(
         target,
         pluginName,
+        'copy',
         stagePath => materializeInstalledPlugin(stagePath, target.platform, options.config!, targetConfigEntries, target.pluginDir),
       )
-      writeOpenCodeEntryFile(target.pluginDir, pluginName)
-      syncOpenCodeSkills(target.pluginDir, pluginName)
     } else if (target.platform === 'opencode') {
-      createOpenCodeSymlinkInstall(target, pluginName)
+      createOpenCodeInstall(target, pluginName, 'symlink')
       verifyOpenCodeInstall(target.pluginDir, pluginName)
     } else if (shouldMaterialize || shouldMaterializeCodexInstall) {
       createCopiedInstall(
@@ -1639,19 +1636,30 @@ export async function uninstallPlugin(
       continue
     }
 
-    const ownedRemoval = removeOwnedInstall(pluginName, target.platform, target.pluginDir)
-    let removedTarget = ownedRemoval.changed
-    if (ownedRemoval.preserved.length > 0 && !options.quiet) {
-      console.warn(`  preserved ${ownedRemoval.preserved.length} modified or unowned installed path(s) under ${target.pluginDir}`)
+    const ownershipRecords = target.platform === 'opencode'
+      ? listInstallOwnership(pluginName, target.platform)
+      : []
+    const removals = target.platform === 'opencode' && ownershipRecords.length > 0
+      ? ownershipRecords.map((record) => removeOwnedInstall(pluginName, target.platform, record.installPath, record.surface))
+      : [removeOwnedInstall(pluginName, target.platform, target.pluginDir)]
+    let removedTarget = removals.some((removal) => removal.changed)
+    const preserved = removals.flatMap((removal) => removal.preserved)
+    if (preserved.length > 0 && !options.quiet) {
+      console.warn(`  preserved ${preserved.length} modified or unowned installed path(s) for ${target.description}`)
     }
     if (target.platform === 'opencode') {
-      const entryPath = getOpenCodeEntryPath(target.pluginDir)
-      if (existsSync(entryPath)) {
-        rmSync(entryPath, { force: true })
-        removedTarget = true
-      }
-      if (removeOpenCodeSkills(pluginName)) {
-        removedTarget = true
+      if (ownershipRecords.length === 0) {
+        const unownedCompanions = [getOpenCodeEntryPath(target.pluginDir)]
+        const skillRoot = getOpenCodeSkillRoot()
+        if (existsSync(skillRoot)) {
+          unownedCompanions.push(...readdirSync(skillRoot)
+            .filter((name) => name.startsWith(`${pluginName}-`))
+            .map((name) => resolve(skillRoot, name)))
+        }
+        const existingUnowned = unownedCompanions.filter(existsSync)
+        if (existingUnowned.length > 0 && !options.quiet) {
+          console.warn(`  preserved ${existingUnowned.length} unowned OpenCode companion path(s)`)
+        }
       }
     }
     if (target.platform === 'codex') {

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -35,6 +35,7 @@ import {
   removeCodexAgentRegistration,
   syncCodexAgentRegistration,
 } from '../codex-agent-install'
+import { removeOwnedInstall, transactionalInstall } from '../install-ownership'
 
 interface InstallTarget {
   platform: TargetPlatform
@@ -520,19 +521,22 @@ function runCommandDefault(command: string, args: string[]): CommandResult {
   }
 }
 
-function createSymlinkInstall(target: PlannedInstallTarget): void {
-  const parentDir = resolve(target.pluginDir, '..')
-  mkdirSync(parentDir, { recursive: true })
-
-  if (existsSync(target.pluginDir)) {
-    rmSync(target.pluginDir, { recursive: true, force: true })
-  }
-
-  symlinkSync(target.sourceDir, target.pluginDir)
+function createSymlinkInstall(target: PlannedInstallTarget, pluginName: string): void {
+  const manifestPath = manifestPathForPlatform(target.platform)
+  transactionalInstall({
+    pluginName,
+    platform: target.platform,
+    sourcePath: target.sourceDir,
+    installPath: target.pluginDir,
+    kind: 'symlink',
+    validate: manifestPath && existsSync(resolve(target.sourceDir, manifestPath))
+      ? path => assertInstalledBundleIntegrity(path, target.platform, `Staged ${target.platform} plugin bundle`)
+      : undefined,
+  })
 }
 
 function createOpenCodeSymlinkInstall(target: PlannedInstallTarget, pluginName: string): void {
-  createSymlinkInstall(target)
+  createSymlinkInstall(target, pluginName)
   writeOpenCodeEntryFile(target.pluginDir, pluginName)
   syncOpenCodeSkills(target.pluginDir, pluginName)
 }
@@ -632,19 +636,32 @@ function clearCodexLocalCache(pluginName: string): void {
   rmSync(cacheRoot, { recursive: true, force: true })
 }
 
-function createCopiedInstall(target: PlannedInstallTarget): void {
-  const parentDir = resolve(target.pluginDir, '..')
-  mkdirSync(parentDir, { recursive: true })
-
-  if (existsSync(target.pluginDir)) {
-    rmSync(target.pluginDir, { recursive: true, force: true })
+function createCopiedInstall(
+  target: PlannedInstallTarget,
+  pluginName: string,
+  prepare?: (stagePath: string) => void,
+  validate?: (path: string) => void,
+): void {
+  const manifestPath = manifestPathForPlatform(target.platform)
+  const validateBundle = (path: string): void => {
+    if (manifestPath && existsSync(resolve(path, manifestPath))) {
+      assertInstalledBundleIntegrity(path, target.platform, `Staged ${target.platform} plugin bundle`)
+    }
+    validate?.(path)
   }
-
-  cpSync(target.sourceDir, target.pluginDir, { recursive: true })
+  transactionalInstall({
+    pluginName,
+    platform: target.platform,
+    sourcePath: target.sourceDir,
+    installPath: target.pluginDir,
+    kind: 'copy',
+    prepare,
+    validate: validateBundle,
+  })
 }
 
 function createOpenCodeCopiedInstall(target: PlannedInstallTarget, pluginName: string): void {
-  createCopiedInstall(target)
+  createCopiedInstall(target, pluginName)
   writeOpenCodeEntryFile(target.pluginDir, pluginName)
   syncOpenCodeSkills(target.pluginDir, pluginName)
 }
@@ -697,6 +714,7 @@ function patchInstalledMcpConfig(
   platform: TargetPlatform,
   config: PluginConfig,
   entries: ResolvedUserConfigEntry[],
+  runtimeRoot = pluginDir,
 ): void {
   if (!config.mcp) return
 
@@ -721,10 +739,10 @@ function patchInstalledMcpConfig(
       if (server.transport === 'stdio') {
         const serverRuntimeEnvVars = collectStdioServerRuntimeEnvVars(server.env, runtimeEnvVars)
         const commandConfig = serverRuntimeEnvVars.size > 0
-          ? buildRuntimeWrappedStdioMcpCommand(server, platform, serverRuntimeEnvVars, pluginDir)
+          ? buildRuntimeWrappedStdioMcpCommand(server, platform, serverRuntimeEnvVars, runtimeRoot)
           : {
-              command: materializeInstalledPluginOwnedStdioPathForPlatform(server.command, platform, pluginDir),
-              args: (server.args ?? []).map((value) => materializeInstalledPluginOwnedStdioPathForPlatform(value, platform, pluginDir)),
+              command: materializeInstalledPluginOwnedStdioPathForPlatform(server.command, platform, runtimeRoot),
+              args: (server.args ?? []).map((value) => materializeInstalledPluginOwnedStdioPathForPlatform(value, platform, runtimeRoot)),
             }
         const stdioEnv = materializeStdioEnvRecord(server.env, env, secretEnvVars, serverRuntimeEnvVars)
         if (serverRuntimeEnvVars.size > 0) ensureMcpRuntimeEnvScript(pluginDir)
@@ -770,10 +788,10 @@ function patchInstalledMcpConfig(
       if (server.transport === 'stdio') {
         const serverRuntimeEnvVars = collectStdioServerRuntimeEnvVars(server.env, runtimeEnvVars)
         const commandConfig = serverRuntimeEnvVars.size > 0
-          ? buildRuntimeWrappedStdioMcpCommand(server, platform, serverRuntimeEnvVars, pluginDir)
+          ? buildRuntimeWrappedStdioMcpCommand(server, platform, serverRuntimeEnvVars, runtimeRoot)
           : {
-              command: materializeInstalledPluginOwnedStdioPathForPlatform(server.command, platform, pluginDir),
-              args: (server.args ?? []).map((value) => materializeInstalledPluginOwnedStdioPathForPlatform(value, platform, pluginDir)),
+              command: materializeInstalledPluginOwnedStdioPathForPlatform(server.command, platform, runtimeRoot),
+              args: (server.args ?? []).map((value) => materializeInstalledPluginOwnedStdioPathForPlatform(value, platform, runtimeRoot)),
             }
         const stdioEnv = materializeStdioEnvRecord(server.env, env, secretEnvVars, serverRuntimeEnvVars)
         if (serverRuntimeEnvVars.size > 0) ensureMcpRuntimeEnvScript(pluginDir)
@@ -870,6 +888,7 @@ function materializeInstalledPlugin(
   platform: TargetPlatform,
   config: PluginConfig,
   entries: ResolvedUserConfigEntry[],
+  runtimeRoot = pluginDir,
 ): void {
   const runtimeEnvVars = collectRuntimeInheritedStdioEnvVars(config, [platform])
   const persistentEntries = entries.filter((entry) => !entry.envVar || !runtimeEnvVars.has(entry.envVar))
@@ -877,7 +896,7 @@ function materializeInstalledPlugin(
     writeInstalledUserConfig(pluginDir, config, persistentEntries, platform)
     disableInstalledEnvValidation(pluginDir, persistentEntries)
   }
-  patchInstalledMcpConfig(pluginDir, platform, config, entries)
+  patchInstalledMcpConfig(pluginDir, platform, config, entries, runtimeRoot)
 }
 
 function codexInstallNeedsCopiedMaterialization(config?: PluginConfig): boolean {
@@ -1547,17 +1566,24 @@ export async function installPlugin(
           : undefined,
       )
     } else if (target.platform === 'opencode' && shouldMaterialize) {
-      createOpenCodeCopiedInstall(target, pluginName)
-      materializeInstalledPlugin(target.pluginDir, target.platform, options.config!, targetConfigEntries)
-      verifyOpenCodeInstall(target.pluginDir, pluginName)
+      createCopiedInstall(
+        target,
+        pluginName,
+        stagePath => materializeInstalledPlugin(stagePath, target.platform, options.config!, targetConfigEntries, target.pluginDir),
+      )
+      writeOpenCodeEntryFile(target.pluginDir, pluginName)
+      syncOpenCodeSkills(target.pluginDir, pluginName)
     } else if (target.platform === 'opencode') {
       createOpenCodeSymlinkInstall(target, pluginName)
       verifyOpenCodeInstall(target.pluginDir, pluginName)
     } else if (shouldMaterialize || shouldMaterializeCodexInstall) {
-      createCopiedInstall(target)
-      materializeInstalledPlugin(target.pluginDir, target.platform, options.config!, targetConfigEntries)
+      createCopiedInstall(
+        target,
+        pluginName,
+        stagePath => materializeInstalledPlugin(stagePath, target.platform, options.config!, targetConfigEntries, target.pluginDir),
+      )
     } else {
-      createSymlinkInstall(target)
+      createSymlinkInstall(target, pluginName)
     }
     const manifestPath = manifestPathForPlatform(target.platform)
     if (manifestPath && existsSync(resolve(target.pluginDir, manifestPath))) {
@@ -1613,10 +1639,10 @@ export async function uninstallPlugin(
       continue
     }
 
-    let removedTarget = false
-    if (existsSync(target.pluginDir)) {
-      rmSync(target.pluginDir, { recursive: true, force: true })
-      removedTarget = true
+    const ownedRemoval = removeOwnedInstall(pluginName, target.platform, target.pluginDir)
+    let removedTarget = ownedRemoval.changed
+    if (ownedRemoval.preserved.length > 0 && !options.quiet) {
+      console.warn(`  preserved ${ownedRemoval.preserved.length} modified or unowned installed path(s) under ${target.pluginDir}`)
     }
     if (target.platform === 'opencode') {
       const entryPath = getOpenCodeEntryPath(target.pluginDir)

--- a/src/cli/publish.ts
+++ b/src/cli/publish.ts
@@ -1929,6 +1929,172 @@ ENTRY_PATH="\${PLUXX_OPENCODE_ENTRY_PATH:-$PLUGIN_ROOT_DIR/$PLUGIN_NAME.ts}"
 SKILLS_ROOT="\${PLUXX_OPENCODE_SKILLS_ROOT:-$HOME/.config/opencode/skills}"
 BUNDLE_PATH="\${PLUXX_OPENCODE_BUNDLE_PATH:-}"
 ${renderInstallerTransactionHelpers('opencode')}
+PLUXX_OPENCODE_COMPANION_STAGE=""
+PLUXX_OPENCODE_COMPANION_JOURNAL=""
+
+pluxx_opencode_companion_cleanup() {
+  [[ -n "$PLUXX_OPENCODE_COMPANION_JOURNAL" && -f "$PLUXX_OPENCODE_COMPANION_JOURNAL" ]] || return 0
+  export PLUXX_OPENCODE_COMPANION_JOURNAL
+  node <<'NODE'
+const fs = require('fs')
+const journal = JSON.parse(fs.readFileSync(process.env.PLUXX_OPENCODE_COMPANION_JOURNAL, 'utf8'))
+for (const move of [...journal.moves].reverse()) {
+  if (fs.existsSync(move.destination)) fs.rmSync(move.destination, { recursive: true, force: true })
+  if (fs.existsSync(move.backup)) fs.renameSync(move.backup, move.destination)
+}
+for (const ledger of journal.ledgers) {
+  if (ledger.backup && fs.existsSync(ledger.backup)) fs.copyFileSync(ledger.backup, ledger.path)
+  else fs.rmSync(ledger.path, { force: true })
+}
+fs.rmSync(process.env.PLUXX_OPENCODE_COMPANION_JOURNAL, { force: true })
+NODE
+}
+
+pluxx_commit_opencode_companions() {
+  export INSTALL_DIR ENTRY_PATH SKILLS_ROOT PLUGIN_NAME PLUXX_OPENCODE_COMPANION_STAGE PLUXX_OPENCODE_COMPANION_JOURNAL
+  node <<'NODE'
+const crypto = require('crypto')
+const fs = require('fs')
+const path = require('path')
+const hash = (value) => crypto.createHash('sha256').update(value).digest('hex')
+const walk = (root) => {
+  const entries = []
+  if (!fs.existsSync(root)) return entries
+  const visit = (directory) => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+      const filepath = path.join(directory, entry.name)
+      const relativePath = path.relative(root, filepath).replace(/\\\\/g, '/')
+      const stats = fs.lstatSync(filepath)
+      if (stats.isSymbolicLink()) entries.push({ path: relativePath, kind: 'symlink', sha256: hash(fs.readlinkSync(filepath)) })
+      else if (stats.isDirectory()) visit(filepath)
+      else if (stats.isFile()) entries.push({ path: relativePath, kind: 'file', sha256: hash(fs.readFileSync(filepath)) })
+    }
+  }
+  visit(root)
+  return entries
+}
+const pluginName = process.env.PLUGIN_NAME
+const installDir = path.resolve(process.env.INSTALL_DIR)
+const entryPath = path.resolve(process.env.ENTRY_PATH)
+const skillsRoot = path.resolve(process.env.SKILLS_ROOT)
+const stageRoot = path.resolve(process.env.PLUXX_OPENCODE_COMPANION_STAGE)
+const home = path.resolve(process.env.HOME)
+const conventionalRoot = path.join(home, '.config', 'opencode')
+const ownershipRoot = installDir === conventionalRoot || installDir.startsWith(conventionalRoot + path.sep)
+  ? path.join(home, '.pluxx/install-ownership')
+  : path.join(path.dirname(installDir), '.pluxx-install-ownership')
+const ledgerRoot = path.join(ownershipRoot, pluginName)
+const candidates = [{ surface: 'entry', source: path.join(stageRoot, 'entry.ts'), destination: entryPath, kind: 'file' }]
+const stagedSkills = path.join(stageRoot, 'skills')
+if (fs.existsSync(stagedSkills)) {
+  for (const name of fs.readdirSync(stagedSkills).sort()) {
+    if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(name)) throw new Error('Unsafe OpenCode skill name: ' + name)
+    candidates.push({ surface: 'skill-' + name, source: path.join(stagedSkills, name), destination: path.join(skillsRoot, pluginName + '-' + name), kind: 'copy' })
+  }
+}
+const previous = new Map()
+if (fs.existsSync(ledgerRoot)) {
+  for (const name of fs.readdirSync(ledgerRoot)) {
+    if (!name.startsWith('opencode--') || !name.endsWith('.json')) continue
+    const surface = name.slice('opencode--'.length, -'.json'.length)
+    previous.set(surface, path.join(ledgerRoot, name))
+  }
+}
+for (const [surface, ledgerPath] of previous) {
+  if (candidates.some((candidate) => candidate.surface === surface)) continue
+  const record = JSON.parse(fs.readFileSync(ledgerPath, 'utf8'))
+  const destination = path.resolve(record.installPath || '')
+  if (!surface.startsWith('skill-') || !destination.startsWith(skillsRoot + path.sep) || !path.basename(destination).startsWith(pluginName + '-')) {
+    throw new Error('Invalid OpenCode companion ownership record: ' + ledgerPath)
+  }
+  candidates.push({ surface, destination, kind: record.kind, remove: true })
+}
+const entriesEqual = (expected, actual) => {
+  const expectedMap = new Map(expected.map((entry) => [entry.path, entry]))
+  const actualMap = new Map(actual.map((entry) => [entry.path, entry]))
+  if (expectedMap.size !== actualMap.size) return false
+  for (const [name, entry] of expectedMap) {
+    const current = actualMap.get(name)
+    if (!current || current.kind !== entry.kind || current.sha256 !== entry.sha256) return false
+  }
+  return true
+}
+for (const candidate of candidates) {
+  const ledgerPath = path.join(ledgerRoot, 'opencode--' + candidate.surface + '.json')
+  candidate.ledgerPath = ledgerPath
+  if (!fs.existsSync(candidate.destination)) {
+    if (fs.existsSync(ledgerPath)) throw new Error('Refusing to replace missing owned OpenCode companion: ' + candidate.destination)
+    continue
+  }
+  if (!fs.existsSync(ledgerPath)) throw new Error('Refusing to replace unowned OpenCode companion: ' + candidate.destination)
+  const record = JSON.parse(fs.readFileSync(ledgerPath, 'utf8'))
+  if (record.schema !== 'pluxx.install-ownership.v1' || record.pluginName !== pluginName || record.platform !== 'opencode' || record.surface !== candidate.surface || path.resolve(record.installPath || '') !== candidate.destination || record.kind !== candidate.kind) {
+    throw new Error('Invalid OpenCode companion ownership record: ' + ledgerPath)
+  }
+  const unchanged = candidate.kind === 'file'
+    ? fs.lstatSync(candidate.destination).isFile() && !fs.lstatSync(candidate.destination).isSymbolicLink() && hash(fs.readFileSync(candidate.destination)) === record.rootSha256
+    : fs.lstatSync(candidate.destination).isDirectory() && !fs.lstatSync(candidate.destination).isSymbolicLink() && entriesEqual(record.entries || [], walk(candidate.destination))
+  if (!unchanged) throw new Error('Refusing to replace modified OpenCode companion: ' + candidate.destination)
+}
+fs.mkdirSync(ledgerRoot, { recursive: true })
+const nonce = process.pid + '-' + crypto.randomBytes(5).toString('hex')
+const journal = { moves: [], ledgers: [] }
+fs.writeFileSync(process.env.PLUXX_OPENCODE_COMPANION_JOURNAL, JSON.stringify(journal))
+const saveJournal = () => fs.writeFileSync(process.env.PLUXX_OPENCODE_COMPANION_JOURNAL, JSON.stringify(journal))
+try {
+  for (const candidate of candidates) {
+    fs.mkdirSync(path.dirname(candidate.destination), { recursive: true })
+    const backup = path.join(path.dirname(candidate.destination), '.' + pluginName + '.pluxx-companion-backup-' + nonce + '-' + journal.moves.length)
+    journal.moves.push({ destination: candidate.destination, backup })
+    if (fs.existsSync(candidate.destination)) fs.renameSync(candidate.destination, backup)
+    if (!candidate.remove) fs.renameSync(candidate.source, candidate.destination)
+    saveJournal()
+  }
+  for (const candidate of candidates) {
+    const ledgerBackup = fs.existsSync(candidate.ledgerPath) ? candidate.ledgerPath + '.backup-' + nonce : undefined
+    if (ledgerBackup) fs.copyFileSync(candidate.ledgerPath, ledgerBackup)
+    journal.ledgers.push({ path: candidate.ledgerPath, backup: ledgerBackup })
+    if (candidate.remove) fs.rmSync(candidate.ledgerPath, { force: true })
+    else {
+      const record = {
+        schema: 'pluxx.install-ownership.v1', pluginName, platform: 'opencode', surface: candidate.surface,
+        installPath: candidate.destination, kind: candidate.kind,
+        ...(candidate.kind === 'file' ? { rootSha256: hash(fs.readFileSync(candidate.destination)) } : { entries: walk(candidate.destination) }),
+        entries: candidate.kind === 'file' ? [] : walk(candidate.destination),
+      }
+      const temporary = candidate.ledgerPath + '.tmp-' + nonce
+      fs.writeFileSync(temporary, JSON.stringify(record, null, 2) + '\\n', { mode: 0o600 })
+      fs.renameSync(temporary, candidate.ledgerPath)
+    }
+    saveJournal()
+  }
+} catch (error) {
+  for (const move of [...journal.moves].reverse()) {
+    if (fs.existsSync(move.destination)) fs.rmSync(move.destination, { recursive: true, force: true })
+    if (fs.existsSync(move.backup)) fs.renameSync(move.backup, move.destination)
+  }
+  for (const ledger of journal.ledgers) {
+    if (ledger.backup && fs.existsSync(ledger.backup)) fs.copyFileSync(ledger.backup, ledger.path)
+    else fs.rmSync(ledger.path, { force: true })
+  }
+  fs.rmSync(process.env.PLUXX_OPENCODE_COMPANION_JOURNAL, { force: true })
+  throw error
+}
+NODE
+}
+
+pluxx_finalize_opencode_companions() {
+  export PLUXX_OPENCODE_COMPANION_JOURNAL
+  node <<'NODE'
+const fs = require('fs')
+const journalPath = process.env.PLUXX_OPENCODE_COMPANION_JOURNAL
+const journal = JSON.parse(fs.readFileSync(journalPath, 'utf8'))
+for (const move of journal.moves) fs.rmSync(move.backup, { recursive: true, force: true })
+for (const ledger of journal.ledgers) if (ledger.backup) fs.rmSync(ledger.backup, { force: true })
+fs.rmSync(journalPath, { force: true })
+NODE
+  PLUXX_OPENCODE_COMPANION_JOURNAL=""
+}
 
 need_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -1943,6 +2109,7 @@ need_cmd node
 
 TMP_DIR="$(mktemp -d)"
 cleanup() {
+  pluxx_opencode_companion_cleanup
   pluxx_tx_cleanup
   rm -rf "$TMP_DIR"
 }
@@ -1973,15 +2140,15 @@ pluxx_begin_install_transaction "$BUNDLE_DIR"
 ${renderInstallerUserConfigSnippet(config, 'opencode', '$PLUXX_TX_STAGE')}
 ${renderInstallerMcpPathMaterializationSnippet('opencode', '$PLUXX_TX_STAGE', '$INSTALL_DIR')}
 ${renderInstallerRuntimeBootstrapSnippet('$PLUXX_TX_STAGE')}
-pluxx_swap_install_transaction
-
-export ENTRY_PATH
-export PLUGIN_NAME
+PLUXX_OPENCODE_COMPANION_STAGE="$TMP_DIR/opencode-companions"
+PLUXX_OPENCODE_COMPANION_JOURNAL="$TMP_DIR/opencode-companions-journal.json"
+mkdir -p "$PLUXX_OPENCODE_COMPANION_STAGE/skills"
+export ENTRY_PATH PLUGIN_NAME PLUXX_OPENCODE_COMPANION_STAGE
 
 node <<'NODE'
 const fs = require('fs')
 
-const entryPath = process.env.ENTRY_PATH
+const entryPath = process.env.PLUXX_OPENCODE_COMPANION_STAGE + '/entry.ts'
 const pluginName = process.env.PLUGIN_NAME
 const exportName = pluginName
   .split(/[^A-Za-z0-9]+/)
@@ -2014,12 +2181,11 @@ const content = [
 fs.writeFileSync(entryPath, content)
 NODE
 
-if [[ -d "$INSTALL_DIR/skills" ]]; then
-  for skill_dir in "$INSTALL_DIR"/skills/*; do
+if [[ -d "$PLUXX_TX_STAGE/skills" ]]; then
+  for skill_dir in "$PLUXX_TX_STAGE"/skills/*; do
     [[ -d "$skill_dir" ]] || continue
     skill_name="$(basename "$skill_dir")"
-    installed_skill_dir="$SKILLS_ROOT/\${PLUGIN_NAME}-\${skill_name}"
-    rm -rf "$installed_skill_dir"
+    installed_skill_dir="$PLUXX_OPENCODE_COMPANION_STAGE/skills/\${skill_name}"
     cp -R "$skill_dir" "$installed_skill_dir"
 
     export SKILL_PATH="$installed_skill_dir/SKILL.md"
@@ -2059,7 +2225,10 @@ fs.writeFileSync(
 NODE
   done
 fi
+pluxx_swap_install_transaction
+pluxx_commit_opencode_companions
 pluxx_finalize_install_transaction
+pluxx_finalize_opencode_companions
 
 echo "Installed $PLUGIN_NAME plugin code to $INSTALL_DIR"
 echo "Installed OpenCode wrapper at $ENTRY_PATH"

--- a/src/cli/publish.ts
+++ b/src/cli/publish.ts
@@ -1015,17 +1015,19 @@ export PLUXX_SAVED_USER_CONFIG_PATH
 `
 }
 
-function renderInstallerMcpPathMaterializationSnippet(platform: TargetPlatform, installDirVariable: string): string {
+function renderInstallerMcpPathMaterializationSnippet(platform: TargetPlatform, installDirVariable: string, runtimeRootVariable = installDirVariable): string {
   if (platform !== 'codex') return ''
 
   return `
 export PLUXX_INSTALL_DIR="${installDirVariable}"
+export PLUXX_RUNTIME_ROOT="${runtimeRootVariable}"
 
 node <<'NODE'
 const fs = require('fs')
 const path = require('path')
 
 const installDir = process.env.PLUXX_INSTALL_DIR
+const runtimeRoot = process.env.PLUXX_RUNTIME_ROOT || installDir
 
 if (installDir) {
   const materializeInstalledStdioPath = (value) => {
@@ -1035,11 +1037,11 @@ if (installDir) {
     const rootRef = normalized.match(/^\\$\\{(?:CLAUDE_PLUGIN_ROOT|CURSOR_PLUGIN_ROOT|PLUGIN_ROOT)\\}[\\\\/](.+)$/)
 
     if (rootRef) {
-      return path.resolve(installDir, rootRef[1])
+      return path.resolve(runtimeRoot, rootRef[1])
     }
 
     if (normalized.startsWith('./') || normalized.startsWith('../')) {
-      return path.resolve(installDir, normalized)
+      return path.resolve(runtimeRoot, normalized)
     }
 
     return value
@@ -1483,6 +1485,135 @@ fi
 `
 }
 
+function renderInstallerTransactionHelpers(platform: 'claude-code' | 'cursor' | 'codex' | 'opencode'): string {
+  return `
+PLUXX_TX_PLATFORM="${platform}"
+PLUXX_TX_STAGE=""
+PLUXX_TX_BACKUP=""
+PLUXX_TX_SWAPPED=0
+
+pluxx_tx_cleanup() {
+  if [[ "$PLUXX_TX_SWAPPED" == "1" ]]; then
+    rm -rf "$INSTALL_DIR"
+    if [[ -e "$PLUXX_TX_BACKUP" || -L "$PLUXX_TX_BACKUP" ]]; then
+      mv "$PLUXX_TX_BACKUP" "$INSTALL_DIR"
+    fi
+  fi
+  [[ -z "$PLUXX_TX_STAGE" ]] || rm -rf "$PLUXX_TX_STAGE"
+}
+
+pluxx_begin_install_transaction() {
+  local bundle_dir="$1"
+  local nonce="$$-$RANDOM"
+  PLUXX_TX_STAGE="$(dirname "$INSTALL_DIR")/.$PLUGIN_NAME.pluxx-stage-$nonce"
+  PLUXX_TX_BACKUP="$(dirname "$INSTALL_DIR")/.$PLUGIN_NAME.pluxx-backup-$nonce"
+  export INSTALL_DIR PLUGIN_NAME PLUXX_TX_PLATFORM PLUXX_TX_STAGE PLUXX_TX_BACKUP
+  export PLUXX_BUNDLE_DIR="$bundle_dir"
+  node <<'NODE'
+const crypto = require('crypto')
+const fs = require('fs')
+const path = require('path')
+const installDir = process.env.INSTALL_DIR
+const pluginName = process.env.PLUGIN_NAME
+const platform = process.env.PLUXX_TX_PLATFORM
+const stage = process.env.PLUXX_TX_STAGE
+const home = path.resolve(process.env.HOME)
+const resolvedInstallDir = path.resolve(installDir)
+const conventionalRoots = [path.join('.claude', 'plugins'), path.join('.cursor', 'plugins'), path.join('.codex', 'plugins'), path.join('.config', 'opencode')].map((value) => path.join(home, value))
+const ownershipRoot = conventionalRoots.some((root) => resolvedInstallDir === root || resolvedInstallDir.startsWith(root + path.sep))
+  ? path.join(home, '.pluxx/install-ownership')
+  : path.join(path.dirname(resolvedInstallDir), '.pluxx-install-ownership')
+const ownershipPath = path.join(ownershipRoot, pluginName, platform + '.json')
+const hash = (value) => crypto.createHash('sha256').update(value).digest('hex')
+const walk = (root) => {
+  if (!fs.existsSync(root)) return []
+  const result = []
+  const visit = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+      const filepath = path.join(dir, entry.name)
+      const relativePath = path.relative(root, filepath).replace(/\\\\/g, '/')
+      const stats = fs.lstatSync(filepath)
+      if (stats.isSymbolicLink()) result.push({ path: relativePath, kind: 'symlink', sha256: hash(fs.readlinkSync(filepath)) })
+      else if (stats.isDirectory()) visit(filepath)
+      else if (stats.isFile()) result.push({ path: relativePath, kind: 'file', sha256: hash(fs.readFileSync(filepath)) })
+    }
+  }
+  visit(root)
+  return result
+}
+if (fs.existsSync(installDir)) {
+  if (!fs.existsSync(ownershipPath)) {
+    const legacy = walk(installDir)
+    if (!legacy.every((entry) => entry.path === '.pluxx-user.json')) {
+      throw new Error('Refusing to replace unowned install at ' + installDir + '. Move it aside or uninstall it manually, then retry.')
+    }
+  } else {
+    const record = JSON.parse(fs.readFileSync(ownershipPath, 'utf8'))
+    if (record.schema !== 'pluxx.install-ownership.v1' || record.pluginName !== pluginName || record.platform !== platform || path.resolve(record.installPath) !== path.resolve(installDir) || !Array.isArray(record.entries)) {
+      throw new Error('Invalid install ownership record: ' + ownershipPath)
+    }
+    const expected = new Map(record.entries.map((entry) => [entry.path, entry]))
+    const actual = new Map(walk(installDir).map((entry) => [entry.path, entry]))
+    for (const [entryPath, entry] of expected) {
+      const current = actual.get(entryPath)
+      if (!current || current.kind !== entry.kind || current.sha256 !== entry.sha256) throw new Error('Refusing to replace modified installed file: ' + entryPath)
+    }
+    for (const entryPath of actual.keys()) if (!expected.has(entryPath)) throw new Error('Refusing to replace unowned installed file: ' + entryPath)
+  }
+}
+fs.cpSync(process.env.PLUXX_BUNDLE_DIR, stage, { recursive: true })
+NODE
+}
+
+pluxx_swap_install_transaction() {
+  if [[ -e "$INSTALL_DIR" || -L "$INSTALL_DIR" ]]; then mv "$INSTALL_DIR" "$PLUXX_TX_BACKUP"; fi
+  mv "$PLUXX_TX_STAGE" "$INSTALL_DIR"
+  PLUXX_TX_SWAPPED=1
+}
+
+pluxx_finalize_install_transaction() {
+  export INSTALL_DIR PLUGIN_NAME PLUXX_TX_PLATFORM
+  node <<'NODE'
+const crypto = require('crypto')
+const fs = require('fs')
+const path = require('path')
+const root = path.resolve(process.env.INSTALL_DIR)
+const hash = (value) => crypto.createHash('sha256').update(value).digest('hex')
+const entries = []
+const visit = (dir) => {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+    const filepath = path.join(dir, entry.name)
+    const relativePath = path.relative(root, filepath).replace(/\\\\/g, '/')
+    const stats = fs.lstatSync(filepath)
+    if (stats.isSymbolicLink()) entries.push({ path: relativePath, kind: 'symlink', sha256: hash(fs.readlinkSync(filepath)) })
+    else if (stats.isDirectory()) visit(filepath)
+    else if (stats.isFile()) entries.push({ path: relativePath, kind: 'file', sha256: hash(fs.readFileSync(filepath)) })
+  }
+}
+visit(root)
+const home = path.resolve(process.env.HOME)
+const conventionalRoots = [path.join('.claude', 'plugins'), path.join('.cursor', 'plugins'), path.join('.codex', 'plugins'), path.join('.config', 'opencode')].map((value) => path.join(home, value))
+const ownershipRoot = conventionalRoots.some((managedRoot) => root === managedRoot || root.startsWith(managedRoot + path.sep))
+  ? path.join(home, '.pluxx/install-ownership')
+  : path.join(path.dirname(root), '.pluxx-install-ownership')
+const ownershipPath = path.join(ownershipRoot, process.env.PLUGIN_NAME, process.env.PLUXX_TX_PLATFORM + '.json')
+fs.mkdirSync(path.dirname(ownershipPath), { recursive: true })
+fs.writeFileSync(ownershipPath, JSON.stringify({
+  schema: 'pluxx.install-ownership.v1',
+  pluginName: process.env.PLUGIN_NAME,
+  platform: process.env.PLUXX_TX_PLATFORM,
+  installPath: root,
+  kind: 'copy',
+  entries,
+}, null, 2) + '\\n', { mode: 0o600 })
+NODE
+  rm -rf "$PLUXX_TX_BACKUP"
+  PLUXX_TX_SWAPPED=0
+  PLUXX_TX_STAGE=""
+}
+`
+}
+
 function renderInstallClaudeCodeScript(config: PluginConfig): string {
   return `#!/usr/bin/env bash
 set -euo pipefail
@@ -1492,11 +1623,13 @@ PLUGIN_NAME="\${PLUXX_PLUGIN_NAME:-PLUGIN_PLACEHOLDER}"
 MARKETPLACE_NAME="\${PLUXX_CLAUDE_MARKETPLACE_NAME:-PLUGIN_PLACEHOLDER-releases}"
 BUNDLE_URL="\${PLUXX_CLAUDE_BUNDLE_URL:-https://github.com/\${REPO}/releases/latest/download/CLAUDE_BUNDLE_PLACEHOLDER}"
 INSTALL_ROOT="\${PLUXX_CLAUDE_MARKETPLACE_DIR:-$HOME/.claude/plugins/data/$MARKETPLACE_NAME}"
+INSTALL_DIR="$INSTALL_ROOT/plugins/$PLUGIN_NAME"
 SKIP_INSTALL="\${PLUXX_CLAUDE_SKIP_INSTALL:-0}"
 BUNDLE_PATH="\${PLUXX_CLAUDE_BUNDLE_PATH:-}"
 AUTHOR_NAME="\${PLUXX_PLUGIN_AUTHOR:-AUTHOR_PLACEHOLDER}"
 HOMEPAGE_URL="\${PLUXX_PLUGIN_HOMEPAGE:-HOMEPAGE_PLACEHOLDER}"
 DESCRIPTION_FALLBACK="\${PLUXX_PLUGIN_DESCRIPTION:-DESCRIPTION_PLACEHOLDER}"
+${renderInstallerTransactionHelpers('claude-code')}
 
 need_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -1509,7 +1642,7 @@ need_cmd tar
 need_cmd mktemp
 need_cmd grep
 need_cmd sed
-${hasInstallerUserConfig(config, 'claude-code') ? 'need_cmd node' : ''}
+need_cmd node
 
 if [[ "$SKIP_INSTALL" != "1" ]]; then
   need_cmd curl
@@ -1518,6 +1651,7 @@ fi
 
 TMP_DIR="$(mktemp -d)"
 cleanup() {
+  pluxx_tx_cleanup
   rm -rf "$TMP_DIR"
 }
 trap cleanup EXIT
@@ -1544,12 +1678,12 @@ VERSION="$(grep -E '"version"' "$PLUGIN_MANIFEST" | head -n1 | sed -E 's/.*"vers
 DESCRIPTION="$(grep -E '"description"' "$PLUGIN_MANIFEST" | head -n1 | sed -E 's/.*"description"[[:space:]]*:[[:space:]]*"([^"]+)".*/\\1/')"
 
 mkdir -p "$INSTALL_ROOT/.claude-plugin" "$INSTALL_ROOT/plugins"
-${renderInstallerSavedUserConfigCaptureSnippet(config, 'claude-code', '$INSTALL_ROOT/plugins/$PLUGIN_NAME')}
-rm -rf "$INSTALL_ROOT/plugins/$PLUGIN_NAME"
-cp -R "$BUNDLE_DIR" "$INSTALL_ROOT/plugins/$PLUGIN_NAME"
-${renderInstallerUserConfigSnippet(config, 'claude-code', '$INSTALL_ROOT/plugins/$PLUGIN_NAME')}
-${renderInstallerMcpPathMaterializationSnippet('claude-code', '$INSTALL_ROOT/plugins/$PLUGIN_NAME')}
-${renderInstallerRuntimeBootstrapSnippet('$INSTALL_ROOT/plugins/$PLUGIN_NAME')}
+${renderInstallerSavedUserConfigCaptureSnippet(config, 'claude-code', '$INSTALL_DIR')}
+pluxx_begin_install_transaction "$BUNDLE_DIR"
+${renderInstallerUserConfigSnippet(config, 'claude-code', '$PLUXX_TX_STAGE')}
+${renderInstallerMcpPathMaterializationSnippet('claude-code', '$PLUXX_TX_STAGE', '$INSTALL_DIR')}
+${renderInstallerRuntimeBootstrapSnippet('$PLUXX_TX_STAGE')}
+pluxx_swap_install_transaction
 
 cat > "$INSTALL_ROOT/.claude-plugin/marketplace.json" <<JSON
 {
@@ -1574,6 +1708,7 @@ cat > "$INSTALL_ROOT/.claude-plugin/marketplace.json" <<JSON
 JSON
 
 if [[ "$SKIP_INSTALL" == "1" ]]; then
+  pluxx_finalize_install_transaction
   echo "Prepared Claude marketplace at: $INSTALL_ROOT"
   echo "Plugin bundle is at: $INSTALL_ROOT/plugins/$PLUGIN_NAME"
   exit 0
@@ -1587,6 +1722,7 @@ fi
 
 claude plugin uninstall "\${PLUGIN_NAME}@\${MARKETPLACE_NAME}" --scope user >/dev/null 2>&1 || true
 claude plugin install "\${PLUGIN_NAME}@\${MARKETPLACE_NAME}" --scope user
+pluxx_finalize_install_transaction
 
 echo
 echo "Installed \${PLUGIN_NAME}@\${MARKETPLACE_NAME} into Claude Code user scope."
@@ -1603,6 +1739,7 @@ PLUGIN_NAME="\${PLUXX_PLUGIN_NAME:-PLUGIN_PLACEHOLDER}"
 BUNDLE_URL="\${PLUXX_CURSOR_BUNDLE_URL:-https://github.com/\${REPO}/releases/latest/download/CURSOR_BUNDLE_PLACEHOLDER}"
 INSTALL_DIR="\${PLUXX_CURSOR_INSTALL_DIR:-$HOME/.cursor/plugins/local/$PLUGIN_NAME}"
 BUNDLE_PATH="\${PLUXX_CURSOR_BUNDLE_PATH:-}"
+${renderInstallerTransactionHelpers('cursor')}
 
 need_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -1614,10 +1751,11 @@ need_cmd() {
 need_cmd tar
 need_cmd mktemp
 need_cmd curl
-${hasInstallerUserConfig(config, 'cursor') ? 'need_cmd node' : ''}
+need_cmd node
 
 TMP_DIR="$(mktemp -d)"
 cleanup() {
+  pluxx_tx_cleanup
   rm -rf "$TMP_DIR"
 }
 trap cleanup EXIT
@@ -1642,11 +1780,12 @@ fi
 
 mkdir -p "$(dirname "$INSTALL_DIR")"
 ${renderInstallerSavedUserConfigCaptureSnippet(config, 'cursor', '$INSTALL_DIR')}
-rm -rf "$INSTALL_DIR"
-cp -R "$BUNDLE_DIR" "$INSTALL_DIR"
-${renderInstallerUserConfigSnippet(config, 'cursor', '$INSTALL_DIR')}
-${renderInstallerMcpPathMaterializationSnippet('cursor', '$INSTALL_DIR')}
-${renderInstallerRuntimeBootstrapSnippet('$INSTALL_DIR')}
+pluxx_begin_install_transaction "$BUNDLE_DIR"
+${renderInstallerUserConfigSnippet(config, 'cursor', '$PLUXX_TX_STAGE')}
+${renderInstallerMcpPathMaterializationSnippet('cursor', '$PLUXX_TX_STAGE', '$INSTALL_DIR')}
+${renderInstallerRuntimeBootstrapSnippet('$PLUXX_TX_STAGE')}
+pluxx_swap_install_transaction
+pluxx_finalize_install_transaction
 
 echo "Installed $PLUGIN_NAME to $INSTALL_DIR"
 echo "${getPublishReloadInstruction('cursor')}"
@@ -1665,6 +1804,7 @@ MARKETPLACE_PATH="\${PLUXX_CODEX_MARKETPLACE_PATH:-$HOME/.agents/plugins/marketp
 BUNDLE_PATH="\${PLUXX_CODEX_BUNDLE_PATH:-}"
 MARKETPLACE_NAME="\${PLUXX_CODEX_MARKETPLACE_NAME:-$PLUGIN_NAME-local}"
 MARKETPLACE_DISPLAY_NAME="\${PLUXX_CODEX_MARKETPLACE_DISPLAY_NAME:-DISPLAY_PLACEHOLDER Local}"
+${renderInstallerTransactionHelpers('codex')}
 
 need_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -1679,6 +1819,7 @@ need_cmd node
 
 TMP_DIR="$(mktemp -d)"
 cleanup() {
+  pluxx_tx_cleanup
   rm -rf "$TMP_DIR"
 }
 trap cleanup EXIT
@@ -1704,11 +1845,11 @@ fi
 
 mkdir -p "$(dirname "$INSTALL_DIR")"
 ${renderInstallerSavedUserConfigCaptureSnippet(config, 'codex', '$INSTALL_DIR')}
-rm -rf "$INSTALL_DIR"
-cp -R "$BUNDLE_DIR" "$INSTALL_DIR"
-${renderInstallerUserConfigSnippet(config, 'codex', '$INSTALL_DIR')}
-${renderInstallerMcpPathMaterializationSnippet('codex', '$INSTALL_DIR')}
-${renderInstallerRuntimeBootstrapSnippet('$INSTALL_DIR')}
+pluxx_begin_install_transaction "$BUNDLE_DIR"
+${renderInstallerUserConfigSnippet(config, 'codex', '$PLUXX_TX_STAGE')}
+${renderInstallerMcpPathMaterializationSnippet('codex', '$PLUXX_TX_STAGE', '$INSTALL_DIR')}
+${renderInstallerRuntimeBootstrapSnippet('$PLUXX_TX_STAGE')}
+pluxx_swap_install_transaction
 ${renderInstallerCodexAgentRegistrationSnippet('$INSTALL_DIR')}
 ${renderInstallerCodexPluginHooksSnippet('$INSTALL_DIR')}
 
@@ -1767,6 +1908,7 @@ fs.writeFileSync(
   ) + '\\n',
 )
 NODE
+pluxx_finalize_install_transaction
 
 echo "Installed $PLUGIN_NAME to $INSTALL_DIR"
 echo "Updated Codex marketplace catalog at $MARKETPLACE_PATH"
@@ -1786,6 +1928,7 @@ INSTALL_DIR="\${PLUXX_OPENCODE_INSTALL_DIR:-$PLUGIN_ROOT_DIR/$PLUGIN_NAME}"
 ENTRY_PATH="\${PLUXX_OPENCODE_ENTRY_PATH:-$PLUGIN_ROOT_DIR/$PLUGIN_NAME.ts}"
 SKILLS_ROOT="\${PLUXX_OPENCODE_SKILLS_ROOT:-$HOME/.config/opencode/skills}"
 BUNDLE_PATH="\${PLUXX_OPENCODE_BUNDLE_PATH:-}"
+${renderInstallerTransactionHelpers('opencode')}
 
 need_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -1800,6 +1943,7 @@ need_cmd node
 
 TMP_DIR="$(mktemp -d)"
 cleanup() {
+  pluxx_tx_cleanup
   rm -rf "$TMP_DIR"
 }
 trap cleanup EXIT
@@ -1825,11 +1969,11 @@ fi
 
 mkdir -p "$(dirname "$INSTALL_DIR")" "$SKILLS_ROOT"
 ${renderInstallerSavedUserConfigCaptureSnippet(config, 'opencode', '$INSTALL_DIR')}
-rm -rf "$INSTALL_DIR"
-cp -R "$BUNDLE_DIR" "$INSTALL_DIR"
-${renderInstallerUserConfigSnippet(config, 'opencode', '$INSTALL_DIR')}
-${renderInstallerMcpPathMaterializationSnippet('opencode', '$INSTALL_DIR')}
-${renderInstallerRuntimeBootstrapSnippet('$INSTALL_DIR')}
+pluxx_begin_install_transaction "$BUNDLE_DIR"
+${renderInstallerUserConfigSnippet(config, 'opencode', '$PLUXX_TX_STAGE')}
+${renderInstallerMcpPathMaterializationSnippet('opencode', '$PLUXX_TX_STAGE', '$INSTALL_DIR')}
+${renderInstallerRuntimeBootstrapSnippet('$PLUXX_TX_STAGE')}
+pluxx_swap_install_transaction
 
 export ENTRY_PATH
 export PLUGIN_NAME
@@ -1915,6 +2059,7 @@ fs.writeFileSync(
 NODE
   done
 fi
+pluxx_finalize_install_transaction
 
 echo "Installed $PLUGIN_NAME plugin code to $INSTALL_DIR"
 echo "Installed OpenCode wrapper at $ENTRY_PATH"

--- a/src/cli/verify-install.ts
+++ b/src/cli/verify-install.ts
@@ -6,6 +6,7 @@ import { doctorConsumer, type DoctorCheck, type DoctorLevel } from './doctor'
 import { planInstallPlugin, resolveInstalledConsumerPath, type PlannedInstallTarget } from './install'
 import { getVerifyInstallStaleAction } from '../distribution-lifecycle'
 import { verifyCodexAgentRegistration } from '../codex-agent-install'
+import { hashInstallBundle, listInstallOwnershipDrift, readInstallOwnership } from '../install-ownership'
 
 type VerifyInstallIssueLevel = Exclude<DoctorLevel, 'success'>
 
@@ -248,6 +249,22 @@ function detectStaleInstall(target: PlannedInstallTarget, pluginName: string, co
   const installedVersion = readInstalledManifestVersion(consumerPath, target.platform)
   if (builtVersion && installedVersion && builtVersion !== installedVersion) {
     return `installed version ${installedVersion} does not match built version ${builtVersion}`
+  }
+
+  const ownership = readInstallOwnership(pluginName, target.platform, consumerPath)
+  if (ownership) {
+    const drift = listInstallOwnershipDrift(ownership)
+    if (drift.length > 0) {
+      return `installed version ${installedVersion ?? 'unknown'} matches the built version, but installed content no longer matches Pluxx ownership: ${drift.join('; ')}`
+    }
+  } else if (target.platform !== 'codex') {
+    try {
+      if (!lstatSync(consumerPath).isSymbolicLink() && hashInstallBundle(target.sourceDir) !== hashInstallBundle(consumerPath)) {
+        return `installed version ${installedVersion ?? 'unknown'} matches the built version, but installed bundle contents differ from the current build`
+      }
+    } catch {
+      // Consumer diagnostics below report unreadable or malformed bundles.
+    }
   }
 
   if (target.platform === 'codex') {

--- a/src/install-ownership.ts
+++ b/src/install-ownership.ts
@@ -1,0 +1,295 @@
+import { createHash, randomBytes } from 'crypto'
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readlinkSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  rmdirSync,
+  symlinkSync,
+  writeFileSync,
+  cpSync,
+} from 'fs'
+import { homedir } from 'os'
+import { dirname, relative, resolve, sep } from 'path'
+import type { TargetPlatform } from './schema'
+
+const INSTALL_OWNERSHIP_SCHEMA = 'pluxx.install-ownership.v1'
+
+export interface InstallOwnedEntry {
+  path: string
+  kind: 'file' | 'symlink'
+  sha256: string
+}
+
+export interface InstallOwnership {
+  schema: typeof INSTALL_OWNERSHIP_SCHEMA
+  pluginName: string
+  platform: TargetPlatform
+  installPath: string
+  kind: 'copy' | 'symlink'
+  symlinkTarget?: string
+  entries: InstallOwnedEntry[]
+}
+
+export interface InstallRemovalResult {
+  changed: boolean
+  removed: string[]
+  preserved: string[]
+  ownershipPath: string
+}
+
+function hash(value: string | Buffer): string {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+function isInside(path: string, root: string): boolean {
+  return path === root || path.startsWith(`${root}${sep}`)
+}
+
+function safeRelativePath(path: string): boolean {
+  if (!path || path.startsWith('/') || path.startsWith('\\')) return false
+  const normalized = path.replace(/\\/g, '/')
+  return normalized !== '..' && !normalized.startsWith('../') && !normalized.includes('/../')
+}
+
+function resolveOwnedPath(root: string, relativePath: string): string {
+  if (!safeRelativePath(relativePath)) throw new Error(`Unsafe install ownership path "${relativePath}".`)
+  const path = resolve(root, relativePath)
+  if (path === root || !isInside(path, root)) throw new Error(`Unsafe install ownership path "${relativePath}".`)
+  return path
+}
+
+function validateIdentity(value: string, label: string): string {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(value)) {
+    throw new Error(`Invalid ${label} "${value}" for install ownership.`)
+  }
+  return value
+}
+
+export function getInstallOwnershipPath(
+  pluginName: string,
+  platform: TargetPlatform,
+  home = process.env.HOME?.trim() || homedir(),
+): string {
+  return resolve(home, '.pluxx/install-ownership', validateIdentity(pluginName, 'plugin name'), `${validateIdentity(platform, 'platform')}.json`)
+}
+
+export function collectInstallEntries(root: string): InstallOwnedEntry[] {
+  if (!existsSync(root)) return []
+  const entries: InstallOwnedEntry[] = []
+
+  const visit = (directory: string): void => {
+    for (const entry of readdirSync(directory, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+      const absolutePath = resolve(directory, entry.name)
+      const relativePath = relative(root, absolutePath).replace(/\\/g, '/')
+      const stats = lstatSync(absolutePath)
+      if (stats.isSymbolicLink()) {
+        entries.push({ path: relativePath, kind: 'symlink', sha256: hash(readlinkSync(absolutePath)) })
+      } else if (stats.isDirectory()) {
+        visit(absolutePath)
+      } else if (stats.isFile()) {
+        entries.push({ path: relativePath, kind: 'file', sha256: hash(readFileSync(absolutePath)) })
+      }
+    }
+  }
+
+  if (lstatSync(root).isDirectory()) visit(root)
+  return entries
+}
+
+export function hashInstallBundle(root: string): string {
+  const digest = createHash('sha256')
+  for (const entry of collectInstallEntries(root)) {
+    digest.update(entry.path)
+    digest.update('\0')
+    digest.update(entry.kind)
+    digest.update('\0')
+    digest.update(entry.sha256)
+    digest.update('\0')
+  }
+  return digest.digest('hex')
+}
+
+export function readInstallOwnership(
+  pluginName: string,
+  platform: TargetPlatform,
+  installPath: string,
+): InstallOwnership | undefined {
+  const ownershipPath = getInstallOwnershipPath(pluginName, platform)
+  if (!existsSync(ownershipPath)) return undefined
+  try {
+    const parsed = JSON.parse(readFileSync(ownershipPath, 'utf-8')) as Partial<InstallOwnership>
+    if (
+      parsed.schema !== INSTALL_OWNERSHIP_SCHEMA
+      || parsed.pluginName !== pluginName
+      || parsed.platform !== platform
+      || resolve(parsed.installPath ?? '') !== resolve(installPath)
+      || (parsed.kind !== 'copy' && parsed.kind !== 'symlink')
+      || !Array.isArray(parsed.entries)
+    ) throw new Error('unexpected ownership schema or identity')
+    for (const entry of parsed.entries) {
+      if (!entry || !safeRelativePath(entry.path) || !['file', 'symlink'].includes(entry.kind) || !/^[a-f0-9]{64}$/.test(entry.sha256)) {
+        throw new Error('invalid owned entry')
+      }
+      resolveOwnedPath(resolve(installPath), entry.path)
+    }
+    if (parsed.kind === 'symlink' && typeof parsed.symlinkTarget !== 'string') throw new Error('missing symlink target')
+    return parsed as InstallOwnership
+  } catch (error) {
+    throw new Error(`Cannot use install ownership record ${ownershipPath}: ${String(error)}`)
+  }
+}
+
+function writeOwnership(record: InstallOwnership): void {
+  const path = getInstallOwnershipPath(record.pluginName, record.platform)
+  mkdirSync(dirname(path), { recursive: true })
+  const temporary = `${path}.tmp-${process.pid}-${randomBytes(4).toString('hex')}`
+  writeFileSync(temporary, `${JSON.stringify(record, null, 2)}\n`, { mode: 0o600 })
+  renameSync(temporary, path)
+}
+
+function buildOwnership(pluginName: string, platform: TargetPlatform, installPath: string, kind: 'copy' | 'symlink'): InstallOwnership {
+  const resolvedPath = resolve(installPath)
+  return {
+    schema: INSTALL_OWNERSHIP_SCHEMA,
+    pluginName,
+    platform,
+    installPath: resolvedPath,
+    kind,
+    ...(kind === 'symlink' ? { symlinkTarget: readlinkSync(resolvedPath) } : {}),
+    entries: kind === 'copy' ? collectInstallEntries(resolvedPath) : [],
+  }
+}
+
+export function listInstallOwnershipDrift(record: InstallOwnership): string[] {
+  const installPath = resolve(record.installPath)
+  if (!existsSync(installPath)) return ['installed path is missing']
+  const details = lstatSync(installPath)
+  if (record.kind === 'symlink') {
+    if (!details.isSymbolicLink()) return ['installed path is no longer the owned symlink']
+    return readlinkSync(installPath) === record.symlinkTarget ? [] : ['installed symlink target was modified']
+  }
+  if (!details.isDirectory() || details.isSymbolicLink()) return ['installed path is no longer the owned copied directory']
+
+  const expected = new Map(record.entries.map((entry) => [entry.path, entry]))
+  const actual = new Map(collectInstallEntries(installPath).map((entry) => [entry.path, entry]))
+  const drift: string[] = []
+  for (const [path, entry] of expected) {
+    const current = actual.get(path)
+    if (!current) drift.push(`owned file is missing: ${path}`)
+    else if (current.kind !== entry.kind || current.sha256 !== entry.sha256) drift.push(`owned file was modified: ${path}`)
+  }
+  for (const path of actual.keys()) if (!expected.has(path)) drift.push(`unowned file is present: ${path}`)
+  return drift
+}
+
+export function assertInstallReplaceable(pluginName: string, platform: TargetPlatform, installPath: string): void {
+  if (!existsSync(installPath)) return
+  const details = lstatSync(installPath)
+  const ownership = readInstallOwnership(pluginName, platform, installPath)
+  if (!ownership) {
+    if (details.isSymbolicLink()) return
+    throw new Error(`Refusing to replace unowned install at ${installPath}. Move it aside or uninstall it manually, then retry.`)
+  }
+  const drift = listInstallOwnershipDrift(ownership)
+  if (drift.length > 0) {
+    throw new Error(`Refusing to replace modified install at ${installPath}: ${drift.join('; ')}`)
+  }
+}
+
+export function transactionalInstall(options: {
+  pluginName: string
+  platform: TargetPlatform
+  sourcePath: string
+  installPath: string
+  kind: 'copy' | 'symlink'
+  prepare?: (stagePath: string) => void
+  validate?: (path: string) => void
+}): InstallOwnership {
+  const installPath = resolve(options.installPath)
+  const parent = dirname(installPath)
+  mkdirSync(parent, { recursive: true })
+  assertInstallReplaceable(options.pluginName, options.platform, installPath)
+  const nonce = `${process.pid}-${randomBytes(5).toString('hex')}`
+  const stagePath = resolve(parent, `.${options.pluginName}.pluxx-stage-${nonce}`)
+  const backupPath = resolve(parent, `.${options.pluginName}.pluxx-backup-${nonce}`)
+  let movedPrevious = false
+  let installedCandidate = false
+
+  try {
+    if (options.kind === 'symlink') symlinkSync(resolve(options.sourcePath), stagePath)
+    else cpSync(options.sourcePath, stagePath, { recursive: true })
+    options.prepare?.(stagePath)
+    options.validate?.(stagePath)
+    if (existsSync(installPath)) {
+      renameSync(installPath, backupPath)
+      movedPrevious = true
+    }
+    renameSync(stagePath, installPath)
+    installedCandidate = true
+    options.validate?.(installPath)
+    const ownership = buildOwnership(options.pluginName, options.platform, installPath, options.kind)
+    writeOwnership(ownership)
+    if (movedPrevious) {
+      try {
+        rmSync(backupPath, { recursive: true, force: true })
+      } catch {
+        // The committed install and ownership are valid; leave the recoverable backup in place.
+      }
+    }
+    return ownership
+  } catch (error) {
+    if (installedCandidate && existsSync(installPath)) rmSync(installPath, { recursive: true, force: true })
+    if (movedPrevious && existsSync(backupPath)) renameSync(backupPath, installPath)
+    throw error
+  } finally {
+    if (existsSync(stagePath)) rmSync(stagePath, { recursive: true, force: true })
+  }
+}
+
+function pruneEmptyParents(path: string, root: string): void {
+  let current = dirname(path)
+  while (current !== root && isInside(current, root)) {
+    try { rmdirSync(current) } catch { break }
+    current = dirname(current)
+  }
+}
+
+export function removeOwnedInstall(pluginName: string, platform: TargetPlatform, installPath: string): InstallRemovalResult {
+  const ownershipPath = getInstallOwnershipPath(pluginName, platform)
+  const record = readInstallOwnership(pluginName, platform, installPath)
+  if (!record) return { changed: false, removed: [], preserved: existsSync(installPath) ? [installPath] : [], ownershipPath }
+  const root = resolve(installPath)
+  const removed: string[] = []
+  const preserved: string[] = []
+
+  if (record.kind === 'symlink') {
+    if (existsSync(root) && lstatSync(root).isSymbolicLink() && readlinkSync(root) === record.symlinkTarget) {
+      rmSync(root, { force: true })
+      removed.push(root)
+    } else if (existsSync(root)) preserved.push(root)
+  } else if (existsSync(root)) {
+    const expected = new Map(record.entries.map((entry) => [entry.path, entry]))
+    for (const entry of [...record.entries].sort((a, b) => b.path.localeCompare(a.path))) {
+      const path = resolveOwnedPath(root, entry.path)
+      if (!existsSync(path)) continue
+      const details = lstatSync(path)
+      const currentKind = details.isSymbolicLink() ? 'symlink' : details.isFile() ? 'file' : undefined
+      const currentHash = currentKind === 'symlink' ? hash(readlinkSync(path)) : currentKind === 'file' ? hash(readFileSync(path)) : undefined
+      if (currentKind === entry.kind && currentHash === entry.sha256) {
+        rmSync(path, { force: true })
+        removed.push(entry.path)
+        pruneEmptyParents(path, root)
+      } else preserved.push(entry.path)
+    }
+    for (const entry of collectInstallEntries(root)) if (!expected.has(entry.path) && !preserved.includes(entry.path)) preserved.push(entry.path)
+    try { rmdirSync(root) } catch { /* Modified or unowned content remains. */ }
+  }
+
+  rmSync(ownershipPath, { force: true })
+  return { changed: removed.length > 0, removed, preserved, ownershipPath }
+}

--- a/src/install-ownership.ts
+++ b/src/install-ownership.ts
@@ -30,8 +30,10 @@ export interface InstallOwnership {
   pluginName: string
   platform: TargetPlatform
   installPath: string
-  kind: 'copy' | 'symlink'
+  surface?: string
+  kind: 'copy' | 'file' | 'symlink'
   symlinkTarget?: string
+  rootSha256?: string
   entries: InstallOwnedEntry[]
 }
 
@@ -74,8 +76,10 @@ export function getInstallOwnershipPath(
   pluginName: string,
   platform: TargetPlatform,
   home = process.env.HOME?.trim() || homedir(),
+  surface?: string,
 ): string {
-  return resolve(home, '.pluxx/install-ownership', validateIdentity(pluginName, 'plugin name'), `${validateIdentity(platform, 'platform')}.json`)
+  const suffix = surface ? `--${validateIdentity(surface, 'install surface')}` : ''
+  return resolve(home, '.pluxx/install-ownership', validateIdentity(pluginName, 'plugin name'), `${validateIdentity(platform, 'platform')}${suffix}.json`)
 }
 
 export function collectInstallEntries(root: string): InstallOwnedEntry[] {
@@ -118,8 +122,9 @@ export function readInstallOwnership(
   pluginName: string,
   platform: TargetPlatform,
   installPath: string,
+  surface?: string,
 ): InstallOwnership | undefined {
-  const ownershipPath = getInstallOwnershipPath(pluginName, platform)
+  const ownershipPath = getInstallOwnershipPath(pluginName, platform, undefined, surface)
   if (!existsSync(ownershipPath)) return undefined
   try {
     const parsed = JSON.parse(readFileSync(ownershipPath, 'utf-8')) as Partial<InstallOwnership>
@@ -127,8 +132,9 @@ export function readInstallOwnership(
       parsed.schema !== INSTALL_OWNERSHIP_SCHEMA
       || parsed.pluginName !== pluginName
       || parsed.platform !== platform
+      || parsed.surface !== surface
       || resolve(parsed.installPath ?? '') !== resolve(installPath)
-      || (parsed.kind !== 'copy' && parsed.kind !== 'symlink')
+      || !['copy', 'file', 'symlink'].includes(parsed.kind ?? '')
       || !Array.isArray(parsed.entries)
     ) throw new Error('unexpected ownership schema or identity')
     for (const entry of parsed.entries) {
@@ -138,6 +144,7 @@ export function readInstallOwnership(
       resolveOwnedPath(resolve(installPath), entry.path)
     }
     if (parsed.kind === 'symlink' && typeof parsed.symlinkTarget !== 'string') throw new Error('missing symlink target')
+    if (parsed.kind === 'file' && !/^[a-f0-9]{64}$/.test(parsed.rootSha256 ?? '')) throw new Error('missing file hash')
     return parsed as InstallOwnership
   } catch (error) {
     throw new Error(`Cannot use install ownership record ${ownershipPath}: ${String(error)}`)
@@ -145,14 +152,20 @@ export function readInstallOwnership(
 }
 
 function writeOwnership(record: InstallOwnership): void {
-  const path = getInstallOwnershipPath(record.pluginName, record.platform)
+  const path = getInstallOwnershipPath(record.pluginName, record.platform, undefined, record.surface)
   mkdirSync(dirname(path), { recursive: true })
   const temporary = `${path}.tmp-${process.pid}-${randomBytes(4).toString('hex')}`
   writeFileSync(temporary, `${JSON.stringify(record, null, 2)}\n`, { mode: 0o600 })
   renameSync(temporary, path)
 }
 
-function buildOwnership(pluginName: string, platform: TargetPlatform, installPath: string, kind: 'copy' | 'symlink'): InstallOwnership {
+function buildOwnership(
+  pluginName: string,
+  platform: TargetPlatform,
+  installPath: string,
+  kind: 'copy' | 'file' | 'symlink',
+  surface?: string,
+): InstallOwnership {
   const resolvedPath = resolve(installPath)
   return {
     schema: INSTALL_OWNERSHIP_SCHEMA,
@@ -160,7 +173,9 @@ function buildOwnership(pluginName: string, platform: TargetPlatform, installPat
     platform,
     installPath: resolvedPath,
     kind,
+    ...(surface ? { surface } : {}),
     ...(kind === 'symlink' ? { symlinkTarget: readlinkSync(resolvedPath) } : {}),
+    ...(kind === 'file' ? { rootSha256: hash(readFileSync(resolvedPath)) } : {}),
     entries: kind === 'copy' ? collectInstallEntries(resolvedPath) : [],
   }
 }
@@ -172,6 +187,10 @@ export function listInstallOwnershipDrift(record: InstallOwnership): string[] {
   if (record.kind === 'symlink') {
     if (!details.isSymbolicLink()) return ['installed path is no longer the owned symlink']
     return readlinkSync(installPath) === record.symlinkTarget ? [] : ['installed symlink target was modified']
+  }
+  if (record.kind === 'file') {
+    if (!details.isFile() || details.isSymbolicLink()) return ['installed path is no longer the owned file']
+    return hash(readFileSync(installPath)) === record.rootSha256 ? [] : ['owned file was modified']
   }
   if (!details.isDirectory() || details.isSymbolicLink()) return ['installed path is no longer the owned copied directory']
 
@@ -187,12 +206,12 @@ export function listInstallOwnershipDrift(record: InstallOwnership): string[] {
   return drift
 }
 
-export function assertInstallReplaceable(pluginName: string, platform: TargetPlatform, installPath: string): void {
+export function assertInstallReplaceable(pluginName: string, platform: TargetPlatform, installPath: string, surface?: string): void {
   if (!existsSync(installPath)) return
   const details = lstatSync(installPath)
-  const ownership = readInstallOwnership(pluginName, platform, installPath)
+  const ownership = readInstallOwnership(pluginName, platform, installPath, surface)
   if (!ownership) {
-    if (details.isSymbolicLink()) return
+    if (!surface && details.isSymbolicLink()) return
     throw new Error(`Refusing to replace unowned install at ${installPath}. Move it aside or uninstall it manually, then retry.`)
   }
   const drift = listInstallOwnershipDrift(ownership)
@@ -204,50 +223,118 @@ export function assertInstallReplaceable(pluginName: string, platform: TargetPla
 export function transactionalInstall(options: {
   pluginName: string
   platform: TargetPlatform
-  sourcePath: string
+  sourcePath?: string
   installPath: string
-  kind: 'copy' | 'symlink'
+  kind: 'copy' | 'file' | 'symlink'
+  surface?: string
+  content?: string
   prepare?: (stagePath: string) => void
   validate?: (path: string) => void
 }): InstallOwnership {
-  const installPath = resolve(options.installPath)
-  const parent = dirname(installPath)
-  mkdirSync(parent, { recursive: true })
-  assertInstallReplaceable(options.pluginName, options.platform, installPath)
+  return transactionalInstallGroup({ pluginName: options.pluginName, platform: options.platform, targets: [options] })[0]
+}
+
+export function transactionalInstallGroup(options: {
+  pluginName: string
+  platform: TargetPlatform
+  targets: Array<{
+    sourcePath?: string
+    installPath: string
+    kind: 'copy' | 'file' | 'symlink'
+    surface?: string
+    content?: string
+    prepare?: (stagePath: string) => void
+    validate?: (path: string) => void
+  }>
+}): InstallOwnership[] {
+  if (options.targets.length === 0) return []
+  const surfaces = new Set<string>()
+  const paths = new Set<string>()
+  for (const target of options.targets) {
+    const surface = target.surface ?? ''
+    if (surfaces.has(surface)) throw new Error(`Duplicate install ownership surface "${surface || 'primary'}".`)
+    surfaces.add(surface)
+    const path = resolve(target.installPath)
+    if (paths.has(path)) throw new Error(`Duplicate transactional install path ${path}.`)
+    paths.add(path)
+  }
+
   const nonce = `${process.pid}-${randomBytes(5).toString('hex')}`
-  const stagePath = resolve(parent, `.${options.pluginName}.pluxx-stage-${nonce}`)
-  const backupPath = resolve(parent, `.${options.pluginName}.pluxx-backup-${nonce}`)
-  let movedPrevious = false
-  let installedCandidate = false
+  const transactions = options.targets.map((target, index) => {
+    const installPath = resolve(target.installPath)
+    const parent = dirname(installPath)
+    mkdirSync(parent, { recursive: true })
+    assertInstallReplaceable(options.pluginName, options.platform, installPath, target.surface)
+    return {
+      ...target,
+      installPath,
+      stagePath: resolve(parent, `.${options.pluginName}.pluxx-stage-${nonce}-${index}`),
+      backupPath: resolve(parent, `.${options.pluginName}.pluxx-backup-${nonce}-${index}`),
+      ownershipPath: getInstallOwnershipPath(options.pluginName, options.platform, undefined, target.surface),
+      previousOwnership: undefined as Buffer | undefined,
+      movedPrevious: false,
+      installedCandidate: false,
+    }
+  })
+  const ownership: InstallOwnership[] = []
 
   try {
-    if (options.kind === 'symlink') symlinkSync(resolve(options.sourcePath), stagePath)
-    else cpSync(options.sourcePath, stagePath, { recursive: true })
-    options.prepare?.(stagePath)
-    options.validate?.(stagePath)
-    if (existsSync(installPath)) {
-      renameSync(installPath, backupPath)
-      movedPrevious = true
+    for (const transaction of transactions) {
+      if (transaction.kind === 'file' && transaction.content !== undefined) {
+        writeFileSync(transaction.stagePath, transaction.content)
+      } else if (transaction.kind === 'symlink') {
+        if (!transaction.sourcePath) throw new Error(`Missing source path for ${transaction.installPath}.`)
+        symlinkSync(resolve(transaction.sourcePath), transaction.stagePath)
+      } else {
+        if (!transaction.sourcePath) throw new Error(`Missing source path for ${transaction.installPath}.`)
+        cpSync(transaction.sourcePath, transaction.stagePath, { recursive: true })
+      }
+      transaction.prepare?.(transaction.stagePath)
+      transaction.validate?.(transaction.stagePath)
     }
-    renameSync(stagePath, installPath)
-    installedCandidate = true
-    options.validate?.(installPath)
-    const ownership = buildOwnership(options.pluginName, options.platform, installPath, options.kind)
-    writeOwnership(ownership)
-    if (movedPrevious) {
-      try {
-        rmSync(backupPath, { recursive: true, force: true })
-      } catch {
-        // The committed install and ownership are valid; leave the recoverable backup in place.
+
+    for (const transaction of transactions) {
+      if (existsSync(transaction.ownershipPath)) transaction.previousOwnership = readFileSync(transaction.ownershipPath)
+      if (existsSync(transaction.installPath)) {
+        renameSync(transaction.installPath, transaction.backupPath)
+        transaction.movedPrevious = true
+      }
+      renameSync(transaction.stagePath, transaction.installPath)
+      transaction.installedCandidate = true
+      transaction.validate?.(transaction.installPath)
+    }
+
+    for (const transaction of transactions) {
+      const record = buildOwnership(
+        options.pluginName,
+        options.platform,
+        transaction.installPath,
+        transaction.kind,
+        transaction.surface,
+      )
+      writeOwnership(record)
+      ownership.push(record)
+    }
+    for (const transaction of transactions) {
+      if (transaction.movedPrevious) {
+        try { rmSync(transaction.backupPath, { recursive: true, force: true }) } catch { /* Recoverable backup. */ }
       }
     }
     return ownership
   } catch (error) {
-    if (installedCandidate && existsSync(installPath)) rmSync(installPath, { recursive: true, force: true })
-    if (movedPrevious && existsSync(backupPath)) renameSync(backupPath, installPath)
+    for (const transaction of [...transactions].reverse()) {
+      if (transaction.installedCandidate && existsSync(transaction.installPath)) rmSync(transaction.installPath, { recursive: true, force: true })
+      if (transaction.movedPrevious && existsSync(transaction.backupPath)) renameSync(transaction.backupPath, transaction.installPath)
+      if (transaction.previousOwnership) {
+        mkdirSync(dirname(transaction.ownershipPath), { recursive: true })
+        writeFileSync(transaction.ownershipPath, transaction.previousOwnership, { mode: 0o600 })
+      } else rmSync(transaction.ownershipPath, { force: true })
+    }
     throw error
   } finally {
-    if (existsSync(stagePath)) rmSync(stagePath, { recursive: true, force: true })
+    for (const transaction of transactions) {
+      if (existsSync(transaction.stagePath)) rmSync(transaction.stagePath, { recursive: true, force: true })
+    }
   }
 }
 
@@ -259,9 +346,9 @@ function pruneEmptyParents(path: string, root: string): void {
   }
 }
 
-export function removeOwnedInstall(pluginName: string, platform: TargetPlatform, installPath: string): InstallRemovalResult {
-  const ownershipPath = getInstallOwnershipPath(pluginName, platform)
-  const record = readInstallOwnership(pluginName, platform, installPath)
+export function removeOwnedInstall(pluginName: string, platform: TargetPlatform, installPath: string, surface?: string): InstallRemovalResult {
+  const ownershipPath = getInstallOwnershipPath(pluginName, platform, undefined, surface)
+  const record = readInstallOwnership(pluginName, platform, installPath, surface)
   if (!record) return { changed: false, removed: [], preserved: existsSync(installPath) ? [installPath] : [], ownershipPath }
   const root = resolve(installPath)
   const removed: string[] = []
@@ -269,6 +356,11 @@ export function removeOwnedInstall(pluginName: string, platform: TargetPlatform,
 
   if (record.kind === 'symlink') {
     if (existsSync(root) && lstatSync(root).isSymbolicLink() && readlinkSync(root) === record.symlinkTarget) {
+      rmSync(root, { force: true })
+      removed.push(root)
+    } else if (existsSync(root)) preserved.push(root)
+  } else if (record.kind === 'file') {
+    if (existsSync(root) && lstatSync(root).isFile() && !lstatSync(root).isSymbolicLink() && hash(readFileSync(root)) === record.rootSha256) {
       rmSync(root, { force: true })
       removed.push(root)
     } else if (existsSync(root)) preserved.push(root)
@@ -292,4 +384,22 @@ export function removeOwnedInstall(pluginName: string, platform: TargetPlatform,
 
   rmSync(ownershipPath, { force: true })
   return { changed: removed.length > 0, removed, preserved, ownershipPath }
+}
+
+export function listInstallOwnership(pluginName: string, platform: TargetPlatform): InstallOwnership[] {
+  const primaryPath = getInstallOwnershipPath(pluginName, platform)
+  const root = dirname(primaryPath)
+  if (!existsSync(root)) return []
+  const prefix = `${platform}--`
+  const paths = readdirSync(root)
+    .filter((name) => name === `${platform}.json` || (name.startsWith(prefix) && name.endsWith('.json')))
+    .sort()
+  return paths.map((name) => {
+    const surface = name === `${platform}.json` ? undefined : name.slice(prefix.length, -'.json'.length)
+    const raw = JSON.parse(readFileSync(resolve(root, name), 'utf-8')) as Partial<InstallOwnership>
+    if (typeof raw.installPath !== 'string') throw new Error(`Cannot use install ownership record ${resolve(root, name)}: missing install path`)
+    const record = readInstallOwnership(pluginName, platform, raw.installPath, surface)
+    if (!record) throw new Error(`Cannot use install ownership record ${resolve(root, name)}.`)
+    return record
+  })
 }

--- a/tests/codex-apply.test.ts
+++ b/tests/codex-apply.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { resolve } from 'path'
 import {
@@ -8,6 +8,7 @@ import {
   ensureCodexHooksFeature,
   ensureCodexMcpApprovals,
   renderCodexCompanionApplyLines,
+  unapplyCodexCompanion,
 } from '../src/cli/codex-apply'
 
 describe('codex companion apply helpers', () => {
@@ -144,6 +145,79 @@ describe('codex companion apply helpers', () => {
         status: 'added',
       }))
       expect(existsSync(resolve(codexHome, 'agents/agent-plugin/reviewer.toml'))).toBe(true)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('unapplies unchanged owned config idempotently and restores unrelated prior config', () => {
+    const dir = mkdtempSync(resolve(tmpdir(), 'pluxx-codex-unapply-'))
+    const consumerRoot = resolve(dir, 'consumer')
+    const codexHome = resolve(dir, 'codex-home')
+    const projectRoot = resolve(dir, 'project')
+    const configPath = resolve(projectRoot, '.codex/config.toml')
+    mkdirSync(resolve(consumerRoot, '.codex-plugin'), { recursive: true })
+    mkdirSync(resolve(consumerRoot, 'hooks'), { recursive: true })
+    mkdirSync(resolve(configPath, '..'), { recursive: true })
+    writeFileSync(resolve(consumerRoot, '.codex-plugin/plugin.json'), JSON.stringify({ name: 'owned-config', hooks: 'hooks/hooks.json' }))
+    writeFileSync(resolve(consumerRoot, 'hooks/hooks.json'), '{}\n')
+    writeFileSync(configPath, 'model = "gpt-test"\n')
+
+    try {
+      applyCodexCompanion({ consumerRoot, projectRoot, codexHome, includeMcpApprovals: false, includeAgents: false })
+      expect(readFileSync(configPath, 'utf-8')).toContain('hooks = true')
+      const removed = unapplyCodexCompanion({ consumerRoot, projectRoot, codexHome })
+      expect(removed.changed).toBe(true)
+      expect(readFileSync(configPath, 'utf-8')).toBe('model = "gpt-test"\n')
+      expect(unapplyCodexCompanion({ consumerRoot, projectRoot, codexHome }).changed).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('preserves Codex config changed after apply instead of restoring over user edits', () => {
+    const dir = mkdtempSync(resolve(tmpdir(), 'pluxx-codex-unapply-edited-'))
+    const consumerRoot = resolve(dir, 'consumer')
+    const codexHome = resolve(dir, 'codex-home')
+    const projectRoot = resolve(dir, 'project')
+    const configPath = resolve(projectRoot, '.codex/config.toml')
+    mkdirSync(resolve(consumerRoot, '.codex-plugin'), { recursive: true })
+    mkdirSync(resolve(consumerRoot, 'hooks'), { recursive: true })
+    writeFileSync(resolve(consumerRoot, '.codex-plugin/plugin.json'), JSON.stringify({ name: 'edited-config', hooks: 'hooks/hooks.json' }))
+    writeFileSync(resolve(consumerRoot, 'hooks/hooks.json'), '{}\n')
+
+    try {
+      applyCodexCompanion({ consumerRoot, projectRoot, codexHome, includeMcpApprovals: false, includeAgents: false })
+      writeFileSync(configPath, `${readFileSync(configPath, 'utf-8')}model = "user-choice"\n`)
+      const result = unapplyCodexCompanion({ consumerRoot, projectRoot, codexHome })
+      expect(result.changed).toBe(false)
+      expect(result.preserved).toBe(true)
+      expect(readFileSync(configPath, 'utf-8')).toContain('model = "user-choice"')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects a config ownership record redirected to another file', () => {
+    const dir = mkdtempSync(resolve(tmpdir(), 'pluxx-codex-unapply-tampered-'))
+    const consumerRoot = resolve(dir, 'consumer')
+    const codexHome = resolve(dir, 'codex-home')
+    const projectRoot = resolve(dir, 'project')
+    const sentinel = resolve(dir, 'sentinel.txt')
+    mkdirSync(resolve(consumerRoot, '.codex-plugin'), { recursive: true })
+    mkdirSync(resolve(consumerRoot, 'hooks'), { recursive: true })
+    writeFileSync(resolve(consumerRoot, '.codex-plugin/plugin.json'), JSON.stringify({ name: 'tampered-config', hooks: 'hooks/hooks.json' }))
+    writeFileSync(resolve(consumerRoot, 'hooks/hooks.json'), '{}\n')
+    writeFileSync(sentinel, 'keep\n')
+
+    try {
+      applyCodexCompanion({ consumerRoot, projectRoot, codexHome, includeMcpApprovals: false, includeAgents: false })
+      const ownershipPath = resolve(codexHome, 'pluxx/config-applies/tampered-config.json')
+      const record = JSON.parse(readFileSync(ownershipPath, 'utf-8'))
+      record.configPath = sentinel
+      writeFileSync(ownershipPath, JSON.stringify(record))
+      expect(() => unapplyCodexCompanion({ consumerRoot, projectRoot, codexHome })).toThrow('unexpected ownership schema')
+      expect(readFileSync(sentinel, 'utf-8')).toBe('keep\n')
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }

--- a/tests/install-ownership.test.ts
+++ b/tests/install-ownership.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { resolve } from 'path'
+import {
+  getInstallOwnershipPath,
+  hashInstallBundle,
+  listInstallOwnershipDrift,
+  readInstallOwnership,
+  removeOwnedInstall,
+  transactionalInstall,
+} from '../src/install-ownership'
+
+const ROOT = resolve(import.meta.dir, '.install-ownership-fixture')
+const HOME = resolve(ROOT, 'home')
+const SOURCE = resolve(ROOT, 'source')
+const INSTALL = resolve(HOME, '.cursor/plugins/local/fixture')
+
+beforeEach(() => {
+  rmSync(ROOT, { recursive: true, force: true })
+  mkdirSync(SOURCE, { recursive: true })
+  writeFileSync(resolve(SOURCE, 'plugin.json'), '{"version":"1.0.0"}\n')
+  writeFileSync(resolve(SOURCE, 'owned.txt'), 'owned\n')
+  process.env.HOME = HOME
+})
+
+afterEach(() => rmSync(ROOT, { recursive: true, force: true }))
+
+describe('install ownership transactions', () => {
+  it('records copied content and detects same-version byte drift', () => {
+    transactionalInstall({
+      pluginName: 'fixture',
+      platform: 'cursor',
+      sourcePath: SOURCE,
+      installPath: INSTALL,
+      kind: 'copy',
+    })
+    const ownership = readInstallOwnership('fixture', 'cursor', INSTALL)!
+    expect(ownership.entries.length).toBe(2)
+    expect(listInstallOwnershipDrift(ownership)).toEqual([])
+
+    writeFileSync(resolve(INSTALL, 'owned.txt'), 'user edit\n')
+    expect(listInstallOwnershipDrift(ownership)).toContain('owned file was modified: owned.txt')
+    expect(hashInstallBundle(INSTALL)).not.toBe(hashInstallBundle(SOURCE))
+  })
+
+  it('keeps the previous working bundle when staged validation fails', () => {
+    transactionalInstall({ pluginName: 'fixture', platform: 'cursor', sourcePath: SOURCE, installPath: INSTALL, kind: 'copy' })
+    writeFileSync(resolve(SOURCE, 'owned.txt'), 'candidate\n')
+
+    expect(() => transactionalInstall({
+      pluginName: 'fixture',
+      platform: 'cursor',
+      sourcePath: SOURCE,
+      installPath: INSTALL,
+      kind: 'copy',
+      validate: () => { throw new Error('invalid candidate') },
+    })).toThrow('invalid candidate')
+    expect(readFileSync(resolve(INSTALL, 'owned.txt'), 'utf-8')).toBe('owned\n')
+  })
+
+  it('restores the previous bundle when live verification fails after the swap', () => {
+    transactionalInstall({ pluginName: 'fixture', platform: 'cursor', sourcePath: SOURCE, installPath: INSTALL, kind: 'copy' })
+    writeFileSync(resolve(SOURCE, 'owned.txt'), 'candidate\n')
+    let calls = 0
+    expect(() => transactionalInstall({
+      pluginName: 'fixture',
+      platform: 'cursor',
+      sourcePath: SOURCE,
+      installPath: INSTALL,
+      kind: 'copy',
+      validate: () => { if (++calls === 2) throw new Error('consumer verification failed') },
+    })).toThrow('consumer verification failed')
+    expect(readFileSync(resolve(INSTALL, 'owned.txt'), 'utf-8')).toBe('owned\n')
+  })
+
+  it('refuses reinstall over modified or unowned copied content', () => {
+    mkdirSync(INSTALL, { recursive: true })
+    writeFileSync(resolve(INSTALL, 'private.txt'), 'mine\n')
+    expect(() => transactionalInstall({ pluginName: 'fixture', platform: 'cursor', sourcePath: SOURCE, installPath: INSTALL, kind: 'copy' })).toThrow('unowned install')
+
+    rmSync(INSTALL, { recursive: true, force: true })
+    transactionalInstall({ pluginName: 'fixture', platform: 'cursor', sourcePath: SOURCE, installPath: INSTALL, kind: 'copy' })
+    writeFileSync(resolve(INSTALL, 'owned.txt'), 'mine\n')
+    expect(() => transactionalInstall({ pluginName: 'fixture', platform: 'cursor', sourcePath: SOURCE, installPath: INSTALL, kind: 'copy' })).toThrow('modified install')
+  })
+
+  it('removes unchanged owned files while preserving modified and extra files', () => {
+    transactionalInstall({ pluginName: 'fixture', platform: 'cursor', sourcePath: SOURCE, installPath: INSTALL, kind: 'copy' })
+    writeFileSync(resolve(INSTALL, 'owned.txt'), 'mine\n')
+    writeFileSync(resolve(INSTALL, 'extra.txt'), 'extra\n')
+
+    const result = removeOwnedInstall('fixture', 'cursor', INSTALL)
+    expect(result.removed).toContain('plugin.json')
+    expect(result.preserved).toEqual(expect.arrayContaining(['owned.txt', 'extra.txt']))
+    expect(existsSync(resolve(INSTALL, 'owned.txt'))).toBe(true)
+    expect(existsSync(resolve(INSTALL, 'extra.txt'))).toBe(true)
+    expect(existsSync(getInstallOwnershipPath('fixture', 'cursor'))).toBe(false)
+  })
+
+  it('rejects tampered ownership paths before deleting anything', () => {
+    mkdirSync(resolve(INSTALL, '..'), { recursive: true })
+    const sentinel = resolve(ROOT, 'sentinel.txt')
+    writeFileSync(sentinel, 'keep\n')
+    const ownershipPath = getInstallOwnershipPath('fixture', 'cursor')
+    mkdirSync(resolve(ownershipPath, '..'), { recursive: true })
+    writeFileSync(ownershipPath, JSON.stringify({
+      schema: 'pluxx.install-ownership.v1',
+      pluginName: 'fixture',
+      platform: 'cursor',
+      installPath: INSTALL,
+      kind: 'copy',
+      entries: [{ path: '../../../../sentinel.txt', kind: 'file', sha256: '0'.repeat(64) }],
+    }))
+    expect(() => removeOwnedInstall('fixture', 'cursor', INSTALL)).toThrow('invalid owned entry')
+    expect(readFileSync(sentinel, 'utf-8')).toBe('keep\n')
+  })
+})

--- a/tests/install-ownership.test.ts
+++ b/tests/install-ownership.test.ts
@@ -8,6 +8,7 @@ import {
   readInstallOwnership,
   removeOwnedInstall,
   transactionalInstall,
+  transactionalInstallGroup,
 } from '../src/install-ownership'
 
 const ROOT = resolve(import.meta.dir, '.install-ownership-fixture')
@@ -71,6 +72,53 @@ describe('install ownership transactions', () => {
       validate: () => { if (++calls === 2) throw new Error('consumer verification failed') },
     })).toThrow('consumer verification failed')
     expect(readFileSync(resolve(INSTALL, 'owned.txt'), 'utf-8')).toBe('owned\n')
+  })
+
+  it('rolls back every owned surface when a companion swap fails', () => {
+    const entryPath = resolve(HOME, '.cursor/plugins/local/fixture.ts')
+    transactionalInstallGroup({
+      pluginName: 'fixture',
+      platform: 'cursor',
+      targets: [
+        { sourcePath: SOURCE, installPath: INSTALL, kind: 'copy' },
+        { installPath: entryPath, kind: 'file', surface: 'entry', content: 'old entry\n' },
+      ],
+    })
+    writeFileSync(resolve(SOURCE, 'owned.txt'), 'candidate\n')
+    let entryValidations = 0
+
+    expect(() => transactionalInstallGroup({
+      pluginName: 'fixture',
+      platform: 'cursor',
+      targets: [
+        { sourcePath: SOURCE, installPath: INSTALL, kind: 'copy' },
+        {
+          installPath: entryPath,
+          kind: 'file',
+          surface: 'entry',
+          content: 'new entry\n',
+          validate: () => { if (++entryValidations === 2) throw new Error('companion verification failed') },
+        },
+      ],
+    })).toThrow('companion verification failed')
+    expect(readFileSync(resolve(INSTALL, 'owned.txt'), 'utf-8')).toBe('owned\n')
+    expect(readFileSync(entryPath, 'utf-8')).toBe('old entry\n')
+    expect(listInstallOwnershipDrift(readInstallOwnership('fixture', 'cursor', entryPath, 'entry')!)).toEqual([])
+  })
+
+  it('refuses to replace an unowned companion file', () => {
+    const entryPath = resolve(HOME, '.cursor/plugins/local/fixture.ts')
+    mkdirSync(resolve(entryPath, '..'), { recursive: true })
+    writeFileSync(entryPath, 'private entry\n')
+    expect(() => transactionalInstall({
+      pluginName: 'fixture',
+      platform: 'cursor',
+      installPath: entryPath,
+      kind: 'file',
+      surface: 'entry',
+      content: 'managed entry\n',
+    })).toThrow('unowned install')
+    expect(readFileSync(entryPath, 'utf-8')).toBe('private entry\n')
   })
 
   it('refuses reinstall over modified or unowned copied content', () => {

--- a/tests/install.test.ts
+++ b/tests/install.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
 import { mkdirSync, rmSync, existsSync, lstatSync, readlinkSync, readFileSync, writeFileSync, cpSync } from 'fs'
-import { resolve } from 'path'
+import { dirname, resolve } from 'path'
 import { ensureHookTrust, getInstallFollowupNotes, installPlugin, listHookCommands, planInstallUserConfig, resolveInstallUserConfig, uninstallPlugin } from '../src/cli/install'
 import type { PluginConfig, TargetPlatform } from '../src/schema'
 
@@ -129,6 +129,20 @@ describe('install', () => {
     expect(readFileSync(resolve(opencodeSkill, 'SKILL.md'), 'utf-8')).toContain('name: megamind/client-intel')
   })
 
+  it('refuses to overwrite an unowned OpenCode companion and leaves the bundle untouched', async () => {
+    mkdirSync(resolve(DIST_DIR, 'opencode/skills/client-intel'), { recursive: true })
+    await Bun.write(resolve(DIST_DIR, 'opencode/index.ts'), 'export const MegamindPlugin = async () => ({});\n')
+    await Bun.write(resolve(DIST_DIR, 'opencode/skills/client-intel/SKILL.md'), '# Client Intel\n')
+    const entryPath = resolve(HOME_DIR, OPENCODE_ENTRY_PATH)
+    mkdirSync(dirname(entryPath), { recursive: true })
+    writeFileSync(entryPath, '// private wrapper\n')
+
+    await expect(installPlugin(DIST_DIR, 'megamind', ['opencode'], { useNativeClaudeInstall: false })).rejects.toThrow('unowned install')
+    expect(readFileSync(entryPath, 'utf-8')).toBe('// private wrapper\n')
+    expect(existsSync(resolve(HOME_DIR, INSTALL_PATHS.opencode))).toBe(false)
+    expect(existsSync(resolve(HOME_DIR, OPENCODE_SKILL_PATH))).toBe(false)
+  })
+
   it('removes Codex marketplace entries on uninstall', async () => {
     mkdirSync(resolve(DIST_DIR, 'codex'), { recursive: true })
     await installPlugin(DIST_DIR, 'megamind', ['codex'], { useNativeClaudeInstall: false })
@@ -226,6 +240,23 @@ describe('install', () => {
     expect(existsSync(resolve(HOME_DIR, INSTALL_PATHS.opencode))).toBe(false)
     expect(existsSync(resolve(HOME_DIR, OPENCODE_ENTRY_PATH))).toBe(false)
     expect(existsSync(resolve(HOME_DIR, OPENCODE_SKILL_PATH))).toBe(false)
+  })
+
+  it('preserves modified OpenCode companions during uninstall', async () => {
+    mkdirSync(resolve(DIST_DIR, 'opencode/skills/client-intel'), { recursive: true })
+    await Bun.write(resolve(DIST_DIR, 'opencode/index.ts'), 'export const MegamindPlugin = async () => ({});\n')
+    await Bun.write(resolve(DIST_DIR, 'opencode/skills/client-intel/SKILL.md'), '# Client Intel\n')
+    await installPlugin(DIST_DIR, 'megamind', ['opencode'], { useNativeClaudeInstall: false })
+    const entryPath = resolve(HOME_DIR, OPENCODE_ENTRY_PATH)
+    const skillPath = resolve(HOME_DIR, OPENCODE_SKILL_PATH, 'SKILL.md')
+    writeFileSync(entryPath, '// user edit\n')
+    writeFileSync(skillPath, '# User edit\n')
+
+    await uninstallPlugin('megamind', ['opencode'], { quiet: true })
+
+    expect(readFileSync(entryPath, 'utf-8')).toBe('// user edit\n')
+    expect(readFileSync(skillPath, 'utf-8')).toBe('# User edit\n')
+    expect(existsSync(resolve(HOME_DIR, INSTALL_PATHS.opencode))).toBe(false)
   })
 
   it('lists only command hooks for install trust warning', () => {

--- a/tests/publish.test.ts
+++ b/tests/publish.test.ts
@@ -222,6 +222,7 @@ interface GeneratedInstallerRunOptions {
   env?: Record<string, string>
   existingUserConfig?: unknown
   extraFiles?: Record<string, string>
+  setupPaths?: (paths: ReturnType<typeof getGeneratedInstallerPaths>, rootDir: string) => void
 }
 
 interface GeneratedInstallerRunResult {
@@ -313,6 +314,7 @@ function runGeneratedInstaller(
       JSON.stringify(options.existingUserConfig, null, 2) + '\n',
     )
   }
+  options.setupPaths?.(paths, rootDir)
 
   let installerRun: GeneratedInstallerRunResult | undefined
   const result = runPublish(config, {
@@ -764,6 +766,25 @@ describe('runPublish', () => {
     expect(installerContent.indexOf('PLUXX_CODEX_ENABLE_PLUGIN_HOOKS')).toBeLessThan(
       installerContent.indexOf('Updated Codex marketplace catalog'),
     )
+  })
+
+  it('rolls back a generated OpenCode install when an unowned companion blocks the transaction', () => {
+    const run = runGeneratedInstaller('opencode', {
+      config: { ...makeConfig(), targets: ['opencode'] },
+      setupPaths: (paths) => {
+        mkdirSync(paths.pluginInstallDir, { recursive: true })
+        writeFileSync(resolve(paths.pluginInstallDir, '.pluxx-user.json'), '{}\n')
+        const entryPath = paths.env.PLUXX_OPENCODE_ENTRY_PATH
+        mkdirSync(resolve(entryPath, '..'), { recursive: true })
+        writeFileSync(entryPath, '// private wrapper\n')
+      },
+    })
+
+    expect(run.status).toBe(1)
+    expect(run.stderr).toContain('Refusing to replace unowned OpenCode companion')
+    expect(readFileSync(resolve(run.rootDir, 'publish-plugin.ts'), 'utf-8')).toBe('// private wrapper\n')
+    expect(readFileSync(resolve(run.pluginInstallDir, '.pluxx-user.json'), 'utf-8')).toBe('{}\n')
+    expect(existsSync(resolve(run.pluginInstallDir, 'package.json'))).toBe(false)
   })
 
   it('reuses saved generated-installer user config across core host updates', () => {

--- a/tests/publish.test.ts
+++ b/tests/publish.test.ts
@@ -749,12 +749,12 @@ describe('runPublish', () => {
     expect(installerContent).toContain('server.http_headers')
     expect(installerContent).toContain('preserveSecretReferences = true')
     expect(installerContent).toContain('Preparing local plugin runtime dependencies...')
-    expect(installerContent).toContain('bash "$INSTALL_DIR/scripts/bootstrap-runtime.sh"')
+    expect(installerContent).toContain('bash "$PLUXX_TX_STAGE/scripts/bootstrap-runtime.sh"')
     expect(installerContent).toContain('PLUXX_CODEX_ENABLE_PLUGIN_HOOKS')
     expect(installerContent).toContain('Codex requires [features].hooks = true')
     expect(installerContent).toContain('hooks = true')
     expect(installerContent).toContain('materializeInstalledStdioPath')
-    expect(installerContent).toContain("path.resolve(installDir, normalized)")
+    expect(installerContent).toContain("path.resolve(runtimeRoot, normalized)")
     expect(installerContent.indexOf('PLUXX_USER_CONFIG_SPEC')).toBeLessThan(
       installerContent.indexOf('Preparing local plugin runtime dependencies...'),
     )
@@ -962,7 +962,10 @@ describe('runPublish', () => {
       expect(run.stdout).not.toContain('reusing saved install values')
       expect(run.stderr).toContain('Ignoring placeholder-looking saved config for SENDLENS_INSTANTLY_API_KEY.')
       expect(run.stderr).toContain('Refusing placeholder-looking saved config for SENDLENS_INSTANTLY_API_KEY.')
-      expect(run.installedUserConfig).toBeUndefined()
+      expect(run.installedUserConfig).toEqual({
+        values: { 'instantly-api-key': 'your api key here' },
+        env: { SENDLENS_INSTANTLY_API_KEY: 'your api key here' },
+      })
     }
   })
 

--- a/tests/verify-install.test.ts
+++ b/tests/verify-install.test.ts
@@ -256,7 +256,7 @@ describe('verifyInstall', () => {
       platform: 'cursor',
       built: true,
       installed: true,
-      stale: false,
+      stale: true,
       ok: false,
     })
     expect(result.checks[0].errors).toBeGreaterThan(0)
@@ -294,7 +294,7 @@ describe('verifyInstall', () => {
       platform: 'cursor',
       built: true,
       installed: true,
-      stale: false,
+      stale: true,
       ok: false,
     })
     expect(result.checks[0].errors).toBeGreaterThan(0)


### PR DESCRIPTION
## Summary

Failed core-four installs can no longer displace a working bundle, and reinstall/uninstall no longer silently destroy modified or unowned files. Candidate bundles are staged and validated before a same-filesystem swap, with the previous install retained until post-install work succeeds and restored on failure.

Install truth is now content-aware rather than version-only. Versioned ownership ledgers hash installed files and symlink targets, `verify-install` reports same-version drift, and generated GitHub Release installers enforce the same transaction and ownership contract as the local CLI.

Codex companion config also gains a conservative inverse: `pluxx codex unapply` restores the previous config only while the Pluxx-applied state remains unchanged. Later user edits are preserved for manual reconciliation, and ownership records are path-validated and owner-readable only.

## Design decisions

- Existing copied installs without valid ownership are never silently adopted; replacement stops with an actionable preservation error.
- Backups remain siblings of the live path so rename is the atomic commit point and rollback stays on the same filesystem.
- Uninstall removes unchanged owned files individually, then prunes empty directories while leaving modified and extra files intact.
- Generated installers embed the narrow transaction helper because release consumers may not have the Pluxx CLI installed.
- Archive checksum/signature verification and publish recovery remain scoped to PLUXX-320.

## Validation

- `npm run typecheck` — passed
- `npm run build` — passed
- Targeted install/distribution/Codex/verification matrix — 104/104 passed before review; final affected matrix 101/101 passed
- Official serial `npm test` after review fixes — 593/593 passed across 54 files
- CE security/reliability/supply-chain review — no unresolved P0–P2 findings

Plan: `docs/orchid/plans/2026-07-12-pluxx-319-transactional-installs.md`

Review: `docs/orchid/reviews/2026-07-12-pluxx-319-code-security-review.md`

Fixes PLUXX-319.

Fixes #409.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
