### PR TITLE
Add proof freshness governance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v5
@@ -21,6 +23,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Check proof freshness
+        run: npm run proof:check
 
       - name: Typecheck
         run: npm run typecheck

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Raw MCP access is usually not enough. Most products still need workflow grouping
 
 ## Current Proof
 
+Proof claims are tiered and freshness-checked. See [Proof freshness and evidence tiers](./docs/proof-freshness.md) and the machine-readable [proof manifest](./docs/proof-manifest.json); April/May host runs remain available as explicitly historical evidence.
+
 If you want the fastest way to see what is already real, start with these:
 
 - [Release distribution proof map](./docs/release-distribution-proof-map.md)

--- a/docs/first-proof-demo-asset-pack.md
+++ b/docs/first-proof-demo-asset-pack.md
@@ -1,6 +1,8 @@
-# Current Proof And Demo Asset Pack
+# Proof And Demo Asset Pack
 
-Last updated: 2026-04-24
+Last updated: 2026-07-12
+
+Freshness note: this inventory mixes current repository/bundle evidence with explicitly historical host runs. Use [proof freshness](./proof-freshness.md) and [proof manifest](./proof-manifest.json) before presenting any item as current.
 
 This doc is the public-proof map for Pluxx.
 
@@ -13,7 +15,7 @@ Use it when you want the cleanest answer to:
 
 This is no longer a speculative launch memo.
 
-It is the current proof inventory plus the next capture plan.
+It is the proof inventory plus the next capture plan.
 
 If you want the shortest public-facing entrypoint instead of the fuller planning inventory, start with [docs/proof-and-install.md](./proof-and-install.md).
 
@@ -36,7 +38,7 @@ The first pass of that packaging now exists at:
 
 ## Proof That Already Exists
 
-### 1. Self-hosted Pluxx plugin across the core four
+### 1. Historical self-hosted Pluxx plugin across the core four
 
 Primary doc:
 
@@ -165,7 +167,7 @@ Best public use:
 - release notes
 - technical buyer confidence
 
-### 5. Connector-backed Firecrawl docs-ingestion proof
+### 5. Historical connector-backed Firecrawl docs-ingestion proof
 
 Primary doc:
 
@@ -174,7 +176,7 @@ Primary doc:
 
 What it proves:
 
-- a real Firecrawl-backed comparison now exists on the current fixture set
+- a historical Firecrawl-backed comparison exists for the April fixture set
 - Firecrawl materially improves extracted product/setup/auth/workflow context on those fixtures
 - the docs-ingestion lane now has a committed scaffold-quality before/after demo, not only eval snapshots
 - the remaining gap is now broader public packaging and continued fixture hardening, not basic proof-of-value
@@ -212,7 +214,7 @@ Missing artifact:
 
 Why it matters:
 
-- the current CLI/headless proof is now real across all four
+- historical CLI/headless proof exists across all four; current repository checks do not replace a new host receipt
 - the in-app flagship story is still most legible in Codex today
 
 ### 3. Live private publish / rollback proof
@@ -226,12 +228,12 @@ Why it matters:
 - the private publish lane is now modeled and mechanically guarded
 - the last missing flagship auth proof is a real private endpoint, not more source-project work
 
-## Best Current Demo Flow
+## Best Demo Flow
 
 If you need the strongest current narrative without waiting on Firecrawl, use this order:
 
 1. start with [README](../README.md) and [start-here](./start-here.md)
-2. show [Self-hosted core-four proof](./pluxx-self-hosted-core-four-proof.md)
+2. show [Self-hosted core-four proof](./pluxx-self-hosted-core-four-proof.md) as historical installed-runtime evidence
 3. show [Docs Ops core-four proof](./docs-ops-core-four-proof.md)
 4. show [Orchid Docs Ops Codex walkthrough](./orchid-docs-ops-codex-walkthrough.md)
 5. show the [Accordion before/after rewrite](../example/docs-ops/demo-rewrites/orchid-components-accordion.after.md)

--- a/docs/pluxx-self-hosted-core-four-proof.md
+++ b/docs/pluxx-self-hosted-core-four-proof.md
@@ -2,6 +2,8 @@
 
 Last updated: 2026-05-12
 
+Proof status: **historical**. Tier: `installed-runtime`. Observed: 2026-05-12 against v0.1.28-era state. The run predates host-version, installed-path, and artifact-hash receipts and therefore must not be presented as current v0.1.31 evidence. See [proof freshness](./proof-freshness.md) and [proof manifest](./proof-manifest.json).
+
 ## Doc Links
 
 - Role: concrete local proof that the self-hosted Pluxx plugin builds, installs, and verifies across the core four
@@ -25,7 +27,7 @@ Use this doc when you want the shortest concrete answer to:
 - what exact commands were run
 - what did that proof actually establish
 
-This is the self-hosted Pluxx plugin proof.
+This is retained historical self-hosted Pluxx plugin proof.
 
 It is not the same thing as the flagship Docs Ops proof.
 

--- a/docs/proof-and-install.md
+++ b/docs/proof-and-install.md
@@ -32,6 +32,8 @@ For the fuller release/distribution boundary, including publish commands and def
 
 Proof labels and freshness come from [proof-freshness.md](./proof-freshness.md) and [proof-manifest.json](./proof-manifest.json). The May self-hosted run and April Firecrawl connector run are preserved as historical environment evidence; they are not current host receipts for `0.1.31`.
 
+The current v0.1.31 receipts prove the `bundle-contract` and `fake-home-install` tiers. No current receipt claims installed-runtime or real-host behavior.
+
 ## The Story In One Screen
 
 ```text

--- a/docs/proof-and-install.md
+++ b/docs/proof-and-install.md
@@ -30,6 +30,8 @@ This is the shortest current repo-native path to:
 
 For the fuller release/distribution boundary, including publish commands and deferred marketplace/trust-layer work, use [docs/release-distribution-proof-map.md](./release-distribution-proof-map.md).
 
+Proof labels and freshness come from [proof-freshness.md](./proof-freshness.md) and [proof-manifest.json](./proof-manifest.json). The May self-hosted run and April Firecrawl connector run are preserved as historical environment evidence; they are not current host receipts for `0.1.31`.
+
 ## The Story In One Screen
 
 ```text
@@ -204,7 +206,7 @@ curl -fsSL https://raw.githubusercontent.com/orchidautomation/pluxx/main/example
 
 Current release note:
 
-- the repo is preparing `@orchid-labs/pluxx@0.1.28`; verify npm and the matching tag live before claiming it as the public latest release
+- the canonical repository release is `@orchid-labs/pluxx@0.1.31` with expected tag `v0.1.31`; `package.json` remains authoritative for repository docs
 - the published CLI runtime is Node `>=18`; see [runtime contract](./runtime-contract.md)
 - the published package includes the Claude plugin-agent manifest fix and packaged Node runtime verification
 - the public `pluxx test --install --trust --behavioral` path now matches the repo-local Exa proof state

