### PR TITLE
fix: make MCP replay tapes safe and deterministic

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,11 @@ Need deterministic MCP replay?
   pluxx mcp proxy --from-mcp <source> --record tape.json
   pluxx mcp proxy --replay tape.json
 
+  Recordings use a versioned schema and recursively redact common credential
+  keys plus source and URL credentials by default. Raw recording is not
+  supported. Review tapes before sharing because arbitrary private tool
+  content may not look like a credential.
+
 Need to refresh from the MCP later?
   pluxx sync
 ```
@@ -206,7 +211,7 @@ Pluxx includes more than scaffold generation:
 - `pluxx eval` checks scaffold and prompt-pack quality
 - `pluxx migrate <path>` imports an existing host-native plugin into a Pluxx project
 - `pluxx doctor --consumer <bundle>` inspects built or installed plugin bundles from the user side
-- `pluxx mcp proxy --record` and `--replay` give you deterministic MCP tapes for debugging and CI
+- `pluxx mcp proxy --record` and `--replay` give you strictly validated, default-redacted deterministic MCP tapes for debugging and CI
 
 ## Authoring Model
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Last updated: 2026-06-27
+Last updated: 2026-07-12
 
 ## Doc Links
 
@@ -186,6 +186,9 @@ The closure plan is now narrower than it was before:
 - local full-suite proof is now also more explicit operationally:
   - `npm test` now acquires a same-worktree suite lock and fails fast instead of creating misleading cross-test flakes when multiple full proof jobs hit the same repo-local fixture paths
   - the follow-on is deeper fixture isolation so more proof paths can run independently without sharing cwd or repo-local temp state
+- local MCP proof is now safer and more deterministic:
+  - new recordings use a versioned schema and default recursive credential redaction before persistence
+  - replay strictly validates tapes, does not consume an expectation on mismatch, reports unused interactions, and supports valid schema-v1 tapes
 - installed consumer-bundle integrity is stricter:
   - generated-shape Claude bundles now fail `doctor --consumer` and `verify-install` when `hooks/hooks.json` is malformed or points at missing bundle-owned targets, even though the Claude manifest omits `hooks`
   - Claude bundles now also fail `doctor --consumer` and `verify-install` when the manifest redundantly points `hooks` at the standard `./hooks/hooks.json` file that current Claude auto-loads anyway

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -1,6 +1,6 @@
 # Start Here
 
-Last updated: 2026-06-27
+Last updated: 2026-07-12
 
 ## Doc Links
 
@@ -167,6 +167,7 @@ The repo already proves a lot.
 - `verify-install` exists and is tested
 - consumer-side `doctor --consumer` exists and is tested
 - `migrate`, `eval`, and `mcp proxy --record/--replay` are shipped
+  - new MCP recordings use a strictly validated schema-v2 tape with default recursive credential redaction; replay remains compatible with valid schema-v1 tapes, preserves expected entries after mismatches, and fails on malformed or incomplete runs
 - `pluxx publish --github-release` can package built primary-front bundles as GitHub Release assets and generate installer scripts, including the `install.sh --agents` front door plus per-host installers; `pluxx publish --npm` covers the npm-backed OpenCode wrapper path:
   - `docs/release-distribution-proof-map.md`
 - the self-hosted Pluxx plugin exists as a real source project in `example/pluxx`

--- a/docs/todo/master-backlog.md
+++ b/docs/todo/master-backlog.md
@@ -1,6 +1,6 @@
 # Master Backlog
 
-Last updated: 2026-06-27
+Last updated: 2026-07-12
 
 This is the most complete repo-native backlog for Pluxx.
 
@@ -162,6 +162,10 @@ Any person or agent should be able to enter the repo and answer:
   - `npm test` now fails fast when another full-suite run is already active in the same worktree
   - the follow-on work is removing more repo-local shared fixture and cwd assumptions so worktree-local serialization is no longer carrying as much reliability weight
   - the current worktree release gate is green again with a passing `npm test`, package runtime verification, dry-run pack, and `npm run release:check` as of 2026-05-17
+- [x] Harden local MCP record/replay tapes as a safe deterministic proof surface:
+  - schema-v2 recordings recursively redact common sensitive keys plus source, URL, and recognized credential values before persistence
+  - strict validation rejects malformed/incomplete tapes and unsupported schemas with explicit migration guidance
+  - replay preserves expected interactions after mismatches, reports unused entries, and remains compatible with valid schema-v1 tapes
 - [x] Use [author-once-hardening.md](./author-once-hardening.md) as the initiative-level TODO for closing the main author-once gap between:
   - the author-once vision
   - the currently shipped compiler, proof, and onboarding reality

--- a/docs/todo/queue.md
+++ b/docs/todo/queue.md
@@ -1,6 +1,6 @@
 # Pluxx Queue
 
-Last updated: 2026-06-27
+Last updated: 2026-07-12
 
 ## Doc Links
 
@@ -189,6 +189,7 @@ The public baseline is also real.
 - docs site is live
 - Mintlify docs reflect the core compiler story more honestly
 - `migrate`, `eval`, `doctor --consumer`, and `mcp proxy --record/--replay` are shipped
+  - MCP record/replay now writes schema-v2 tapes with default recursive credential redaction, strictly validates replay input, keeps mismatched expectations recoverable, reports unused interactions, and retains valid schema-v1 replay compatibility
 - the self-hosted Pluxx plugin exists:
   - canonical source project: `example/pluxx`
   - repo-local Codex dogfood surface: `plugins/pluxx`

--- a/example/pluxx/INSTRUCTIONS.md
+++ b/example/pluxx/INSTRUCTIONS.md
@@ -153,6 +153,7 @@ If the user wants the smoother reusable path, help them bootstrap or upgrade the
 
 - Prefer a deterministic first pass before semantic rewrites.
 - When importing, call out auth shape clearly: none, bearer, custom header, or platform-managed runtime auth.
+- When recording MCP replay tapes, explain that default redaction covers recognized credentials rather than arbitrary private tool content; review every tape before committing or sharing it.
 - When refining a scaffold, preserve mixed-ownership boundaries and custom-note blocks.
 - Do not silently rewrite auth wiring, target configuration, or generated platform outputs unless the user explicitly asks.
 - Before shipping, run `pluxx doctor`, `pluxx lint`, and `pluxx test`.

--- a/plugins/pluxx/AGENTS.md
+++ b/plugins/pluxx/AGENTS.md
@@ -153,6 +153,7 @@ If the user wants the smoother reusable path, help them bootstrap or upgrade the
 
 - Prefer a deterministic first pass before semantic rewrites.
 - When importing, call out auth shape clearly: none, bearer, custom header, or platform-managed runtime auth.
+- When recording MCP replay tapes, explain that default redaction covers recognized credentials rather than arbitrary private tool content; review every tape before committing or sharing it.
 - When refining a scaffold, preserve mixed-ownership boundaries and custom-note blocks.
 - Do not silently rewrite auth wiring, target configuration, or generated platform outputs unless the user explicitly asks.
 - Before shipping, run `pluxx doctor`, `pluxx lint`, and `pluxx test`.

--- a/site/docs.json
+++ b/site/docs.json
@@ -68,7 +68,8 @@
           "reference/pluxx-config",
           "reference/auth-runtime-auth",
           "reference/hooks-commands-agents",
-          "reference/validation-and-size-limits"
+          "reference/validation-and-size-limits",
+          "reference/privacy-policy"
         ]
       }
     ]

--- a/site/reference/cli-reference.mdx
+++ b/site/reference/cli-reference.mdx
@@ -234,7 +234,9 @@ npx @orchid-labs/pluxx migrate ./existing-plugin
 
 ### `pluxx mcp proxy --from-mcp ... [--record ...]`
 
-Run a local stdio proxy in front of a live MCP. With `--record`, save a deterministic tape.
+Run a local stdio proxy in front of a live MCP. With `--record`, save a deterministic schema-v2 tape. Pluxx recursively redacts common sensitive keys, URL userinfo and sensitive query values, source-command credentials, and recognized authorization values before writing the file. Raw recording is not supported.
+
+**Privacy warning:** redaction is a credential-safety boundary, not a general content classifier. Tool results can contain private documents or customer data under ordinary field names. Review every tape before committing, uploading, or sharing it.
 
 ```bash
 npx @orchid-labs/pluxx mcp proxy \