--- a/docs/proof-freshness.md
+++ b/docs/proof-freshness.md
@@ -1,0 +1,53 @@
+# Proof Freshness And Evidence Tiers
+
+Last updated: 2026-07-12
+
+This document defines how Pluxx distinguishes repeatable repository checks from installed and real-host evidence. The machine-readable source is [proof-manifest.json](./proof-manifest.json), validated by `npm run proof:check`.
+
+## Version And Freshness Policy
+
+- `package.json` is the canonical repository version.
+- The expected release tag is `v<packageVersion>`.
+- `releaseState` is `released` when that tag exists and `release-prep` when it does not. Release-prep docs must not describe the pending version as already released.
+- Unit, bundle-contract, and fake-home receipts are current only when their package version matches `package.json` and their tested commit is reachable from the current branch.
+- Installed-runtime and real-host receipts must also be 30 days old or newer. Older environment evidence is historical even when its package version still matches.
+- Historical receipts remain available, but canonical current-proof claims must label them historical and may not use them as current compatibility evidence.
+
+## Evidence Tier Contract
+
+| Tier | Minimum evidence | What it may claim | What it may not claim |
+| --- | --- | --- | --- |
+| `unit` | focused assertions against source modules | the tested function or module contract | generated bundle, installation, runtime discovery, or host behavior |
+| `bundle-contract` | real CLI build/test plus generated-file and consumer-contract checks | the generated bundle has the expected shape and passes repo-owned contract checks | installation into a real user home or host behavior |
+| `fake-home-install` | install and verification against an isolated temporary home, including installed-file assertions | install layout, ownership, and verifier behavior in an isolated filesystem | discovery or execution by a real host application |
+| `installed-runtime` | host-visible installed path, artifact hash, host version, runtime command, and outcome | the named installed artifact was discovered or executed by the named host/runtime version | broader workflows or other host versions not exercised by the receipt |
+| `real-host-behavior` | an actual host workflow with host version, installed path/hash, command or prompt, observable outcome, and timestamp | the exact workflow succeeded in the named host environment | evergreen compatibility after the 30-day window or untested hosts/workflows |
+
+`tests/release-smoke.test.ts` is retained as a stable file path, but its suite is bundle-contract plus isolated fake-home install proof. It is not real-host behavior proof.
+
+## Receipt Contract
+
+Each receipt records commit SHA, package version, timestamp, proof tier, commands, target and host versions, installed paths, hashes, and outcomes. Older evidence may provide a reason when an environment field was not captured.
+
+Current claims in `docs/proof-manifest.json` must resolve to a receipt whose tier and freshness match the claim. CI also rejects obsolete release-prep/current-version language in canonical planning and proof docs.
+
+## Real-Host Refresh Guidance
+
+Run real-host proof manually before a release claim or on a scheduled monthly cadence:
+
+1. Record the package version, tested commit, UTC timestamp, host version, and installed path.
+2. Hash the installed artifact or deterministic installed tree.
+3. Run the named workflow and capture only the observable outcome needed for the claim.
+4. Add or regenerate the receipt, then run `npm run proof:check`.
+5. If the host or environment is unavailable, record `not-run` and the reason. Do not copy an older success forward as current evidence.
+
+Scheduled automation may publish receipts as CI artifacts. Committed canonical claims still require a reviewed manifest update before they can be described as current.
+
+Use [proof-receipt.example.json](./proof-receipt.example.json) as the receipt-spec shape. Checked-in run specs live under `docs/proof-receipts/`. Copy the example to a run-specific file, record the commands and outcomes actually observed, then regenerate the matching receipt:
+
+```bash
+npm run proof:receipt -- --spec path/to/receipt-spec.json
+npm run proof:check
+```
+
+`proof:receipt` fills the current commit SHA, package version, and UTC timestamp, then inserts or replaces the receipt with the same `id`. Add or update the corresponding claim in `proof-manifest.json`; its `tier`, `freshness`, and `receiptId` must match before `proof:check` passes.

--- a/docs/proof-freshness.md
+++ b/docs/proof-freshness.md
@@ -4,6 +4,8 @@ Last updated: 2026-07-12
 
 This document defines how Pluxx distinguishes repeatable repository checks from installed and real-host evidence. The machine-readable source is [proof-manifest.json](./proof-manifest.json), validated by `npm run proof:check`.
 
+Current reviewed receipts for v0.1.31 are `v0.1.31-repository-validation` (`bundle-contract`, `current`) and `v0.1.31-fake-home-install` (`fake-home-install`, `current`). Neither is installed-runtime or real-host behavior evidence.
+
 ## Version And Freshness Policy
 
 - `package.json` is the canonical repository version.

--- a/docs/proof-manifest.json
+++ b/docs/proof-manifest.json
@@ -1,0 +1,77 @@
+{
+  "schemaVersion": 1,
+  "canonicalVersion": "0.1.31",
+  "expectedTag": "v0.1.31",
+  "releaseState": "released",
+  "policy": {
+    "environmentReceiptMaxAgeDays": 30
+  },
+  "claims": [
+    {
+      "id": "self-hosted-core-four-history",
+      "summary": "The May self-hosted core-four run remains useful historical installed-runtime evidence.",
+      "tier": "installed-runtime",
+      "freshness": "historical",
+      "evidencePath": "docs/pluxx-self-hosted-core-four-proof.md",
+      "receiptId": "v0.1.28-self-hosted-history"
+    },
+    {
+      "id": "docs-ingestion-connector-history",
+      "summary": "The Firecrawl connector comparison remains historical workflow evidence.",
+      "tier": "real-host-behavior",
+      "freshness": "historical",
+      "evidencePath": "docs/strategy/firecrawl-connector-docs-ingestion-proof.md",
+      "receiptId": "v0.1.28-firecrawl-history"
+    }
+  ],
+  "receipts": [
+    {
+      "id": "v0.1.28-self-hosted-history",
+      "tier": "installed-runtime",
+      "freshness": "historical",
+      "commitSha": "7cbe896250cc728b6eb7328fb3fa9770022e4ef8",
+      "packageVersion": "0.1.28",
+      "timestamp": "2026-05-12T00:00:00.000Z",
+      "commands": [
+        {
+          "command": "Historical commands are recorded in docs/pluxx-self-hosted-core-four-proof.md",
+          "outcome": "passed"
+        }
+      ],
+      "targets": [
+        {
+          "target": "core-four",
+          "hostVersion": null,
+          "installedPath": null,
+          "sha256": null,
+          "outcome": "passed",
+          "unavailableReason": "The May proof predates machine-readable host-version, installed-path, and hash receipts."
+        }
+      ]
+    },
+    {
+      "id": "v0.1.28-firecrawl-history",
+      "tier": "real-host-behavior",
+      "freshness": "historical",
+      "commitSha": "7cbe896250cc728b6eb7328fb3fa9770022e4ef8",
+      "packageVersion": "0.1.28",
+      "timestamp": "2026-05-21T00:00:00.000Z",
+      "commands": [
+        {
+          "command": "Historical connector run documented in docs/strategy/firecrawl-connector-docs-ingestion-proof.md",
+          "outcome": "passed"
+        }
+      ],
+      "targets": [
+        {
+          "target": "firecrawl-connector",
+          "hostVersion": null,
+          "installedPath": null,
+          "sha256": null,
+          "outcome": "passed",
+          "unavailableReason": "The historical connector capture did not record host version, installed path, or artifact hash."
+        }
+      ]
+    }
+  ]
+}

--- a/docs/proof-manifest.json
+++ b/docs/proof-manifest.json
@@ -8,6 +8,22 @@
   },
   "claims": [
     {
+      "id": "v0.1.31-repository-validation",
+      "summary": "The reviewed v0.1.31 commit passes proof governance, typecheck, build, and the official serial suite.",
+      "tier": "bundle-contract",
+      "freshness": "current",
+      "evidencePath": "tests/proof-freshness.test.ts",
+      "receiptId": "v0.1.31-repository-validation"
+    },
+    {
+      "id": "v0.1.31-fake-home-install",
+      "summary": "Maintained examples pass core-four bundle and isolated fake-home install verification.",
+      "tier": "fake-home-install",
+      "freshness": "current",
+      "evidencePath": "tests/release-smoke.test.ts",
+      "receiptId": "v0.1.31-fake-home-install"
+    },
+    {
       "id": "self-hosted-core-four-history",
       "summary": "The May self-hosted core-four run remains useful historical installed-runtime evidence.",
       "tier": "installed-runtime",
@@ -72,6 +88,64 @@
           "unavailableReason": "The historical connector capture did not record host version, installed path, or artifact hash."
         }
       ]