@@ -245,6 +247,8 @@ npx @orchid-labs/pluxx mcp proxy \
 ### `pluxx mcp proxy --replay <tape.json>`
 
 Replay a recorded MCP session without hitting the live server again.
+
+Replay accepts existing schema-v1 tapes and current schema-v2 tapes, validates their structure strictly, preserves the expected interaction after a mismatch, and fails when the input ends with unused interactions. Unsupported schema versions return an explicit migration error.
 
 User story:
 

--- a/site/reference/privacy-policy.mdx
+++ b/site/reference/privacy-policy.mdx
@@ -26,6 +26,19 @@ However, some workflows may involve:
 
 Those systems have their own privacy and retention policies.
 
+## MCP record/replay tapes
+
+`pluxx mcp proxy --record` writes local replay tapes for debugging and CI. Current recordings use a versioned schema and apply Pluxx's default recursive credential-redaction policy before the file is written. The policy covers common sensitive keys, authorization values, URL credentials and sensitive query parameters, and source-command credential flags. Pluxx does not provide a raw-recording mode.
+
+Redaction does not determine whether arbitrary tool content is private. A tool result may contain customer records, private documents, personal data, or confidential text under an ordinary field name. Treat every tape as potentially sensitive:
+
+- use synthetic values in tests and examples
+- review the serialized tape before committing or sharing it
+- keep tapes out of public repositories unless their contents are intentionally publishable
+- delete local tapes when they are no longer needed
+
+Replay reads the local tape you select. It does not upload the tape to a Pluxx-operated service.
+
 ## User responsibility
 
 You are responsible for reviewing:
@@ -34,6 +47,7 @@ You are responsible for reviewing:
 - the host agents and models you invoke
 - any credentials or environment variables you provide
 - any third-party services you use alongside Pluxx
+- any MCP replay tapes you retain, commit, upload, or share
 
 ## Contact
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3511,7 +3511,7 @@ Usage:
   pluxx agent run <kind> --runner <id>    Execute a prompt pack via Claude, Cursor, Codex, or OpenCode headlessly
   pluxx codex apply --consumer <path>     Register custom agents and merge generated Codex companion prerequisites
   pluxx discover-mcp [--host <hosts...>] List installed MCP servers from local host configs
-  pluxx mcp proxy ...                     Run a local MCP proxy with optional record/replay tapes
+  pluxx mcp proxy ...                     Run a local MCP proxy with redacted, versioned record/replay tapes
   pluxx autopilot --from-mcp ...          Run import + agent refinement + verification in one command
   pluxx init [name] [--from-mcp <source>|--from-installed-mcp <selector>] Create a new pluxx.config.ts
   pluxx sync [--from-mcp <source>]        Refresh MCP-derived scaffold files

--- a/src/cli/mcp-proxy.ts
+++ b/src/cli/mcp-proxy.ts
@@ -1,27 +1,55 @@
 import { mkdirSync, readFileSync } from 'fs'
+import { rename, rm, writeFile } from 'fs/promises'
+import { randomUUID } from 'crypto'
 import { dirname, resolve } from 'path'
 import * as readline from 'readline'
 import type { Readable, Writable } from 'stream'
 import { createMcpClient, McpIntrospectionError, type McpClient } from '../mcp/introspect'
 import { parseMcpSourceInput } from './init-from-mcp'
-import { writeTextFile } from '../text-files'
 