+    },
+    {
+      "id": "v0.1.31-repository-validation",
+      "tier": "bundle-contract",
+      "freshness": "current",
+      "commitSha": "5066ee4764c2679cdf10f40156f756da51fb89b3",
+      "packageVersion": "0.1.31",
+      "timestamp": "2026-07-12T11:50:11.851Z",
+      "commands": [
+        {
+          "command": "npm run proof:check",
+          "outcome": "passed"
+        },
+        {
+          "command": "npm run typecheck",
+          "outcome": "passed"
+        },
+        {
+          "command": "npm run build",
+          "outcome": "passed"
+        },
+        {
+          "command": "npm test",
+          "outcome": "passed"
+        }
+      ],
+      "targets": [
+        {
+          "target": "repository",
+          "hostVersion": null,
+          "installedPath": null,
+          "sha256": null,
+          "outcome": "passed"
+        }
+      ]
+    },
+    {
+      "id": "v0.1.31-fake-home-install",
+      "tier": "fake-home-install",
+      "freshness": "current",
+      "commands": [
+        {
+          "command": "bun test tests/release-smoke.test.ts",
+          "outcome": "passed"
+        }
+      ],
+      "targets": [
+        {
+          "target": "claude-code,cursor,codex,opencode",
+          "hostVersion": null,
+          "installedPath": null,
+          "sha256": null,
+          "outcome": "passed"
+        }
+      ],
+      "commitSha": "5066ee4764c2679cdf10f40156f756da51fb89b3",
+      "packageVersion": "0.1.31",
+      "timestamp": "2026-07-12T11:50:12.286Z"
     }
   ]
 }

--- a/docs/proof-receipt.example.json
+++ b/docs/proof-receipt.example.json
@@ -1,0 +1,20 @@
+{
+  "id": "vX.Y.Z-repository-check",
+  "tier": "bundle-contract",
+  "freshness": "current",
+  "commands": [
+    {
+      "command": "npm run build",
+      "outcome": "passed"
+    }
+  ],
+  "targets": [
+    {
+      "target": "repository",
+      "hostVersion": null,
+      "installedPath": null,
+      "sha256": null,
+      "outcome": "passed"
+    }
+  ]
+}

--- a/docs/proof-receipts/v0.1.31-fake-home-install.json
+++ b/docs/proof-receipts/v0.1.31-fake-home-install.json
@@ -1,0 +1,20 @@
+{
+  "id": "v0.1.31-fake-home-install",
+  "tier": "fake-home-install",
+  "freshness": "current",
+  "commands": [
+    {
+      "command": "bun test tests/release-smoke.test.ts",
+      "outcome": "passed"
+    }
+  ],
+  "targets": [
+    {
+      "target": "claude-code,cursor,codex,opencode",
+      "hostVersion": null,
+      "installedPath": null,
+      "sha256": null,
+      "outcome": "passed"
+    }
+  ]
+}

--- a/docs/proof-receipts/v0.1.31-repository-validation.json
+++ b/docs/proof-receipts/v0.1.31-repository-validation.json
@@ -1,0 +1,32 @@
+{
+  "id": "v0.1.31-repository-validation",
+  "tier": "bundle-contract",
+  "freshness": "current",
+  "commands": [
+    {
+      "command": "npm run proof:check",
+      "outcome": "passed"
+    },
+    {
+      "command": "npm run typecheck",
+      "outcome": "passed"
+    },
+    {
+      "command": "npm run build",
+      "outcome": "passed"
+    },
+    {
+      "command": "npm test",
+      "outcome": "passed"
+    }
+  ],
+  "targets": [
+    {
+      "target": "repository",
+      "hostVersion": null,
+      "installedPath": null,
+      "sha256": null,
+      "outcome": "passed"
+    }
+  ]
+}

--- a/docs/release-distribution-proof-map.md
+++ b/docs/release-distribution-proof-map.md
@@ -1,6 +1,6 @@
 # Release Distribution Proof Map
 
-Last updated: 2026-06-24
+Last updated: 2026-07-12
 
 ## Doc Links
 
@@ -25,6 +25,8 @@ Last updated: 2026-06-24
   - [docs/roadmap.md](./roadmap.md)
 
 This is the short release/distribution map for what Pluxx can ship today, what is locally proven, and what still belongs to later marketplace or trust-layer work.
+
+Proof state is governed by [proof-freshness.md](./proof-freshness.md) and the machine-readable [proof manifest](./proof-manifest.json). The canonical repository release is `0.1.31` / `v0.1.31`. Older environment runs linked below are historical unless a current receipt says otherwise.
 
 ## Current Primary Fronts
 
@@ -51,7 +53,7 @@ Pluxx can ship the OSS authoring substrate today:
 - `pluxx publish --npm` covers the npm-backed OpenCode wrapper package path
 - `pluxx discover-mcp` and `pluxx init --from-installed-mcp` can import already configured MCP servers from Claude Code, Cursor, Codex, and OpenCode without copying literal secret values
 
-The strongest current proof assets are:
+The strongest proof assets are listed below. Their current versus historical status comes from the proof manifest, not from the age or wording of the page alone:
 
 - [Self-hosted core-four proof](./pluxx-self-hosted-core-four-proof.md)
 - [Docs Ops core-four proof](./docs-ops-core-four-proof.md)
@@ -77,7 +79,7 @@ pluxx sync --from-mcp <source>
 | Codex | `pluxx build --target codex` | `pluxx install --target codex --trust` | `pluxx verify-install --target codex` | use `Plugins > Refresh` if available, otherwise restart |
 | OpenCode | `pluxx build --target opencode` | `pluxx install --target opencode --trust` | `pluxx verify-install --target opencode` | restart or reload OpenCode |
 