-interface ProxyTapeInteraction {
-  kind: 'request' | 'notify'
+interface ProxyTapeNotification {
+  kind: 'notify'
   method: string
   params?: Record<string, unknown>
-  result?: unknown
-  error?: {
+}
+
+interface ProxyTapeSuccessfulRequest {
+  kind: 'request'
+  method: string
+  params?: Record<string, unknown>
+  result: unknown
+}
+
+interface ProxyTapeFailedRequest {
+  kind: 'request'
+  method: string
+  params?: Record<string, unknown>
+  error: {
     code: number
     message: string
   }
 }
 
-interface ProxyTape {
+type ProxyTapeInteraction = ProxyTapeNotification | ProxyTapeSuccessfulRequest | ProxyTapeFailedRequest
+
+interface ProxyTapeV1 {
   version: 1
   source?: string
   interactions: ProxyTapeInteraction[]
 }
+
+interface ProxyTapeV2 {
+  version: 2
+  redaction: {
+    policy: 'pluxx-default'
+    version: 1
+    marker: typeof REDACTION_MARKER
+  }
+  source?: string
+  interactions: ProxyTapeInteraction[]
+}
+
+type ProxyTape = ProxyTapeV1 | ProxyTapeV2
 
 interface McpProxyOptions {
   source?: string
@@ -35,14 +63,35 @@ interface ProxyIo {
   error: Writable
 }
 
+const REDACTION_MARKER = '[REDACTED]'
+const TAPE_SCHEMA_VERSION = 2
+const REDACTION_POLICY_VERSION = 1
+const SENSITIVE_KEY_PATTERN = /(?:^|[^a-z])(auth(?:orization)?|api[-_ ]?key|bearer|client[-_ ]?secret|cookie|credential|password|passwd|private[-_ ]?key|refresh[-_ ]?token|secret|session[-_ ]?id|token)(?:$|[^a-z])/i
+const SENSITIVE_COMPACT_KEYS = new Set([
+  'apikey',
+  'auth',
+  'authorization',
+  'clientsecret',
+  'cookie',
+  'credentials',
+  'password',
+  'passwd',
+  'privatekey',
+  'refreshtoken',
+  'secret',
+  'sessionid',
+  'token',
+])
+
 function usage(): string {
   return [
     'Usage: pluxx mcp proxy --from-mcp <source> [--record <tape.json>]',
     '       pluxx mcp proxy --replay <tape.json>',
     '',
     'Acts as a local stdio MCP proxy for development and CI.',
-    '- --record stores normalized request/response interactions as a replay tape.',
-    '- --replay serves a deterministic stdio MCP session from a recorded tape.',
+    '- --record stores a schema-versioned replay tape with default recursive credential redaction.',
+    '- Raw recording is not supported; review tapes before sharing because arbitrary private content may remain.',
+    '- --replay validates the tape strictly and serves a deterministic stdio MCP session.',
   ].join('\n')
 }
 
@@ -82,6 +131,276 @@ function parseOptions(rawArgs: string[]): McpProxyOptions {
   }
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function assertOnlyKeys(value: Record<string, unknown>, allowed: string[], path: string): void {
+  const unexpected = Object.keys(value).filter((key) => !allowed.includes(key))
+  if (unexpected.length > 0) {
+    throw new Error(`${path} contains unsupported field ${JSON.stringify(unexpected[0])}.`)
+  }
+}
+
+function validateInteraction(value: unknown, index: number): ProxyTapeInteraction {
+  const path = `interactions[${index}]`
+  if (!isRecord(value)) throw new Error(`${path} must be an object.`)
+  assertOnlyKeys(value, ['kind', 'method', 'params', 'result', 'error'], path)
+
+  if (value.kind !== 'request' && value.kind !== 'notify') {
+    throw new Error(`${path}.kind must be "request" or "notify".`)
+  }
+  if (typeof value.method !== 'string' || value.method.length === 0) {
+    throw new Error(`${path}.method must be a non-empty string.`)
+  }
+  if (Object.hasOwn(value, 'params') && !isRecord(value.params)) {
+    throw new Error(`${path}.params must be an object when present.`)
+  }
+
+  const hasResult = Object.hasOwn(value, 'result')
+  const hasError = Object.hasOwn(value, 'error')
+  if (value.kind === 'notify') {
+    if (hasResult || hasError) {
+      throw new Error(`${path} notification cannot contain result or error.`)
+    }
+  } else if (hasResult === hasError) {
+    throw new Error(`${path} request must contain exactly one of result or error.`)
+  }
+
+  if (hasError) {
+    if (!isRecord(value.error)) throw new Error(`${path}.error must be an object.`)
+    assertOnlyKeys(value.error, ['code', 'message'], `${path}.error`)
+    if (!Number.isInteger(value.error.code)) {
+      throw new Error(`${path}.error.code must be an integer.`)
+    }
+    if (typeof value.error.message !== 'string') {
+      throw new Error(`${path}.error.message must be a string.`)
+    }
+  }
+
+  const common = {
+    method: value.method,
+    ...(isRecord(value.params) ? { params: value.params } : {}),
+  }
+  if (value.kind === 'notify') return { kind: 'notify', ...common }
+  if (hasError) {
+    const error = value.error as { code: number; message: string }
+    return { kind: 'request', ...common, error }
+  }
+  return { kind: 'request', ...common, result: value.result }
+}
+
+function validateReplayTape(value: unknown, filepath: string): ProxyTape {
+  if (!isRecord(value)) {
+    throw new Error(`Replay tape must contain a JSON object: ${filepath}`)
+  }
+  if (value.version !== 1 && value.version !== 2) {
+    const shownVersion = Object.hasOwn(value, 'version') ? String(value.version) : 'missing'
+    throw new Error(
+      `Unsupported MCP replay tape schema version ${shownVersion}. `
+      + 'Pluxx supports schema versions 1 and 2; recreate or migrate this tape.',
+    )
+  }
+
+  const allowedTapeKeys = value.version === 2
+    ? ['version', 'redaction', 'source', 'interactions']
+    : ['version', 'source', 'interactions']
+  assertOnlyKeys(value, allowedTapeKeys, 'Replay tape')
+  if (Object.hasOwn(value, 'source') && typeof value.source !== 'string') {
+    throw new Error('Replay tape source must be a string when present.')
+  }
+  if (!Array.isArray(value.interactions)) {
+    throw new Error('Replay tape interactions must be an array.')
+  }
+
+  if (value.version === 2) {
+    if (!isRecord(value.redaction)) {
+      throw new Error('Replay tape schema version 2 requires redaction metadata.')
+    }
+    assertOnlyKeys(value.redaction, ['policy', 'version', 'marker'], 'Replay tape redaction')
+    if (
+      value.redaction.policy !== 'pluxx-default'
+      || value.redaction.version !== REDACTION_POLICY_VERSION
+      || value.redaction.marker !== REDACTION_MARKER
+    ) {
+      throw new Error(
+        'Replay tape redaction metadata is unsupported; expected pluxx-default policy version 1.',
+      )
+    }
+  }
+
+  return {
+    ...value,
+    interactions: value.interactions.map((entry, index) => validateInteraction(entry, index)),
+  } as unknown as ProxyTape
+}
+
+function isSensitiveKey(key: string): boolean {
+  const compact = key.toLowerCase().replace(/[^a-z0-9]/g, '')
+  const words = key
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean)
+  const wordSet = new Set(words)
+  return SENSITIVE_COMPACT_KEYS.has(compact)
+    || wordSet.has('auth')
+    || wordSet.has('authentication')
+    || wordSet.has('authorization')
+    || wordSet.has('cookie')
+    || wordSet.has('credential')
+    || wordSet.has('credentials')
+    || wordSet.has('password')
+    || wordSet.has('passwd')
+    || wordSet.has('secret')
+    || wordSet.has('token')
+    || (wordSet.has('api') && wordSet.has('key'))
+    || (wordSet.has('access') && wordSet.has('key'))
+    || (wordSet.has('private') && wordSet.has('key'))
+    || (wordSet.has('session') && wordSet.has('id'))
+    || compact.endsWith('apikey')
+    || compact.endsWith('password')
+    || compact.endsWith('privatekey')
+    || compact.endsWith('secret')
+    || compact.endsWith('sessionid')
+    || compact.endsWith('token')
+    || SENSITIVE_KEY_PATTERN.test(key)
+}
+
+function collectSensitiveValues(value: unknown, output: Set<string>, parentKey?: string): void {
+  if (parentKey && isSensitiveKey(parentKey)) {
+    if (typeof value === 'string' && value.length >= 4) output.add(value)
+    if (typeof value === 'number' || typeof value === 'bigint') output.add(String(value))
+  }
+
+  if (Array.isArray(value)) {
+    for (const entry of value) collectSensitiveValues(entry, output, parentKey)
+    return
+  }
+  if (!isRecord(value)) return
+  for (const [key, nested] of Object.entries(value)) collectSensitiveValues(nested, output, key)
+}
+
+function redactUrl(rawUrl: string): string {
+  try {
+    const url = new URL(rawUrl)
+    let changed = false
+    if (url.username) {
+      url.username = REDACTION_MARKER
+      changed = true
+    }
+    if (url.password) {
+      url.password = REDACTION_MARKER
+      changed = true
+    }
+    for (const key of [...url.searchParams.keys()]) {
+      if (isSensitiveKey(key)) {
+        url.searchParams.set(key, REDACTION_MARKER)
+        changed = true
+      }
+    }
+    return changed ? url.toString() : rawUrl
+  } catch {
+    return rawUrl
+  }
+}
+
+interface RedactionContext {
+  sensitiveValues: Set<string>
+  orderedSensitiveValues: string[]
+}
+
+function buildRedactionContext(sensitiveValues: Set<string>): RedactionContext {
+  return {
+    sensitiveValues,
+    orderedSensitiveValues: [...sensitiveValues]
+      .filter((entry) => entry.length >= 4 && entry !== REDACTION_MARKER)
+      .sort((left, right) => right.length - left.length),
+  }
+}
+
+function redactString(value: string, context: RedactionContext): string {
+  const trimmed = value.trim()
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+    try {
+      const parsed = JSON.parse(trimmed) as unknown
+      if (typeof parsed === 'object' && parsed !== null) {
+        const embeddedSensitiveValues = new Set(context.sensitiveValues)
+        collectSensitiveValues(parsed, embeddedSensitiveValues)
+        const serializedBeforeRedaction = JSON.stringify(parsed)
+        const redactedValue = redactValue(parsed, buildRedactionContext(embeddedSensitiveValues))
+        const serializedAfterRedaction = JSON.stringify(redactedValue)
+        return serializedAfterRedaction === serializedBeforeRedaction ? value : serializedAfterRedaction
+      }
+    } catch {
+      // Not every source string beginning with a brace is intended to be JSON.
+    }
+  }
+
+  let redacted = value
+  for (const sensitiveValue of context.orderedSensitiveValues) {
+    redacted = redacted.replaceAll(sensitiveValue, REDACTION_MARKER)
+  }
+
+  redacted = redacted.replace(
+    /\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]+/gi,
+    `$1 ${REDACTION_MARKER}`,
+  )
+  redacted = redacted.replace(
+    /(["']?authorization["']?\s*[:=]\s*["']?)(?:Bearer|Basic)?\s*[^\s,"';]+/gi,
+    `$1${REDACTION_MARKER}`,
+  )
+  redacted = redacted.replace(
+    /((?:--header|-H)(?:=|\s+))(["'])([A-Za-z0-9_-]+)\s*:\s*([\s\S]*?)\2/g,
+    (whole, prefix: string, quote: string, headerName: string) => isSensitiveKey(headerName)
+      ? `${prefix}${quote}${headerName}: ${REDACTION_MARKER}${quote}`
+      : whole,
+  )
+  redacted = redacted.replace(
+    /((?:--header|-H)(?:=|\s+))([A-Za-z0-9_-]+)\s*:\s*([^\s]+)/g,
+    (whole, prefix: string, headerName: string) => isSensitiveKey(headerName)
+      ? `${prefix}${headerName}: ${REDACTION_MARKER}`
+      : whole,
+  )
+  redacted = redacted.replace(
+    /(^|\s)([A-Za-z_][A-Za-z0-9_]*)=(?:"[^"]*"|'[^']*'|[^\s]+)/g,
+    (whole, prefix: string, variableName: string) => isSensitiveKey(variableName)
+      ? `${prefix}${variableName}=${REDACTION_MARKER}`
+      : whole,
+  )
+  redacted = redacted.replace(
+    /(--[A-Za-z][A-Za-z0-9_-]*)(=|\s+)(?:"[^"]*"|'[^']*'|[^\s]+)/g,
+    (whole, flag: string, separator: string) => isSensitiveKey(flag.slice(2))
+      ? `${flag}${separator}${REDACTION_MARKER}`
+      : whole,
+  )
+  redacted = redacted.replace(/https?:\/\/[^\s"'<>]+/gi, (url) => redactUrl(url))
+  return redacted
+}
+
+function redactValue(value: unknown, context: RedactionContext, parentKey?: string): unknown {
+  if (parentKey && isSensitiveKey(parentKey)) return REDACTION_MARKER
+  if (typeof value === 'string') return redactString(value, context)
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index += 1) {
+      value[index] = redactValue(value[index], context)
+    }
+    return value
+  }
+  if (!isRecord(value)) return value
+
+  for (const [key, nested] of Object.entries(value)) {
+    value[key] = redactValue(nested, context, key)
+  }
+  return value
+}
+
+function redactRecordedTape(tape: ProxyTapeV2): ProxyTapeV2 {
+  const sensitiveValues = new Set<string>()
+  collectSensitiveValues(tape, sensitiveValues)
+  return redactValue(tape, buildRedactionContext(sensitiveValues)) as ProxyTapeV2
+}
+
 function stableStringify(value: unknown): string {
   if (value === null || typeof value !== 'object') {
     return JSON.stringify(value)
@@ -97,10 +416,48 @@ function stableStringify(value: unknown): string {
   return `{${entries.join(',')}}`
 }
 
+function matchesRedactedString(expected: string, actual: string): boolean {
+  const segments = expected.split(REDACTION_MARKER)
+  if (segments.length === 1) return expected === actual
+  if (!actual.startsWith(segments[0]!)) return false
+
+  let cursor = segments[0]!.length
+  for (let index = 1; index < segments.length - 1; index += 1) {
+    const segment = segments[index]!
+    const segmentIndex = actual.indexOf(segment, cursor)
+    if (segmentIndex === -1) return false
+    cursor = segmentIndex + segment.length
+  }
+  return actual.slice(cursor).endsWith(segments.at(-1)!)
+}
+
+function matchesRedactedValue(expected: unknown, actual: unknown): boolean {
+  if (expected === REDACTION_MARKER) return true
+  if (typeof expected === 'string' && typeof actual === 'string') {
+    return matchesRedactedString(expected, actual)
+  }
+  if (Array.isArray(expected)) {
+    return Array.isArray(actual)
+      && expected.length === actual.length
+      && expected.every((entry, index) => matchesRedactedValue(entry, actual[index]))
+  }
+  if (isRecord(expected)) {
+    if (!isRecord(actual)) return false
+    const expectedKeys = Object.keys(expected).sort()
+    const actualKeys = Object.keys(actual).sort()
+    return expectedKeys.length === actualKeys.length
+      && expectedKeys.every((key, index) => key === actualKeys[index])
+      && expectedKeys.every((key) => matchesRedactedValue(expected[key], actual[key]))
+  }
+  return Object.is(expected, actual)
+}
+
 function sameParams(
   left: Record<string, unknown> | undefined,
   right: Record<string, unknown> | undefined,
+  redacted = false,
 ): boolean {
+  if (redacted) return matchesRedactedValue(left ?? null, right ?? null)
   return stableStringify(left ?? null) === stableStringify(right ?? null)
 }
 
@@ -121,17 +478,29 @@ function sendError(output: Writable, id: number | string | null, code: number, m
 
 async function loadReplayTape(filepath: string): Promise<ProxyTape> {
   const absolutePath = resolve(process.cwd(), filepath)
-  const tape = JSON.parse(readFileSync(absolutePath, 'utf-8')) as ProxyTape
-  if (tape.version !== 1 || !Array.isArray(tape.interactions)) {
-    throw new Error(`Replay tape is not a valid pluxx MCP tape: ${filepath}`)
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(readFileSync(absolutePath, 'utf-8'))
+  } catch (error) {
+    throw new Error(
+      `Replay tape could not be parsed as JSON: ${filepath}. ${error instanceof Error ? error.message : String(error)}`,
+    )
   }
-  return tape
+  return validateReplayTape(parsed, filepath)
 }
 
-async function writeTape(filepath: string, tape: ProxyTape): Promise<void> {
+async function writeTape(filepath: string, tape: ProxyTapeV2): Promise<void> {
   const absolutePath = resolve(process.cwd(), filepath)
   mkdirSync(dirname(absolutePath), { recursive: true })
-  await writeTextFile(absolutePath, `${JSON.stringify(tape, null, 2)}\n`)
+  const temporaryPath = `${absolutePath}.${randomUUID()}.tmp`
+  const content = `${JSON.stringify(redactRecordedTape(tape), null, 2)}\n`
+  try {
+    await writeFile(temporaryPath, content, { encoding: 'utf-8', flag: 'wx', mode: 0o600 })
+    await rename(temporaryPath, absolutePath)
+  } catch (error) {
+    await rm(temporaryPath, { force: true }).catch(() => {})
+    throw error
+  }
 }
 
 function serializeError(error: unknown): { code: number; message: string } {
@@ -149,9 +518,14 @@ function serializeError(error: unknown): { code: number; message: string } {
 }
 
 async function proxyLiveSession(client: McpClient, options: McpProxyOptions, io: ProxyIo): Promise<void> {
-  const tape: ProxyTape | null = options.recordPath
+  const tape: ProxyTapeV2 | null = options.recordPath
     ? {
-        version: 1,
+        version: TAPE_SCHEMA_VERSION,
+        redaction: {
+          policy: 'pluxx-default',
+          version: REDACTION_POLICY_VERSION,
+          marker: REDACTION_MARKER,
+        },
         source: options.source,
         interactions: [],
       }
@@ -204,7 +578,7 @@ async function proxyLiveSession(client: McpClient, options: McpProxyOptions, io:
           kind: 'request',
           method,
           ...(params ? { params } : {}),
-          result,
+          result: result ?? null,
         })
       } catch (error) {
         const serialized = serializeError(error)
@@ -219,16 +593,23 @@ async function proxyLiveSession(client: McpClient, options: McpProxyOptions, io:
     }
   } finally {
     rl.close()
-    await client.close()
+    let closeError: unknown
+    try {
+      await client.close()
+    } catch (error) {
+      closeError = error
+    }
     if (tape && options.recordPath) {
       await writeTape(options.recordPath, tape)
     }
+    if (closeError) throw closeError
   }
 }
 
 async function replaySession(filepath: string, io: ProxyIo): Promise<void> {
   const tape = await loadReplayTape(filepath)
-  const interactions = [...tape.interactions]
+  let interactionIndex = 0
+  let replayWasExhausted = false
   const rl = readline.createInterface({
     input: io.input,
     crlfDelay: Infinity,
@@ -254,32 +635,53 @@ async function replaySession(filepath: string, io: ProxyIo): Promise<void> {
       const id = typeof message.id === 'number' || typeof message.id === 'string'
         ? message.id
         : null
-      const expected = interactions.shift()
+      const expected = tape.interactions[interactionIndex]
 
       if (!expected) {
+        replayWasExhausted = true
+        const message = `Replay tape exhausted before handling ${method}.`
         if (id !== null) {
-          sendError(io.output, id, -32001, `Replay tape exhausted before handling ${method}.`)
+          sendError(io.output, id, -32001, message)
+        } else {
+          io.error.write(`${message}\n`)
         }
         continue
       }
 
-      if (expected.kind !== (id === null ? 'notify' : 'request') || expected.method !== method || !sameParams(expected.params, params)) {
+      const actualKind = id === null ? 'notify' : 'request'
+      const kindAndMethodMatch = expected.kind === actualKind && expected.method === method
+      let comparableParams = params
+      if (kindAndMethodMatch && tape.version === 2) {
+        const sensitiveValues = new Set<string>()
+        collectSensitiveValues(params, sensitiveValues)
+        comparableParams = redactValue(
+          params,
+          buildRedactionContext(sensitiveValues),
+        ) as Record<string, unknown> | undefined
+      }
+      const paramsMatch = kindAndMethodMatch
+        && sameParams(expected.params, comparableParams, tape.version === 2)
+      if (!kindAndMethodMatch || !paramsMatch) {
+        const message = kindAndMethodMatch
+          ? `Replay parameter mismatch for ${actualKind} ${method}.`
+          : `Replay mismatch. Expected ${expected.kind} ${expected.method}, received ${actualKind} ${method}.`
         if (id !== null) {
-          sendError(
-            io.output,
-            id,
-            -32002,
-            `Replay mismatch. Expected ${expected.kind} ${expected.method}, received ${id === null ? 'notify' : 'request'} ${method}.`,
-          )
+          sendError(io.output, id, -32002, message)
+        } else {
+          io.error.write(`${message}\n`)
         }
         continue
       }
 
+      interactionIndex += 1
       if (id === null) {
         continue
       }
+      if (expected.kind === 'notify') {
+        continue
+      }
 
-      if (expected.error) {
+      if ('error' in expected) {
         sendError(io.output, id, expected.error.code, expected.error.message)
         continue
       }
@@ -292,6 +694,21 @@ async function replaySession(filepath: string, io: ProxyIo): Promise<void> {
     }
   } finally {
     rl.close()
+  }
+
+  if (replayWasExhausted) {
+    throw new Error('Replay input contained interactions after the tape was exhausted.')
+  }
+
+  const unusedCount = tape.interactions.length - interactionIndex
+  if (unusedCount > 0) {
+    const summary = tape.interactions
+      .slice(interactionIndex, interactionIndex + 3)
+      .map((entry) => `${entry.kind} ${entry.method}`)
+      .join(', ')
+    const message = `Replay tape has ${unusedCount} unused interaction${unusedCount === 1 ? '' : 's'}: ${summary}${unusedCount > 3 ? ', ...' : ''}.`
+    io.error.write(`${message}\n`)
+    throw new Error(message)
   }
 }
 

--- a/tests/mcp-proxy.test.ts
+++ b/tests/mcp-proxy.test.ts
@@ -7,7 +7,15 @@ import { runMcpProxyWithIo } from '../src/cli/mcp-proxy'
 const TEST_DIR = resolve(import.meta.dir, '.mcp-proxy')
 const STUB_SERVER_PATH = resolve(TEST_DIR, 'stub-server.js')
 const TAPE_PATH = resolve(TEST_DIR, 'dev-tape.json')
-const QUOTED_STUB_SOURCE = `bun "${STUB_SERVER_PATH}"`
+const FIXTURE_SECRET = 'pluxx-fixture-secret-not-a-real-credential'
+const SOURCE_ONLY_SECRET = 'pluxx-source-only-fixture-secret'
+const COMPOUND_KEY_SECRET = 'pluxx-compound-key-fixture-secret'
+const PRIVATE_KEY_SECRET = 'pluxx-private-key-fixture-secret'
+const HEADER_SECRET = 'pluxx-header-only-fixture-secret with-spaces'
+const ENV_SECRET = 'pluxx-env-assignment-fixture-secret'
+const FLAG_SECRET = 'pluxx-refresh-flag-fixture-secret'
+const PRETTY_JSON_TEXT = '{\n  "safe": "value"\n}'
+const SECRET_STUB_SOURCE = `bun "${STUB_SERVER_PATH}" PLUXX_CLIENT_SECRET=${ENV_SECRET} --api-key ${FIXTURE_SECRET} --refresh-token=${FLAG_SECRET} --endpoint "https://fixture-user:${SOURCE_ONLY_SECRET}@example.com/mcp?token=${SOURCE_ONLY_SECRET}&mode=test" --header "X-API-Key: ${HEADER_SECRET}"`
 
 function buildRequest(id: number, method: string, params?: Record<string, unknown>) {
   return JSON.stringify({
@@ -24,6 +32,39 @@ function buildNotify(method: string, params?: Record<string, unknown>) {
     method,
     ...(params ? { params } : {}),
   })
+}
+
+function startReplay(lines: string[]): {
+  completion: Promise<void>
+  stdout: () => string
+  stderr: () => string
+} {
+  const input = new PassThrough()
+  const output = new PassThrough()
+  const error = new PassThrough()
+  let stdout = ''
+  let stderr = ''
+  output.on('data', (chunk) => {
+    stdout += chunk.toString('utf-8')
+  })
+  error.on('data', (chunk) => {
+    stderr += chunk.toString('utf-8')
+  })
+
+  const proxyRun = runMcpProxyWithIo(['--replay', TAPE_PATH], { input, output, error })
+  for (const line of lines) input.write(`${line}\n`)
+  input.end()
+  return {
+    completion: proxyRun,
+    stdout: () => stdout,
+    stderr: () => stderr,
+  }
+}
+
+async function runReplay(lines: string[]): Promise<{ stdout: string; stderr: string }> {
+  const replay = startReplay(lines)
+  await replay.completion
+  return { stdout: replay.stdout(), stderr: replay.stderr() }
 }
 
 beforeEach(() => {
@@ -71,6 +112,40 @@ rl.on('line', (line) => {
         }],
       },
     })
+    return
+  }
+
+  if (message.method === 'tools/call') {
+    const apiKey = message.params?.arguments?.apiKey
+    const secretAccessKey = message.params?.arguments?.secretAccessKey
+    const privateKeyPem = message.params?.arguments?.privateKeyPem
+    if (message.params?.arguments?.fail === true) {
+      send({
+        jsonrpc: '2.0',
+        id: message.id,
+        error: {
+          code: -32042,
+          message: 'Tool failed with Authorization: Bearer ' + apiKey + ' access=' + secretAccessKey + ' private=' + privateKeyPem,
+        },
+      })
+      return
+    }
+
+    send({
+      jsonrpc: '2.0',
+      id: message.id,
+      result: {
+        content: [{ type: 'text', text: ${JSON.stringify(PRETTY_JSON_TEXT)} }],
+        structuredContent: {
+          apiKey,
+          secretAccessKey,
+          privateKeyPem,
+          nested: {
+            authorization: 'Bearer ' + apiKey,
+          },
+        },
+      },
+    })
   }
 })`,
   )
@@ -96,7 +171,7 @@ describe('mcp proxy', () => {
 
     const proxyRun = runMcpProxyWithIo([
       '--from-mcp',
-      QUOTED_STUB_SOURCE,
+      SECRET_STUB_SOURCE,
       '--record',
       TAPE_PATH,
     ], {
@@ -110,8 +185,33 @@ describe('mcp proxy', () => {
       capabilities: {},
       clientInfo: { name: 'test-client', version: '0.1.0' },
     })}\n`)
-    input.write(`${buildNotify('notifications/initialized')}\n`)
+    input.write(`${buildNotify('notifications/initialized', {
+      sessionToken: FIXTURE_SECRET,
+      note: `notification ${FIXTURE_SECRET}`,
+    })}\n`)
     input.write(`${buildRequest(2, 'tools/list')}\n`)
+    input.write(`${buildRequest(3, 'tools/call', {
+      name: 'search_accounts',
+      arguments: {
+        apiKey: FIXTURE_SECRET,
+        secretAccessKey: COMPOUND_KEY_SECRET,
+        privateKeyPem: PRIVATE_KEY_SECRET,
+        note: `credential ${FIXTURE_SECRET}`,
+        nested: {
+          authorization: `Bearer ${FIXTURE_SECRET}`,
+          endpoint: `https://fixture-user:${FIXTURE_SECRET}@example.com/search?token=${FIXTURE_SECRET}&page=1`,
+        },
+      },
+    })}\n`)
+    input.write(`${buildRequest(4, 'tools/call', {
+      name: 'search_accounts',
+      arguments: {
+        apiKey: FIXTURE_SECRET,
+        secretAccessKey: COMPOUND_KEY_SECRET,
+        privateKeyPem: PRIVATE_KEY_SECRET,
+        fail: true,
+      },
+    })}\n`)
     input.end()
 
     await proxyRun
@@ -119,23 +219,84 @@ describe('mcp proxy', () => {
     expect(stderr).toBe('')
 
     const lines = stdout.trim().split('\n').map((line) => JSON.parse(line) as Record<string, unknown>)
-    expect(lines).toHaveLength(2)
+    expect(lines).toHaveLength(4)
     expect(lines[0].id).toBe(1)
     expect(lines[1].id).toBe(2)
     expect((lines[1].result as { tools: Array<{ name: string }> }).tools[0]?.name).toBe('search_accounts')
+    expect((lines[3].error as { code: number }).code).toBe(-32042)
 
-    const tape = JSON.parse(readFileSync(TAPE_PATH, 'utf-8')) as {
+    const tapeText = readFileSync(TAPE_PATH, 'utf-8')
+    const tape = JSON.parse(tapeText) as {
       version: number
       source: string
+      redaction: { policy: string; version: number; marker: string }
       interactions: Array<{ kind: string; method: string }>
     }
-    expect(tape.version).toBe(1)
-    expect(tape.source).toBe(QUOTED_STUB_SOURCE)
+    expect(tape.version).toBe(2)
+    expect(tape.redaction).toEqual({
+      policy: 'pluxx-default',
+      version: 1,
+      marker: '[REDACTED]',
+    })
+    expect(tape.source).toContain('[REDACTED]')
+    expect(tapeText).not.toContain(FIXTURE_SECRET)
+    expect(tapeText).not.toContain(SOURCE_ONLY_SECRET)
+    expect(tapeText).not.toContain(COMPOUND_KEY_SECRET)
+    expect(tapeText).not.toContain(PRIVATE_KEY_SECRET)
+    expect(tapeText).not.toContain(HEADER_SECRET)
+    expect(tapeText).not.toContain('with-spaces')
+    expect(tapeText).not.toContain(ENV_SECRET)
+    expect(tapeText).not.toContain(FLAG_SECRET)
+    expect(((tape.interactions[3] as { result: { content: Array<{ text: string }> } }).result.content[0]?.text)).toBe(PRETTY_JSON_TEXT)
     expect(tape.interactions.map((entry) => `${entry.kind}:${entry.method}`)).toEqual([
       'request:initialize',
       'notify:notifications/initialized',
       'request:tools/list',
+      'request:tools/call',
+      'request:tools/call',
     ])
+
+    const replay = await runReplay([
+      buildRequest(101, 'initialize', {
+        protocolVersion: '2025-03-26',
+        capabilities: {},
+        clientInfo: { name: 'test-client', version: '0.1.0' },
+      }),
+      buildNotify('notifications/initialized', {
+        sessionToken: FIXTURE_SECRET,
+        note: `notification ${FIXTURE_SECRET}`,
+      }),
+      buildRequest(102, 'tools/list'),
+      buildRequest(103, 'tools/call', {
+        name: 'search_accounts',
+        arguments: {
+          apiKey: FIXTURE_SECRET,
+          secretAccessKey: COMPOUND_KEY_SECRET,
+          privateKeyPem: PRIVATE_KEY_SECRET,
+          note: `credential ${FIXTURE_SECRET}`,
+          nested: {
+            authorization: `Bearer ${FIXTURE_SECRET}`,
+            endpoint: `https://fixture-user:${FIXTURE_SECRET}@example.com/search?token=${FIXTURE_SECRET}&page=1`,
+          },
+        },
+      }),
+      buildRequest(104, 'tools/call', {
+        name: 'search_accounts',
+        arguments: {
+          apiKey: FIXTURE_SECRET,
+          secretAccessKey: COMPOUND_KEY_SECRET,
+          privateKeyPem: PRIVATE_KEY_SECRET,
+          fail: true,
+        },
+      }),
+    ])
+    expect(replay.stderr).toBe('')
+    expect(replay.stdout).not.toContain(FIXTURE_SECRET)
+    expect(replay.stdout).not.toContain(COMPOUND_KEY_SECRET)
+    const replayResponses = replay.stdout.trim().split('\n').map((line) => JSON.parse(line) as Record<string, unknown>)
+    expect(replayResponses).toHaveLength(4)
+    expect(((replayResponses[2]?.result as { content: Array<{ text: string }> }).content[0]?.text)).toBe(PRETTY_JSON_TEXT)
+    expect((replayResponses[3]?.error as { code: number }).code).toBe(-32042)
   })
 
   it('replays a recorded MCP tape deterministically with new request ids', async () => {
@@ -182,37 +343,15 @@ describe('mcp proxy', () => {
       }, null, 2),
     )
 
-    const input = new PassThrough()
-    const output = new PassThrough()
-    const error = new PassThrough()
-    let stdout = ''
-    let stderr = ''
-    output.on('data', (chunk) => {
-      stdout += chunk.toString('utf-8')
-    })
-    error.on('data', (chunk) => {
-      stderr += chunk.toString('utf-8')
-    })
-
-    const proxyRun = runMcpProxyWithIo([
-      '--replay',
-      TAPE_PATH,
-    ], {
-      input,
-      output,
-      error,
-    })
-
-    input.write(`${buildRequest(41, 'initialize', {
-      protocolVersion: '2025-03-26',
-      capabilities: {},
-      clientInfo: { name: 'test-client', version: '0.1.0' },
-    })}\n`)
-    input.write(`${buildNotify('notifications/initialized')}\n`)
-    input.write(`${buildRequest(99, 'tools/list')}\n`)
-    input.end()
-
-    await proxyRun
+    const { stdout, stderr } = await runReplay([
+      buildRequest(41, 'initialize', {
+        protocolVersion: '2025-03-26',
+        capabilities: {},
+        clientInfo: { name: 'test-client', version: '0.1.0' },
+      }),
+      buildNotify('notifications/initialized'),
+      buildRequest(99, 'tools/list'),
+    ])
 
     expect(stderr).toBe('')
 
@@ -221,5 +360,294 @@ describe('mcp proxy', () => {
     expect(lines[0].id).toBe(41)
     expect(lines[1].id).toBe(99)
     expect((lines[1].result as { tools: Array<{ name: string }> }).tools[0]?.name).toBe('search_accounts')
+  })
+
+  it('matches redacted v2 parameters without requiring recorded secrets', async () => {
+    writeFileSync(TAPE_PATH, JSON.stringify({
+      version: 2,
+      redaction: {
+        policy: 'pluxx-default',
+        version: 1,
+        marker: '[REDACTED]',
+      },
+      interactions: [{
+        kind: 'request',
+        method: 'tools/call',
+        params: {
+          name: 'search_accounts',
+          arguments: {
+            apiKey: '[REDACTED]',
+            endpoint: 'https://example.com/search?token=%5BREDACTED%5D&page=1',
+          },
+        },
+        result: {
+          content: [{ type: 'text', text: 'fixture response' }],
+        },
+      }],
+    }, null, 2))
+
+    const { stdout, stderr } = await runReplay([buildRequest(91, 'tools/call', {
+      name: 'search_accounts',
+      arguments: {
+        apiKey: FIXTURE_SECRET,
+        endpoint: `https://example.com/search?token=${FIXTURE_SECRET}&page=1`,
+      },
+    })])
+
+    expect(stderr).toBe('')
+    const response = JSON.parse(stdout.trim()) as { id: number; result: unknown }
+    expect(response.id).toBe(91)
+    expect(response.result).toEqual({
+      content: [{ type: 'text', text: 'fixture response' }],
+    })
+  })
+
+  it('does not consume request or notification interactions on mismatch', async () => {
+    writeFileSync(TAPE_PATH, JSON.stringify({
+      version: 1,
+      interactions: [
+        {
+          kind: 'notify',
+          method: 'notifications/initialized',
+        },
+        {
+          kind: 'request',
+          method: 'tools/list',
+          result: { tools: [{ name: 'search_accounts' }] },
+        },
+      ],
+    }, null, 2))
+
+    const { stdout, stderr } = await runReplay([
+      buildNotify('notifications/cancelled'),
+      buildNotify('notifications/initialized'),
+      buildRequest(70, 'tools/list', { unexpected: true }),
+      buildRequest(71, 'tools/call', { name: 'wrong_tool' }),
+      buildRequest(72, 'tools/list'),
+    ])
+
+    const responses = stdout.trim().split('\n').map((line) => JSON.parse(line) as {
+      id: number
+      error?: { code: number; message: string }
+      result?: unknown
+    })
+    expect(responses).toHaveLength(3)
+    expect(responses[0]).toMatchObject({ id: 70, error: { code: -32002 } })
+    expect(responses[0]?.error?.message).toBe('Replay parameter mismatch for request tools/list.')
+    expect(responses[1]).toMatchObject({ id: 71, error: { code: -32002 } })
+    expect(responses[2]).toMatchObject({ id: 72, result: { tools: [{ name: 'search_accounts' }] } })
+    expect(stderr).toContain('Replay mismatch. Expected notify notifications/initialized')
+  })
+
+  it('replays recorded RPC errors', async () => {
+    writeFileSync(TAPE_PATH, JSON.stringify({
+      version: 1,
+      interactions: [{
+        kind: 'request',
+        method: 'tools/call',
+        params: { name: 'search_accounts', arguments: { fail: true } },
+        error: { code: -32042, message: 'Fixture tool failure' },
+      }],
+    }, null, 2))
+
+    const { stdout, stderr } = await runReplay([
+      buildRequest(72, 'tools/call', { name: 'search_accounts', arguments: { fail: true } }),
+    ])
+
+    expect(stderr).toBe('')
+    expect(JSON.parse(stdout.trim())).toMatchObject({
+      id: 72,
+      error: { code: -32042, message: 'Fixture tool failure' },
+    })
+  })
+
+  it('rejects malformed, unsupported, and incomplete tapes clearly', async () => {
+    const cases: Array<{ value: string; message: string }> = [
+      { value: '{not-json', message: 'could not be parsed as JSON' },
+      { value: 'null', message: 'must contain a JSON object' },
+      {
+        value: JSON.stringify({ interactions: [] }),
+        message: 'schema version missing',
+      },
+      {
+        value: JSON.stringify({ version: 99, interactions: [] }),
+        message: 'Unsupported MCP replay tape schema version 99',
+      },
+      {
+        value: JSON.stringify({ version: 1, interactions: [], extra: true }),
+        message: 'unsupported field "extra"',
+      },
+      {
+        value: JSON.stringify({ version: 1, source: 42, interactions: [] }),
+        message: 'source must be a string',
+      },
+      {
+        value: JSON.stringify({ version: 1, interactions: {} }),
+        message: 'interactions must be an array',
+      },
+      {
+        value: JSON.stringify({ version: 2, interactions: [] }),
+        message: 'redaction',
+      },
+      {
+        value: JSON.stringify({
+          version: 2,
+          redaction: { policy: 'unknown', version: 1, marker: '[REDACTED]' },
+          interactions: [],
+        }),
+        message: 'redaction metadata is unsupported',
+      },
+      {
+        value: JSON.stringify({
+          version: 2,
+          redaction: { policy: 'pluxx-default', version: 1, marker: '[REDACTED]', extra: true },
+          interactions: [],
+        }),
+        message: 'Replay tape redaction contains unsupported field "extra"',
+      },
+      {
+        value: JSON.stringify({
+          version: 2,
+          redaction: { policy: 'pluxx-default', version: 2, marker: '[REDACTED]' },
+          interactions: [],
+        }),
+        message: 'redaction metadata is unsupported',
+      },
+      {
+        value: JSON.stringify({
+          version: 2,
+          redaction: { policy: 'pluxx-default', version: 1, marker: '[MASKED]' },
+          interactions: [],
+        }),
+        message: 'redaction metadata is unsupported',
+      },
+      {
+        value: JSON.stringify({ version: 1, interactions: [null] }),
+        message: 'interactions[0] must be an object',
+      },
+      {
+        value: JSON.stringify({ version: 1, interactions: [{ kind: 'event', method: 'tools/list' }] }),
+        message: 'kind must be "request" or "notify"',
+      },
+      {
+        value: JSON.stringify({
+          version: 1,
+          interactions: [{ kind: 'notify', method: 'notifications/initialized', extra: true }],
+        }),
+        message: 'interactions[0] contains unsupported field "extra"',
+      },
+      {
+        value: JSON.stringify({ version: 1, interactions: [{ kind: 'notify', method: '' }] }),
+        message: 'method must be a non-empty string',
+      },
+      {
+        value: JSON.stringify({
+          version: 1,
+          interactions: [{ kind: 'notify', method: 'notifications/initialized', params: [] }],
+        }),
+        message: 'params must be an object',
+      },
+      {
+        value: JSON.stringify({
+          version: 1,
+          interactions: [{ kind: 'request', method: 'tools/list' }],
+        }),
+        message: 'exactly one of result or error',
+      },
+      {
+        value: JSON.stringify({
+          version: 1,
+          interactions: [{ kind: 'notify', method: 'notifications/initialized', result: null }],
+        }),
+        message: 'notification cannot contain result or error',
+      },
+      {
+        value: JSON.stringify({
+          version: 1,
+          interactions: [{
+            kind: 'request',
+            method: 'tools/list',
+            result: null,
+            error: { code: -32000, message: 'failure' },
+          }],
+        }),
+        message: 'exactly one of result or error',
+      },
+      {
+        value: JSON.stringify({
+          version: 1,
+          interactions: [{ kind: 'request', method: 'tools/list', error: [] }],
+        }),
+        message: 'error must be an object',
+      },
+      {
+        value: JSON.stringify({
+          version: 1,
+          interactions: [{ kind: 'request', method: 'tools/list', error: { code: 1.5, message: 'failure' } }],
+        }),
+        message: 'error.code must be an integer',
+      },
+      {
+        value: JSON.stringify({
+          version: 1,
+          interactions: [{
+            kind: 'request',
+            method: 'tools/list',
+            error: { code: -32000, message: 'failure', extra: true },
+          }],
+        }),
+        message: 'interactions[0].error contains unsupported field "extra"',
+      },
+      {
+        value: JSON.stringify({
+          version: 1,
+          interactions: [{ kind: 'request', method: 'tools/list', error: { code: -32000, message: 42 } }],
+        }),
+        message: 'error.message must be a string',
+      },
+    ]
+
+    for (const testCase of cases) {
+      writeFileSync(TAPE_PATH, testCase.value)
+      await expect(runReplay([])).rejects.toThrow(testCase.message)
+    }
+  })
+
+  it('fails replay when interactions remain unused', async () => {
+    writeFileSync(TAPE_PATH, JSON.stringify({
+      version: 1,
+      interactions: [{
+        kind: 'request',
+        method: 'tools/list',
+        result: { tools: [] },
+      }],
+    }, null, 2))
+
+    await expect(runReplay([])).rejects.toThrow(
+      'Replay tape has 1 unused interaction: request tools/list.',
+    )
+  })
+
+  it('fails when requests and notifications arrive after the tape is exhausted', async () => {
+    writeFileSync(TAPE_PATH, JSON.stringify({
+      version: 1,
+      interactions: [{
+        kind: 'request',
+        method: 'tools/list',
+        result: { tools: [] },
+      }],
+    }, null, 2))
+
+    const replay = startReplay([
+      buildRequest(80, 'tools/list'),
+      buildRequest(81, 'tools/list'),
+      buildNotify('notifications/initialized'),
+    ])
+    await expect(replay.completion).rejects.toThrow(
+      'Replay input contained interactions after the tape was exhausted.',
+    )
+    const responses = replay.stdout().trim().split('\n').map((line) => JSON.parse(line))
+    expect(responses[1]).toMatchObject({ id: 81, error: { code: -32001 } })
+    expect(replay.stderr()).toContain('Replay tape exhausted before handling notifications/initialized.')
   })
 })


### PR DESCRIPTION
## Summary

MCP development tapes no longer persist recognized credentials by default or lose their expected interaction after a replay mismatch. New recordings use a schema-v2 contract with recursive credential redaction across source commands, request parameters, results, and errors; raw recording is intentionally unsupported, while valid schema-v1 tapes remain replayable.

Replay now validates tape structure before serving it, preserves the current expectation after method or parameter mismatches, and fails clearly when input is malformed, exhausted early, or leaves interactions unused. Tape replacement uses an exclusive mode-0600 sibling temporary file and atomic rename so interrupted writes do not leave a partially written target.

The CLI and privacy guidance explicitly warn that arbitrary private content under ordinary field names cannot be classified automatically, so operators must still review tapes before sharing them.

## Validation

- `npm test -- tests/mcp-proxy.test.ts` — 8/8 passed, covering source/parameter/result/error redaction, schema-v1 compatibility, schema-v2 matching, recoverable mismatches, malformed tapes, and unused/exhausted interactions.
- `npm run typecheck` — passed.
- `npm run build` — passed.
- `npm test` — 590/590 passed across 53 files, run serially.
- CE correctness/security/reliability review — no actionable findings remain.
- Specialized security diff scan — complete, zero reportable findings.

## Residual risk

The redaction taxonomy cannot infer arbitrary private content stored under ordinary field names. Schema-v2 redaction markers intentionally wildcard only the recorded redacted value positions while preserving method, structure, key, array-length, and surrounding-string equality.

Fixes #405.
Fixes PLUXX-315.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