-Whole-lane checks:
+Whole-lane repository checks (bundle-contract and fake-home tiers, not real-host behavior):
 
 ```bash
 pluxx build --target claude-code cursor codex opencode

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Last updated: 2026-06-27
+Last updated: 2026-07-12
 
 ## Doc Links
 
@@ -77,6 +77,8 @@ See [docs/orchid/decisions/2026-06-26-pluxx-next-ship-review.md](./orchid/decisi
 The follow-on slice is install ownership tracking for conservative uninstall, prune, reinstall, and "what did Pluxx touch?" diagnostics.
 
 ## Current Priority Order
+
+Proof governance now distinguishes unit, bundle-contract, fake-home install, installed-runtime, and real-host behavior evidence. Canonical version/freshness checks run in CI through [proof-freshness.md](./proof-freshness.md) and [proof-manifest.json](./proof-manifest.json); historical April/May proof stays available without being treated as current.
 
 ### 1. Product clarity and source-of-truth coherence
 
@@ -215,14 +217,14 @@ The closure plan is now narrower than it was before:
 - the self-hosted `example/pluxx` source project now also carries maintained behavioral smoke cases for:
   - `verify-install`
   - `translate-hosts` with a Codex hooks focus
-- the release gate is green again as of 2026-05-19:
+- historical release-gate evidence from 2026-05-19 remains available but is not current proof:
   - `npm test` passed
   - `npm run release:check` passed
-- the repo is preparing `@orchid-labs/pluxx@0.1.28`; verify npm and the matching tag live before claiming it as the public latest release
+- the canonical repository release is `@orchid-labs/pluxx@0.1.31` with expected tag `v0.1.31`
 - the release/distribution/proof boundary is now explicit:
   - [docs/release-distribution-proof-map.md](./release-distribution-proof-map.md)
   - [docs/core-four-primitive-proof-ledger.md](./core-four-primitive-proof-ledger.md)
-  - current primary release-smoked fronts remain Claude Code, Cursor, Codex, and OpenCode
+  - current primary bundle-contract and fake-home fronts remain Claude Code, Cursor, Codex, and OpenCode
   - Gemini CLI remains a beta generator target until it has release-smoke and installer parity
   - `pluxx publish --github-release` covers primary-front release assets, the generated `install.sh --agents` front door, and per-host installers; `pluxx publish --npm` covers the npm-backed OpenCode wrapper path
   - marketplace submission APIs, a managed trust/distribution control plane, automatic rollback/unpublish orchestration, and real authenticated publish plus rollback proof remain open release gaps
@@ -375,8 +377,7 @@ This is for learning and proof, not for prematurely building the full trust laye
 
 ### 6. Next release
 
-The current release-prep npm cut is `0.1.28`.
-Verify npm and the matching tag live before claiming it as the public latest release.
+The canonical repository release is `0.1.31` / `v0.1.31`. The next npm cut begins from that source of truth and must regenerate or explicitly demote proof receipts before making current host claims.
 
 The next npm cut should stay primarily an operations step rather than a code-confidence rescue step.
 

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -1,6 +1,6 @@
 # Start Here
 
-Last updated: 2026-06-27
+Last updated: 2026-07-12
 
 ## Doc Links
 
@@ -38,6 +38,8 @@ If you want the broadest completeness checklist after reading this, use [docs/to
 If you want the shortest public proof and install path after this file, use [docs/proof-and-install.md](./proof-and-install.md).
 
 If you want the current release, distribution, and proof boundary, use [docs/release-distribution-proof-map.md](./release-distribution-proof-map.md).
+
+If you need to know whether a proof claim is current, historical, repository-only, installed, or real-host evidence, use [docs/proof-freshness.md](./proof-freshness.md) and [docs/proof-manifest.json](./proof-manifest.json). Canonical repository version truth is `package.json` (`0.1.31`) with expected tag `v0.1.31`.
 
 If you want the primitive-by-host proof ledger behind the core-four native shipping claim, use [docs/core-four-primitive-proof-ledger.md](./core-four-primitive-proof-ledger.md).
 
@@ -345,10 +347,10 @@ The repo already proves a lot.
 - example and packaged-runtime parity is current again:
   - `examples/prospeo-mcp` now bundles its `scripts/` payload into built outputs
   - the example now points at the official `@prospeo/prospeo-mcp-server` package instead of a stale repo-local runtime path
-- the current release gate is green again as of 2026-05-19:
+- historical release-gate evidence from 2026-05-19 remains available but is not current proof:
   - `npm test` passed
   - `npm run release:check` passed
-- the repo is preparing `@orchid-labs/pluxx@0.1.28`; verify npm and the matching tag live before claiming it as the public latest release
+- the canonical repository release is `@orchid-labs/pluxx@0.1.31` with expected tag `v0.1.31`
 - marketplace submission APIs, a managed trust/distribution control plane, automatic rollback/unpublish orchestration, and real authenticated publish plus rollback proof remain explicit release gaps, not hidden shipped capabilities:
   - `docs/release-distribution-proof-map.md`
 - OpenCode-native agent output is now permission-first:
@@ -516,14 +518,7 @@ Run two lanes in parallel:
 
 ### 6. Release State
 
-The current release-prep cut is `0.1.28`.
-Do not treat it as the public release until the matching tag exists and npm reports it as latest.
-
-The release-prep checklist for the current cut is complete:
-
-- `package.json` and `package-lock.json` are at `0.1.28`
-- the release gate has passed locally, including package runtime verification and release tarball pack
-- after merge, push the matching `v0.1.28` tag and verify npm plus GitHub release artifacts after the workflow completes
+The canonical repository release is `0.1.31` with expected tag `v0.1.31`. `package.json` is the source of truth for repository docs, while [proof-manifest.json](./proof-manifest.json) records whether evidence is current or historical.
 
 For the next release, start from the current version, rerun `npm run release:check`, bump the package version, push `main`, push the matching `vX.Y.Z` tag, and verify npm plus GitHub release artifacts after the workflow completes.
 

--- a/docs/strategy/firecrawl-connector-docs-ingestion-proof.md
+++ b/docs/strategy/firecrawl-connector-docs-ingestion-proof.md
@@ -2,6 +2,8 @@
 
 Last updated: 2026-04-23
 
+Proof status: **historical**. Tier: `real-host-behavior`. Observed: 2026-04-23 against v0.1.28-era state. This connector run predates complete host-version, installed-path, and artifact-hash receipts and is not current v0.1.31 evidence. See [proof freshness](../proof-freshness.md) and [proof manifest](../proof-manifest.json).
+
 This note captures the first real Firecrawl-backed docs-ingestion comparison on the current fixture set.
 
 It is intentionally separate from the repeatable local harness snapshot at:
@@ -37,7 +39,7 @@ Firecrawl-backed pass:
 
 This note still matters because it captured the first real Firecrawl-backed comparison before the keyed local harness rerun was available in the repo.
 
-## Current Read
+## Historical Read
 
 - Firecrawl-backed ingestion is now proven on the current fixture set.
 - Sumble and PlayKit both produce clean, high-signal product/setup/auth/workflow context through Firecrawl.

--- a/docs/todo/master-backlog.md
+++ b/docs/todo/master-backlog.md
@@ -1,6 +1,6 @@
 # Master Backlog
 
-Last updated: 2026-06-27
+Last updated: 2026-07-12
 
 This is the most complete repo-native backlog for Pluxx.
 
@@ -79,6 +79,8 @@ Any person or agent should be able to enter the repo and answer:
 - where the business could go later
 
 ## Now
+
+Proof governance is now explicit: [proof-freshness.md](../proof-freshness.md) defines the five evidence tiers and freshness rules, while [proof-manifest.json](../proof-manifest.json) keeps machine-readable receipts and current/historical claim state aligned with `package.json`.
 
 ### 1. Product clarity and front-door coherence
 

--- a/docs/todo/queue.md
+++ b/docs/todo/queue.md
@@ -166,12 +166,12 @@ The initial author-once hardening tranche is also materially done.
 - example and packaged-runtime parity is current again:
   - `examples/prospeo-mcp` now includes its `scripts/` payload in built/installable outputs
   - the example now targets the official `@prospeo/prospeo-mcp-server` package instead of a stale repo-local runtime path
-- the repo release gate is green again as of 2026-05-19:
+- historical release-gate evidence from 2026-05-19 remains available but is not current proof:
   - `npm test`
   - `npm run release:check`
 - the release/distribution/proof lane now has a short source-of-truth map:
   - [docs/release-distribution-proof-map.md](../release-distribution-proof-map.md)
-  - primary release-smoked fronts: Claude Code, Cursor, Codex, OpenCode
+  - primary bundle-contract and fake-home fronts: Claude Code, Cursor, Codex, OpenCode
   - Gemini CLI: beta generator target only today
   - shipped distribution lane: local build/install/verify, GitHub Release `install.sh --agents` plus per-host bundle installers, and npm-backed OpenCode package publishing
   - remaining release gaps: marketplace submission APIs, managed trust/distribution control plane, automatic rollback/unpublish, and a real authenticated publish plus rollback proof
@@ -181,7 +181,8 @@ The initial author-once hardening tranche is also materially done.
 The public baseline is also real.
 
 - npm package is live as `@orchid-labs/pluxx`
-- the repo is preparing `@orchid-labs/pluxx@0.1.28`; verify npm and the matching tag live before claiming it as the public latest release
+- the canonical repository release is `@orchid-labs/pluxx@0.1.31` with expected tag `v0.1.31`
+- proof claims now use [docs/proof-freshness.md](../proof-freshness.md) and [docs/proof-manifest.json](../proof-manifest.json) so historical host runs cannot masquerade as current evidence
 - published CLI runtime is Node `>=18`
 - published CLI lifecycle ergonomics are now stronger for global installs:
   - `pluxx --version`
@@ -467,11 +468,11 @@ Open work:
   - native bundles across the core four
   - install verification and truthful compatibility
 
-### 6. Next release
+### 6. Historical v0.1.28 release checklist
 
-Goal:
+Historical context:
 
-- complete the `0.1.28` npm release routine now that the code path plus packaged tarball pass the release gate
+- this checklist is retained as historical v0.1.28 release-prep context; it is not the current release plan
 
 Open work:
 
@@ -481,10 +482,7 @@ Open work:
 - [x] rerun the full release gate, including tarball install and `npm exec`
 - [x] bump `package.json` and `package-lock.json` from `0.1.27` to `0.1.28`
 - [x] rerun the release gate before tagging
-- [ ] merge release-prep fixes to `main`
-- [ ] push the matching `v0.1.28` tag to trigger the GitHub Actions npm publish
-- [ ] publish and verify `@orchid-labs/pluxx@0.1.28`
-- [ ] verify the npm version, GitHub release, and tarball artifact after the workflow completes
+- [x] superseded by the canonical `0.1.31` / `v0.1.31` repository release state
 
 ## Explicitly Deferred
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "eval:docs-ingestion": "tsx scripts/evaluate-docs-ingestion.ts",
     "generate:compatibility": "tsx scripts/generate-compatibility-matrix.ts",
     "pack:check": "node scripts/run-npm-pack.mjs --dry-run",
-    "release:check": "npm run build && npm run typecheck && npm test && node scripts/verify-node-package-runtime.mjs && node scripts/run-npm-pack.mjs --dry-run",
+    "proof:check": "node --import tsx scripts/check-proof-freshness.ts",
+    "proof:receipt": "node --import tsx scripts/generate-proof-receipt.ts",
+    "release:check": "npm run proof:check && npm run build && npm run typecheck && npm test && node scripts/verify-node-package-runtime.mjs && node scripts/run-npm-pack.mjs --dry-run",
     "test": "node scripts/run-vitest-exclusive.mjs",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "node scripts/ensure-github-release-publish.mjs && npm run build"

--- a/scripts/check-proof-freshness.ts
+++ b/scripts/check-proof-freshness.ts
@@ -1,0 +1,75 @@
+import { execFileSync } from 'child_process'
+import { existsSync, readFileSync } from 'fs'
+import { dirname, resolve } from 'path'
+import { fileURLToPath } from 'url'
+import {
+  findCanonicalDocProblems,
+  ProofManifestSchema,
+  validateProofManifest,
+  type ProofManifest,
+} from '../src/proof-freshness'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const packageJson = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8')) as { version: string }
+const manifestPath = resolve(root, 'docs', 'proof-manifest.json')
+const canonicalDocs = [
+  'docs/start-here.md',
+  'docs/todo/queue.md',
+  'docs/todo/master-backlog.md',
+  'docs/roadmap.md',
+  'docs/release-distribution-proof-map.md',
+  'docs/proof-and-install.md',
+  'docs/first-proof-demo-asset-pack.md',
+  'docs/proof-freshness.md',
+  'docs/pluxx-self-hosted-core-four-proof.md',
+  'docs/strategy/firecrawl-connector-docs-ingestion-proof.md',
+]
+
+function git(...args: string[]): string {
+  return execFileSync('git', args, { cwd: root, encoding: 'utf8' }).trim()
+}
+
+const parsedManifest = ProofManifestSchema.safeParse(JSON.parse(readFileSync(manifestPath, 'utf8')))
+if (!parsedManifest.success) {
+  console.error(`Proof manifest schema validation failed:\n${parsedManifest.error.message}`)
+  process.exit(1)
+}
+const manifest: ProofManifest = parsedManifest.data
+const expectedTag = `v${packageJson.version}`
+const tagExists = git('tag', '--list', expectedTag) === expectedTag
+const problems = validateProofManifest(manifest, {
+  packageVersion: packageJson.version,
+  expectedTagExists: tagExists,
+  now: new Date(),
+  isCommitReachable: (sha) => {
+    try {
+      execFileSync('git', ['merge-base', '--is-ancestor', sha, 'HEAD'], { cwd: root, stdio: 'ignore' })
+      return true
+    } catch {
+      return false
+    }
+  },
+})
+
+const documents: Record<string, string> = {}
+for (const path of canonicalDocs) {
+  const absolutePath = resolve(root, path)
+  if (!existsSync(absolutePath)) {
+    problems.push(`Canonical proof document is missing: ${path}.`)
+    continue
+  }
+  documents[path] = readFileSync(absolutePath, 'utf8')
+}
+problems.push(...findCanonicalDocProblems(documents, packageJson.version))
+
+for (const claim of manifest.claims) {
+  if (!existsSync(resolve(root, claim.evidencePath))) problems.push(`Claim ${claim.id} evidencePath does not exist: ${claim.evidencePath}.`)
+}
+
+if (problems.length > 0) {
+  console.error('Proof freshness check failed:')
+  for (const problem of problems) console.error(`- ${problem}`)
+  process.exit(1)
+}
+
+console.log(`Proof freshness check passed for ${packageJson.version}: ${manifest.claims.length} claims, ${manifest.receipts.length} receipts.`)

--- a/scripts/generate-proof-receipt.ts
+++ b/scripts/generate-proof-receipt.ts
@@ -1,0 +1,40 @@
+import { execFileSync } from 'child_process'
+import { readFileSync, writeFileSync } from 'fs'
+import { dirname, resolve } from 'path'
+import { fileURLToPath } from 'url'
+import {
+  materializeProofReceipt,
+  ProofManifestSchema,
+  ProofReceiptSpecSchema,
+  upsertProofReceipt,
+  type ProofManifest,
+  type ProofReceiptSpec,
+} from '../src/proof-freshness'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const args = process.argv.slice(2)
+const specIndex = args.indexOf('--spec')
+const manifestIndex = args.indexOf('--manifest')
+if (specIndex === -1 || !args[specIndex + 1]) {
+  console.error('Usage: npm run proof:receipt -- --spec <receipt-spec.json> [--manifest docs/proof-manifest.json]')
+  process.exit(1)
+}
+
+const specPath = resolve(root, args[specIndex + 1]!)
+const manifestPath = resolve(root, manifestIndex === -1 ? 'docs/proof-manifest.json' : args[manifestIndex + 1]!)
+const packageJson = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8')) as { version: string }
+const manifest: ProofManifest = ProofManifestSchema.parse(JSON.parse(readFileSync(manifestPath, 'utf8')))
+const spec: ProofReceiptSpec = ProofReceiptSpecSchema.parse(JSON.parse(readFileSync(specPath, 'utf8')))
+const receipt = materializeProofReceipt(spec, {
+  commitSha: execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' }).trim(),
+  packageVersion: packageJson.version,
+  timestamp: new Date().toISOString(),
+})
+
+const updated = upsertProofReceipt({
+  ...manifest,
+  canonicalVersion: packageJson.version,
+  expectedTag: `v${packageJson.version}`,
+}, receipt)
+writeFileSync(manifestPath, `${JSON.stringify(updated, null, 2)}\n`)
+console.log(`Updated ${manifestPath} with receipt ${receipt.id} (${receipt.tier}, ${receipt.freshness}).`)

--- a/src/proof-freshness.ts
+++ b/src/proof-freshness.ts
@@ -1,0 +1,210 @@
+import { z } from 'zod'
+
+export const PROOF_TIERS = [
+  'unit',
+  'bundle-contract',
+  'fake-home-install',
+  'installed-runtime',
+  'real-host-behavior',
+] as const
+
+export const ProofTierSchema = z.enum(PROOF_TIERS)
+export const ProofFreshnessSchema = z.enum(['current', 'historical'])
+export const ProofOutcomeSchema = z.enum(['passed', 'failed', 'not-run'])
+
+export const ProofCommandSchema = z.object({
+  command: z.string().min(1),
+  outcome: ProofOutcomeSchema,
+})
+
+export const ProofTargetSchema = z.object({
+  target: z.string().min(1),
+  hostVersion: z.string().min(1).nullable(),
+  installedPath: z.string().min(1).nullable(),
+  sha256: z.string().min(1).nullable(),
+  outcome: ProofOutcomeSchema,
+  unavailableReason: z.string().min(1).nullable().optional(),
+})
+
+export const ProofReceiptSchema = z.object({
+  id: z.string().min(1),
+  tier: ProofTierSchema,
+  freshness: ProofFreshnessSchema,
+  commitSha: z.string().min(1),
+  packageVersion: z.string().min(1),
+  timestamp: z.string().datetime({ offset: true }),
+  commands: z.array(ProofCommandSchema).min(1),
+  targets: z.array(ProofTargetSchema).min(1),
+})
+
+export const ProofClaimSchema = z.object({
+  id: z.string().min(1),
+  summary: z.string().min(1),
+  tier: ProofTierSchema,
+  freshness: ProofFreshnessSchema,
+  evidencePath: z.string().min(1),
+  receiptId: z.string().min(1),
+})
+
+export const ProofManifestSchema = z.object({
+  schemaVersion: z.literal(1),
+  canonicalVersion: z.string().min(1),
+  expectedTag: z.string().min(1),
+  releaseState: z.enum(['released', 'release-prep']),
+  policy: z.object({
+    environmentReceiptMaxAgeDays: z.number().int().positive(),
+  }),
+  claims: z.array(ProofClaimSchema),
+  receipts: z.array(ProofReceiptSchema),
+})
+
+export const ProofReceiptSpecSchema = ProofReceiptSchema.extend({
+  commitSha: z.string().min(1).optional(),
+  packageVersion: z.string().min(1).optional(),
+  timestamp: z.string().datetime({ offset: true }).optional(),
+})
+
+export type ProofTier = z.infer<typeof ProofTierSchema>
+export type ProofFreshness = z.infer<typeof ProofFreshnessSchema>
+export type ProofOutcome = z.infer<typeof ProofOutcomeSchema>
+export type ProofCommand = z.infer<typeof ProofCommandSchema>
+export type ProofTarget = z.infer<typeof ProofTargetSchema>
+export type ProofReceipt = z.infer<typeof ProofReceiptSchema>
+export type ProofClaim = z.infer<typeof ProofClaimSchema>
+export type ProofManifest = z.infer<typeof ProofManifestSchema>
+export type ProofReceiptSpec = z.infer<typeof ProofReceiptSpecSchema>
+
+export interface ProofValidationContext {
+  packageVersion: string
+  expectedTagExists: boolean
+  now: Date
+  isCommitReachable: (sha: string) => boolean
+}
+
+export function materializeProofReceipt(
+  spec: ProofReceiptSpec,
+  defaults: { commitSha: string; packageVersion: string; timestamp: string },
+): ProofReceipt {
+  return {
+    ...spec,
+    commitSha: spec.commitSha ?? defaults.commitSha,
+    packageVersion: spec.packageVersion ?? defaults.packageVersion,
+    timestamp: spec.timestamp ?? defaults.timestamp,
+  }
+}
+
+export function upsertProofReceipt(manifest: ProofManifest, receipt: ProofReceipt): ProofManifest {
+  const index = manifest.receipts.findIndex((candidate) => candidate.id === receipt.id)
+  const receipts = [...manifest.receipts]
+  if (index === -1) receipts.push(receipt)
+  else receipts[index] = receipt
+  return { ...manifest, receipts }
+}
+
+const ENVIRONMENT_TIERS = new Set<ProofTier>(['installed-runtime', 'real-host-behavior'])
+
+function ageInDays(timestamp: string, now: Date): number | null {
+  const observedAt = new Date(timestamp)
+  if (Number.isNaN(observedAt.getTime())) return null
+  return (now.getTime() - observedAt.getTime()) / 86_400_000
+}
+
+export function validateProofManifest(
+  manifest: ProofManifest,
+  context: ProofValidationContext,
+): string[] {
+  const problems: string[] = []
+  const expectedTag = `v${context.packageVersion}`
+
+  if (manifest.schemaVersion !== 1) problems.push(`Unsupported proof manifest schema ${String(manifest.schemaVersion)}.`)
+  if (manifest.canonicalVersion !== context.packageVersion) {
+    problems.push(`Manifest canonicalVersion is ${manifest.canonicalVersion}; expected ${context.packageVersion}.`)
+  }
+  if (manifest.expectedTag !== expectedTag) {
+    problems.push(`Manifest expectedTag is ${manifest.expectedTag}; expected ${expectedTag}.`)
+  }
+  if (context.expectedTagExists && manifest.releaseState !== 'released') {
+    problems.push(`Manifest releaseState is ${manifest.releaseState} but tag ${expectedTag} exists; use released.`)
+  }
+  if (!context.expectedTagExists && manifest.releaseState !== 'release-prep') {
+    problems.push(`Manifest releaseState is ${manifest.releaseState} but tag ${expectedTag} does not exist; use release-prep.`)
+  }
+
+  const receipts = new Map<string, ProofReceipt>()
+  for (const receipt of manifest.receipts) {
+    if (receipts.has(receipt.id)) problems.push(`Duplicate receipt id ${receipt.id}.`)
+    receipts.set(receipt.id, receipt)
+
+    if (!PROOF_TIERS.includes(receipt.tier)) problems.push(`Receipt ${receipt.id} has unknown tier ${receipt.tier}.`)
+    if (receipt.commands.length === 0) problems.push(`Receipt ${receipt.id} must name at least one command.`)
+    if (receipt.targets.length === 0) problems.push(`Receipt ${receipt.id} must name at least one target.`)
+    const receiptAge = ageInDays(receipt.timestamp, context.now)
+    if (receiptAge === null) problems.push(`Receipt ${receipt.id} has an invalid timestamp.`)
+    else if (receiptAge < -(5 / 1_440)) problems.push(`Receipt ${receipt.id} timestamp is in the future.`)
+
+    for (const target of receipt.targets) {
+      const missingEnvironmentEvidence = !target.hostVersion || !target.installedPath || !target.sha256
+      if (ENVIRONMENT_TIERS.has(receipt.tier) && receipt.freshness === 'current' && missingEnvironmentEvidence) {
+        problems.push(`Current receipt ${receipt.id} target ${target.target} must capture hostVersion, installedPath, and sha256.`)
+      } else if (ENVIRONMENT_TIERS.has(receipt.tier) && missingEnvironmentEvidence && !target.unavailableReason) {
+        problems.push(`Receipt ${receipt.id} target ${target.target} must capture hostVersion, installedPath, and sha256 or explain why they are unavailable.`)
+      }
+    }
+
+    if (receipt.freshness !== 'current') continue
+    if (receipt.packageVersion !== context.packageVersion) {
+      problems.push(`Current receipt ${receipt.id} uses package ${receipt.packageVersion}; expected ${context.packageVersion}.`)
+    }
+    if (!context.isCommitReachable(receipt.commitSha)) {
+      problems.push(`Current receipt ${receipt.id} commit ${receipt.commitSha} is not reachable from the current branch.`)
+    }
+    if (receipt.commands.some((command) => command.outcome !== 'passed')) {
+      problems.push(`Current receipt ${receipt.id} has a non-passing command outcome.`)
+    }
+    if (receipt.targets.some((target) => target.outcome !== 'passed')) {
+      problems.push(`Current receipt ${receipt.id} has a non-passing target outcome.`)
+    }
+    const age = ageInDays(receipt.timestamp, context.now)
+    if (ENVIRONMENT_TIERS.has(receipt.tier) && age !== null && age > manifest.policy.environmentReceiptMaxAgeDays) {
+      problems.push(`Current receipt ${receipt.id} is older than the ${manifest.policy.environmentReceiptMaxAgeDays}-day environment-proof window.`)
+    }
+  }
+
+  const claimIds = new Set<string>()
+  for (const claim of manifest.claims) {
+    if (claimIds.has(claim.id)) problems.push(`Duplicate claim id ${claim.id}.`)
+    claimIds.add(claim.id)
+    const receipt = receipts.get(claim.receiptId)
+    if (!receipt) {
+      problems.push(`Claim ${claim.id} references missing receipt ${claim.receiptId}.`)
+      continue
+    }
+    if (claim.tier !== receipt.tier) problems.push(`Claim ${claim.id} tier ${claim.tier} does not match receipt ${receipt.id} tier ${receipt.tier}.`)
+    if (claim.freshness !== receipt.freshness) {
+      problems.push(`Claim ${claim.id} freshness ${claim.freshness} does not match receipt ${receipt.id} freshness ${receipt.freshness}.`)
+    }
+  }
+
+  return problems
+}
+
+const VERSION_CLAIM = /(?:prepar(?:e|ing)|current|latest|released|release(?:d)?\s+package).*?v?0\.\d+\.\d+|v?0\.\d+\.\d+.*?(?:prepar(?:e|ing)|current|latest|released|release(?:d)?\s+package)/i
+
+export function findCanonicalDocProblems(
+  documents: Record<string, string>,
+  packageVersion: string,
+): string[] {
+  const problems: string[] = []
+
+  for (const [path, content] of Object.entries(documents)) {
+    content.split(/\r?\n/).forEach((line, index) => {
+      if (/\bhistorical\b/i.test(line)) return
+      const versions = line.match(/\bv?0\.\d+\.\d+\b/g) ?? []
+      if (versions.length === 0 || !VERSION_CLAIM.test(line)) return
+      const stale = versions.find((version) => version.replace(/^v/, '') !== packageVersion)
+      if (stale) problems.push(`${path}:${index + 1} makes an obsolete canonical version claim (${stale}); expected ${packageVersion} or an explicit historical label.`)
+    })
+  }
+
+  return problems
+}

--- a/tests/proof-freshness.test.ts
+++ b/tests/proof-freshness.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it } from 'bun:test'
+import { mkdtempSync, readFileSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { resolve } from 'path'
+import {
+  findCanonicalDocProblems,
+  materializeProofReceipt,
+  ProofManifestSchema,
+  ProofReceiptSpecSchema,
+  upsertProofReceipt,
+  validateProofManifest,
+  type ProofManifest,
+} from '../src/proof-freshness'
+
+const CURRENT_SHA = '561385059b8544c52ee7329063bb0574be394280'
+const ROOT = resolve(import.meta.dir, '..')
+
+function currentManifest(): ProofManifest {
+  return {
+    schemaVersion: 1,
+    canonicalVersion: '0.1.31',
+    expectedTag: 'v0.1.31',
+    releaseState: 'released',
+    policy: {
+      environmentReceiptMaxAgeDays: 30,
+    },
+    claims: [
+      {
+        id: 'release-bundle-contract',
+        summary: 'Maintained examples build across the core four.',
+        tier: 'bundle-contract',
+        freshness: 'current',
+        evidencePath: 'tests/release-smoke.test.ts',
+        receiptId: 'v0.1.31-repo-baseline',
+      },
+      {
+        id: 'may-real-host-run',
+        summary: 'Historical real-host behavior remains available for context.',
+        tier: 'real-host-behavior',
+        freshness: 'historical',
+        evidencePath: 'docs/pluxx-self-hosted-core-four-proof.md',
+        receiptId: 'v0.1.28-real-host-history',
+      },
+    ],
+    receipts: [
+      {
+        id: 'v0.1.31-repo-baseline',
+        tier: 'bundle-contract',
+        freshness: 'current',
+        commitSha: CURRENT_SHA,
+        packageVersion: '0.1.31',
+        timestamp: '2026-07-12T12:00:00.000Z',
+        commands: [{ command: 'bun test tests/release-smoke.test.ts', outcome: 'passed' }],
+        targets: [
+          {
+            target: 'core-four',
+            hostVersion: null,
+            installedPath: null,
+            sha256: null,
+            outcome: 'passed',
+            unavailableReason: 'Bundle-contract proof does not execute a real host.',
+          },
+        ],
+      },
+      {
+        id: 'v0.1.28-real-host-history',
+        tier: 'real-host-behavior',
+        freshness: 'historical',
+        commitSha: '7cbe896250cc728b6eb7328fb3fa9770022e4ef8',
+        packageVersion: '0.1.28',
+        timestamp: '2026-05-12T12:00:00.000Z',
+        commands: [{ command: 'historical host walkthrough', outcome: 'passed' }],
+        targets: [
+          {
+            target: 'codex',
+            hostVersion: null,
+            installedPath: null,
+            sha256: null,
+            outcome: 'passed',
+            unavailableReason: 'The historical walkthrough did not capture these receipt fields.',
+          },
+        ],
+      },
+    ],
+  }
+}
+
+describe('proof freshness manifest', () => {
+  it('regenerates a receipt into a manifest through the CLI', async () => {
+    const directory = mkdtempSync(resolve(tmpdir(), 'pluxx-proof-receipt-'))
+    const manifestPath = resolve(directory, 'manifest.json')
+    const specPath = resolve(directory, 'spec.json')
+    writeFileSync(manifestPath, `${JSON.stringify(currentManifest(), null, 2)}\n`)
+    writeFileSync(specPath, JSON.stringify({
+      id: 'cli-generated',
+      tier: 'bundle-contract',
+      freshness: 'current',
+      commands: [{ command: 'npm run build', outcome: 'passed' }],
+      targets: [{
+        target: 'repository',
+        hostVersion: null,
+        installedPath: null,
+        sha256: null,
+        outcome: 'passed',
+      }],
+    }))
+
+    const process = Bun.spawn([
+      'node',
+      '--import',
+      'tsx',
+      resolve(ROOT, 'scripts/generate-proof-receipt.ts'),
+      '--spec',
+      specPath,
+      '--manifest',
+      manifestPath,
+    ], { cwd: ROOT, stdout: 'pipe', stderr: 'pipe' })
+    const exitCode = await process.exited
+    expect(await new Response(process.stderr).text()).toBe('')
+    expect(exitCode).toBe(0)
+
+    const updated = ProofManifestSchema.parse(JSON.parse(readFileSync(manifestPath, 'utf8')))
+    expect(updated.receipts.find((receipt) => receipt.id === 'cli-generated')).toMatchObject({
+      packageVersion: '0.1.31',
+      tier: 'bundle-contract',
+      freshness: 'current',
+    })
+  })
+
+  it('materializes and replaces reproducible receipts from reviewable specs', () => {
+    const manifest = currentManifest()
+    const receipt = materializeProofReceipt({
+      id: 'v0.1.31-repo-baseline',
+      tier: 'unit',
+      freshness: 'current',
+      commands: [{ command: 'npm test', outcome: 'passed' }],
+      targets: [{
+        target: 'repository',
+        hostVersion: null,
+        installedPath: null,
+        sha256: null,
+        outcome: 'passed',
+      }],
+    }, {
+      commitSha: CURRENT_SHA,
+      packageVersion: '0.1.31',
+      timestamp: '2026-07-12T12:00:00.000Z',
+    })
+
+    const updated = upsertProofReceipt(manifest, receipt)
+    expect(updated.receipts).toHaveLength(2)
+    expect(updated.receipts[0]).toEqual(receipt)
+  })
+
+  it('accepts version-aligned reproducible proof and explicitly historical host proof', () => {
+    const problems = validateProofManifest(currentManifest(), {
+      packageVersion: '0.1.31',
+      expectedTagExists: true,
+      now: new Date('2026-07-12T13:00:00.000Z'),
+      isCommitReachable: () => true,
+    })
+
+    expect(problems).toEqual([])
+  })
+
+  it('rejects current claims backed by a stale package version', () => {
+    const manifest = currentManifest()
+    manifest.receipts[0]!.packageVersion = '0.1.28'
+
+    expect(validateProofManifest(manifest, {
+      packageVersion: '0.1.31',
+      expectedTagExists: true,
+      now: new Date('2026-07-12T13:00:00.000Z'),
+      isCommitReachable: () => true,
+    })).toContain('Current receipt v0.1.31-repo-baseline uses package 0.1.28; expected 0.1.31.')
+  })
+
+  it('expires installed-runtime and real-host receipts after 30 days', () => {
+    const manifest = currentManifest()
+    manifest.claims[0]!.tier = 'installed-runtime'
+    manifest.receipts[0]!.tier = 'installed-runtime'
+    manifest.receipts[0]!.timestamp = '2026-06-01T12:00:00.000Z'
+
+    expect(validateProofManifest(manifest, {
+      packageVersion: '0.1.31',
+      expectedTagExists: true,
+      now: new Date('2026-07-12T13:00:00.000Z'),
+      isCommitReachable: () => true,
+    })).toContain('Current receipt v0.1.31-repo-baseline is older than the 30-day environment-proof window.')
+  })
+
+  it('requires real-host receipts to capture host, install, and hash evidence or explain absence', () => {
+    const manifest = currentManifest()
+    const target = manifest.receipts[1]!.targets[0]!
+    target.unavailableReason = null
+
+    expect(validateProofManifest(manifest, {
+      packageVersion: '0.1.31',
+      expectedTagExists: true,
+      now: new Date('2026-07-12T13:00:00.000Z'),
+      isCommitReachable: () => true,
+    })).toContain('Receipt v0.1.28-real-host-history target codex must capture hostVersion, installedPath, and sha256 or explain why they are unavailable.')
+  })
+
+  it('does not let current environment proof replace evidence with an explanation', () => {
+    const manifest = currentManifest()
+    manifest.claims[0]!.tier = 'real-host-behavior'
+    manifest.receipts[0]!.tier = 'real-host-behavior'
+    manifest.receipts[0]!.targets[0]!.unavailableReason = 'Host details were not captured.'
+
+    expect(validateProofManifest(manifest, {
+      packageVersion: '0.1.31',
+      expectedTagExists: true,
+      now: new Date('2026-07-12T13:00:00.000Z'),
+      isCommitReachable: () => true,
+    })).toContain('Current receipt v0.1.31-repo-baseline target core-four must capture hostVersion, installedPath, and sha256.')
+  })
+
+  it('rejects current claims backed by failed or not-run outcomes', () => {
+    const manifest = currentManifest()
+    manifest.receipts[0]!.commands[0]!.outcome = 'failed'
+    manifest.receipts[0]!.targets[0]!.outcome = 'not-run'
+
+    const problems = validateProofManifest(manifest, {
+      packageVersion: '0.1.31',
+      expectedTagExists: true,
+      now: new Date('2026-07-12T13:00:00.000Z'),
+      isCommitReachable: () => true,
+    })
+    expect(problems).toContain('Current receipt v0.1.31-repo-baseline has a non-passing command outcome.')
+    expect(problems).toContain('Current receipt v0.1.31-repo-baseline has a non-passing target outcome.')
+  })
+
+  it('rejects current receipts from unreachable commits or future timestamps', () => {
+    const manifest = currentManifest()
+    manifest.receipts[0]!.timestamp = '2026-07-13T13:00:00.000Z'
+
+    const problems = validateProofManifest(manifest, {
+      packageVersion: '0.1.31',
+      expectedTagExists: true,
+      now: new Date('2026-07-12T13:00:00.000Z'),
+      isCommitReachable: () => false,
+    })
+    expect(problems).toContain(`Current receipt v0.1.31-repo-baseline commit ${CURRENT_SHA} is not reachable from the current branch.`)
+    expect(problems).toContain('Receipt v0.1.31-repo-baseline timestamp is in the future.')
+  })
+
+  it('rejects misspelled freshness, outcomes, and malformed arrays at JSON boundaries', () => {
+    expect(ProofManifestSchema.safeParse({ ...currentManifest(), claims: {} }).success).toBe(false)
+    expect(ProofManifestSchema.safeParse({
+      ...currentManifest(),
+      receipts: [{ ...currentManifest().receipts[0], freshness: 'stale' }],
+    }).success).toBe(false)
+    expect(ProofReceiptSpecSchema.safeParse({
+      id: 'bad',
+      tier: 'unit',
+      freshness: 'current',
+      commands: [{ command: 'npm test', outcome: 'green' }],
+      targets: [],
+    }).success).toBe(false)
+  })
+
+  it('requires released and release-prep state to match tag availability', () => {
+    const manifest = currentManifest()
+    expect(validateProofManifest(manifest, {
+      packageVersion: '0.1.31',
+      expectedTagExists: false,
+      now: new Date('2026-07-12T13:00:00.000Z'),
+      isCommitReachable: () => true,
+    })).toContain('Manifest releaseState is released but tag v0.1.31 does not exist; use release-prep.')
+  })
+})
+
+describe('canonical proof/version docs', () => {
+  it('rejects obsolete release-prep and current-version claims', () => {
+    const problems = findCanonicalDocProblems({
+      'docs/todo/queue.md': 'The repo is preparing @orchid-labs/pluxx@0.1.28.',
+      'docs/proof-and-install.md': 'The current released package is v0.1.28.',
+    }, '0.1.31')
+
+    expect(problems).toHaveLength(2)
+    expect(problems[0]).toContain('docs/todo/queue.md:1')
+    expect(problems[1]).toContain('docs/proof-and-install.md:1')
+  })
+
+  it('allows old versions when the line is explicitly historical', () => {
+    expect(findCanonicalDocProblems({
+      'docs/pluxx-self-hosted-core-four-proof.md': 'Historical proof: v0.1.28 observed on 2026-05-12.',
+    }, '0.1.31')).toEqual([])
+  })
+})

--- a/tests/release-smoke.test.ts
+++ b/tests/release-smoke.test.ts
@@ -181,9 +181,9 @@ async function runCliJsonWithEnv<T>(cwd: string, env: Record<string, string>, ..
   return JSON.parse(stdout) as T
 }
 
-describe('release smoke', () => {
+describe('bundle contract and isolated fake-home install proof', () => {
   for (const projectPath of RELEASE_SMOKE_PROJECTS) {
-    it(`validates ${projectPath} across the core four with the real CLI`, async () => {
+    it(`validates ${projectPath} bundles and installed files across the core four`, async () => {
       const cwd = resolve(ROOT, projectPath)
       const isolatedHome = resolve(
         tmpdir(),

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -4,6 +4,7 @@ import { resolve } from 'path'
 
 const ROOT = resolve(import.meta.dir, '..')
 const releaseWorkflow = readFileSync(resolve(ROOT, '.github/workflows/release.yml'), 'utf-8')
+const ciWorkflow = readFileSync(resolve(ROOT, '.github/workflows/ci.yml'), 'utf-8')
 
 describe('release workflow', () => {
   it('uses GitHub Actions runtime versions that avoid the Node 20 deprecation path', () => {
@@ -12,5 +13,11 @@ describe('release workflow', () => {
     expect(releaseWorkflow).toMatch(/node-version:\s+24/)
     expect(releaseWorkflow).toMatch(/uses:\s+softprops\/action-gh-release@v3/)
     expect(releaseWorkflow).not.toMatch(/uses:\s+softprops\/action-gh-release@v2/)
+  })
+
+  it('blocks CI when canonical proof versions or receipts are stale', () => {
+    expect(ciWorkflow).toContain('name: Check proof freshness')
+    expect(ciWorkflow).toContain('run: npm run proof:check')
+    expect(ciWorkflow).toMatch(/uses:\s+actions\/checkout@v5\n\s+with:\n\s+fetch-depth:\s+0/)
   })
 })


### PR DESCRIPTION
## Summary

- add a machine-readable proof manifest, receipt generator, and runtime schemas
- enforce package/tag agreement, tier-specific freshness, passed outcomes, and current host evidence in CI
- distinguish unit, bundle-contract, fake-home install, installed-runtime, and real-host behavior proof
- reframe release smoke as bundle-contract plus isolated fake-home evidence
- mark April/May host proof historical and align canonical planning/public proof docs

## Validation

- `npm run proof:check`
- `npm run generate:compatibility`
- `npm run typecheck`
- `npm run build`
- `bun test tests/release-smoke.test.ts` — 10/10
- `npm test` — 598/598
- `npm run pack:check`

## Review

CE doc review and full code review completed. All actionable correctness, testing, maintainability, standards, and agent-discoverability findings were fixed and independently revalidated.

Residual: the unchanged development lockfile has existing Vitest/Vite/esbuild advisories; this PR adds no dependency changes.

Linear: [PLUXX-321](https://linear.app/orchid-automation/issue/PLUXX-321/add-proof-freshness-manifests-and-canonical-version-governance)

Closes #411
