### PR TITLE
chore(release): prepare v0.1.32

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,8 @@ jobs:
           echo "package_version=${PACKAGE_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Run release checks
+        env:
+          PLUXX_RELEASE_TAG: ${{ github.ref_name }}
         run: npm run release:check
 
       - name: Pack release tarball

--- a/docs/orchid/plans/2026-07-13-pluxx-322-release-prep.md
+++ b/docs/orchid/plans/2026-07-13-pluxx-322-release-prep.md
@@ -24,11 +24,12 @@ Product Contract unchanged. This plan packages the nine already-merged PLUXX-313
 - R5. Current 0.1.32 repository and fake-home claims cite a reachable commit containing the release-prep changes and only commands observed passing.
 - R6. Official serial `npm test` and `npm run release:check` pass after the version/proof changes.
 - R7. A ready, linked, autofix-enabled PR reaches GitHub `CLEAN` with no actionable review threads.
+- R8. The tag-triggered publish workflow can validate the exact expected tag while the tagged release-prep commit remains immutable, without weakening ordinary branch or post-release proof-state checks.
 
 ## Scope boundaries
 
 - No merge, tag, npm publish, GitHub Release mutation, force-push, or task/archive cleanup.
-- No production behavior changes beyond version metadata and accurate release/proof/planning truth.
+- No shipped CLI/plugin behavior changes; release-workflow changes are limited to making the proof-state transition safe for the exact expected tag event.
 - No real-host or live publish proof is claimed; public npm, GitHub, tarball, and CLI verification remains coordinator-owned after release.
 - Historical evidence stays historical even when still useful context.
 
@@ -51,7 +52,7 @@ Demote 0.1.31 current claims and receipts to historical. After U1 is committed a
 
 ### U3. Full release verification and review
 
-Install dependencies reproducibly when needed. Run focused version, proof, package, workflow, and release-smoke checks; the official serial suite; and the full release gate. Record exact results, run CE code/doc/release review, and resolve every actionable finding.
+Install dependencies reproducibly when needed. Run focused version, proof, package, workflow, and release-smoke checks; the official serial suite; and the full release gate. Verify both strict ordinary proof-state validation and the exact-tag publish transition. Record exact results, run CE code/doc/release review, and resolve every actionable finding.
 
 ### U4. PR and merge-ready handoff
 
@@ -63,6 +64,7 @@ Push the focused branch, open a ready PR linked to PLUXX-322, apply the autofix 
 - Focused proof freshness/version, release workflow, package, meta CLI, and release-smoke checks.
 - Official serial `npm test`.
 - `npm run release:check`.
+- Run the release gate with approved npm registry access and temporary-directory writes because packaged-runtime verification performs an isolated tarball install and `npm exec`; diagnose any command failure rather than treating sandbox restrictions as a pass.
 - CE code/doc/release review with no actionable residuals.
 - Ready PR with autofix enabled, GitHub `CLEAN`, and no actionable review threads.
 

--- a/docs/orchid/plans/2026-07-13-pluxx-322-release-prep.md
+++ b/docs/orchid/plans/2026-07-13-pluxx-322-release-prep.md
@@ -1,0 +1,75 @@
+---
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+product_contract_source: linear-pluxx-322
+linear_issue: PLUXX-322
+created: 2026-07-13
+---
+
+# PLUXX-322 Pluxx v0.1.32 Release Preparation
+
+## Goal capsule
+
+Prepare a focused 0.1.32 release PR from exact post-audit main `f92e3cc4b6b292c10e8d2cf4fdbac97afb7e97db`, with truthful release-prep docs and fresh repository-owned proof. The coordinator will merge, tag, publish, verify public artifacts, and archive work.
+
+Product Contract unchanged. This plan packages the nine already-merged PLUXX-313 through PLUXX-321 remediations; it does not change their behavior.
+
+## Requirements
+
+- R1. `package.json`, `package-lock.json`, and canonical version surfaces identify 0.1.32.
+- R2. Canonical planning docs say all nine audit remediations are merged and make the 0.1.32 release PR the current next action.
+- R3. Pending 0.1.32 is described as `release-prep`, never already tagged, published, or released.
+- R4. Existing 0.1.31 receipts remain historical; they are not reused as current 0.1.32 evidence.
+- R5. Current 0.1.32 repository and fake-home claims cite a reachable commit containing the release-prep changes and only commands observed passing.
+- R6. Official serial `npm test` and `npm run release:check` pass after the version/proof changes.
+- R7. A ready, linked, autofix-enabled PR reaches GitHub `CLEAN` with no actionable review threads.
+
+## Scope boundaries
+
+- No merge, tag, npm publish, GitHub Release mutation, force-push, or task/archive cleanup.
+- No production behavior changes beyond version metadata and accurate release/proof/planning truth.
+- No real-host or live publish proof is claimed; public npm, GitHub, tarball, and CLI verification remains coordinator-owned after release.
+- Historical evidence stays historical even when still useful context.
+
+## Key technical decisions
+
+- Use `package.json` as canonical version truth and set the proof manifest to `v0.1.32` plus `release-prep` until the tag exists.
+- Commit release/version/doc truth before generating current receipts so receipt SHAs point to code that contains 0.1.32.
+- Keep a separate proof-record commit if needed; an ancestor release-prep commit remains reachable from the final branch.
+- Describe the audit tranche by outcomes without inventing live publish evidence.
+
+## Implementation units
+
+### U1. Version and release-prep truth
+
+Move package, lockfile, and maintained release docs to pending 0.1.32. Preserve explicitly historical version references. Verify package/lock agreement and run the proof-freshness check.
+
+### U2. Proof reset and fresh receipts
+
+Demote 0.1.31 current claims and receipts to historical. After U1 is committed and the named checks pass, generate new current 0.1.32 receipts through the maintained repository command. Verify manifest version, tag, state, claim linkage, passing outcomes, and reachable commit ancestry.
+
+### U3. Full release verification and review
+
+Install dependencies reproducibly when needed. Run focused version, proof, package, workflow, and release-smoke checks; the official serial suite; and the full release gate. Record exact results, run CE code/doc/release review, and resolve every actionable finding.
+
+### U4. PR and merge-ready handoff
+
+Push the focused branch, open a ready PR linked to PLUXX-322, apply the autofix label, monitor checks and reviews, resolve actionable findings, and stop at GitHub `CLEAN` without merging.
+
+## Verification contract
+
+- `npm ci` when dependency state requires it.
+- Focused proof freshness/version, release workflow, package, meta CLI, and release-smoke checks.
+- Official serial `npm test`.
+- `npm run release:check`.
+- CE code/doc/release review with no actionable residuals.
+- Ready PR with autofix enabled, GitHub `CLEAN`, and no actionable review threads.
+
+## Definition of done
+
+- Package, proof, planning, and public release docs agree on 0.1.32 release prep.
+- Fresh current receipts reference committed 0.1.32 state and observed passing commands only.
+- Official serial tests and the release gate pass after final proof changes.
+- PLUXX-322, PLUXX-312, and the project carry exact branch, commit, PR, and proof state.
+- Coordinator receives an explicit no-merge/no-tag/no-publish handoff and residual-risk summary.

--- a/docs/orchid/reviews/2026-07-13-pluxx-322-release-review.md
+++ b/docs/orchid/reviews/2026-07-13-pluxx-322-release-review.md
@@ -17,6 +17,7 @@ Ready for PR review. CE correctness, testing, maintainability, project-standards
 - Documented the release gate's temporary-install and npm registry requirement.
 - Corrected the active v0.1.32 sequence in `docs/start-here.md` and refreshed the public proof page date.
 - Fixed generated-installer test isolation after Blocks reproduced three user-config failures in a fresh environment. Each fixture removes its prior run root, creates writable home and temp roots, and inherits only the executable path before applying isolated host paths and explicit fixture overrides, so reused workspaces, sandbox temp policy, CI secrets, or workspace config cannot change test semantics.
+- Integrated the same-branch Blocks repair for OpenCode companion moves across filesystem boundaries; `EXDEV` now falls back to copy/remove while retaining the existing transaction rollback path.
 - Re-ran the complete release gate after all receipt, manifest, review, workflow, test, and documentation changes.
 
 ## Verification

--- a/docs/orchid/reviews/2026-07-13-pluxx-322-release-review.md
+++ b/docs/orchid/reviews/2026-07-13-pluxx-322-release-review.md
@@ -16,11 +16,13 @@ Ready for PR review. CE correctness, testing, maintainability, project-standards
 - Added an exact-tag publish transition so the immutable `release-prep` tag commit can pass its release workflow without weakening ordinary branch or post-release proof-state checks. Focused proof and workflow coverage verifies exact-match, mismatch, and normal strict behavior.
 - Documented the release gate's temporary-install and npm registry requirement.
 - Corrected the active v0.1.32 sequence in `docs/start-here.md` and refreshed the public proof page date.
+- Fixed generated-installer test isolation after Blocks reproduced three user-config failures in a fresh environment. The helper now removes config-declared variables from the ambient runner environment before applying explicit fixture overrides, so CI secrets or workspace config cannot change test semantics.
 - Re-ran the complete release gate after all receipt, manifest, review, workflow, test, and documentation changes.
 
 ## Verification
 
 - `npm exec -- vitest run tests/proof-freshness.test.ts tests/release-workflow.test.ts` — passed, 17/17.
+- Ambient-config reproduction of `tests/publish.test.ts` — passed, 43/43 after the isolation fix.
 - `npm run release:check` — passed with exit 0 on the completed working tree:
   - proof freshness: 6 claims, 6 receipts
   - build and typecheck: passed

--- a/docs/orchid/reviews/2026-07-13-pluxx-322-release-review.md
+++ b/docs/orchid/reviews/2026-07-13-pluxx-322-release-review.md
@@ -1,0 +1,33 @@
+---
+artifact_contract: orchid-review/v1
+linear_issue: PLUXX-322
+reviewed: 2026-07-13
+base: f92e3cc4b6b292c10e8d2cf4fdbac97afb7e97db
+---
+
+# PLUXX-322 v0.1.32 Release Review
+
+## Verdict
+
+Ready for PR review. CE correctness, testing, maintainability, project-standards, agent-native, learnings, adversarial release-gate, coherence, and feasibility passes found no unresolved actionable items after fixes.
+
+## Findings resolved
+
+- Added an exact-tag publish transition so the immutable `release-prep` tag commit can pass its release workflow without weakening ordinary branch or post-release proof-state checks. Focused proof and workflow coverage verifies exact-match, mismatch, and normal strict behavior.
+- Documented the release gate's temporary-install and npm registry requirement.
+- Corrected the active v0.1.32 sequence in `docs/start-here.md` and refreshed the public proof page date.
+- Re-ran the complete release gate after all receipt, manifest, review, workflow, test, and documentation changes.
+
+## Verification
+
+- `npm exec -- vitest run tests/proof-freshness.test.ts tests/release-workflow.test.ts` — passed, 17/17.
+- `npm run release:check` — passed with exit 0 on the completed working tree:
+  - proof freshness: 6 claims, 6 receipts
+  - build and typecheck: passed
+  - official serial suite: 61 files, 752 tests passed
+  - packed Node package runtime verification: passed
+  - dry-run package: `@orchid-labs/pluxx@0.1.32`, 192 files, 707.7 kB
+
+## Boundaries
+
+No merge, tag, publish, GitHub Release mutation, public registry verification, or real-host proof was performed. Those remain coordinator-owned after this PR reaches a clean mergeable state.

--- a/docs/orchid/reviews/2026-07-13-pluxx-322-release-review.md
+++ b/docs/orchid/reviews/2026-07-13-pluxx-322-release-review.md
@@ -16,13 +16,13 @@ Ready for PR review. CE correctness, testing, maintainability, project-standards
 - Added an exact-tag publish transition so the immutable `release-prep` tag commit can pass its release workflow without weakening ordinary branch or post-release proof-state checks. Focused proof and workflow coverage verifies exact-match, mismatch, and normal strict behavior.
 - Documented the release gate's temporary-install and npm registry requirement.
 - Corrected the active v0.1.32 sequence in `docs/start-here.md` and refreshed the public proof page date.
-- Fixed generated-installer test isolation after Blocks reproduced three user-config failures in a fresh environment. The helper now removes config-declared variables from the ambient runner environment before applying explicit fixture overrides, so CI secrets or workspace config cannot change test semantics.
+- Fixed generated-installer test isolation after Blocks reproduced three user-config failures in a fresh environment. Installer fixtures now inherit only the executable path before applying their isolated home/host paths and explicit fixture overrides, so CI secrets or workspace config cannot change test semantics.
 - Re-ran the complete release gate after all receipt, manifest, review, workflow, test, and documentation changes.
 
 ## Verification
 
 - `npm exec -- vitest run tests/proof-freshness.test.ts tests/release-workflow.test.ts` — passed, 17/17.
-- Ambient-config reproduction of `tests/publish.test.ts` — passed, 43/43 after the isolation fix.
+- Ambient-config reproduction of `tests/publish.test.ts` — passed, 44/44 after the isolation fix.
 - `npm run release:check` — passed with exit 0 on the completed working tree:
   - proof freshness: 6 claims, 6 receipts
   - build and typecheck: passed

--- a/docs/orchid/reviews/2026-07-13-pluxx-322-release-review.md
+++ b/docs/orchid/reviews/2026-07-13-pluxx-322-release-review.md
@@ -16,13 +16,14 @@ Ready for PR review. CE correctness, testing, maintainability, project-standards
 - Added an exact-tag publish transition so the immutable `release-prep` tag commit can pass its release workflow without weakening ordinary branch or post-release proof-state checks. Focused proof and workflow coverage verifies exact-match, mismatch, and normal strict behavior.
 - Documented the release gate's temporary-install and npm registry requirement.
 - Corrected the active v0.1.32 sequence in `docs/start-here.md` and refreshed the public proof page date.
-- Fixed generated-installer test isolation after Blocks reproduced three user-config failures in a fresh environment. Installer fixtures now inherit only the executable path before applying their isolated home/host paths and explicit fixture overrides, so CI secrets or workspace config cannot change test semantics.
+- Fixed generated-installer test isolation after Blocks reproduced three user-config failures in a fresh environment. Each fixture removes its prior run root, creates writable home and temp roots, and inherits only the executable path before applying isolated host paths and explicit fixture overrides, so reused workspaces, sandbox temp policy, CI secrets, or workspace config cannot change test semantics.
 - Re-ran the complete release gate after all receipt, manifest, review, workflow, test, and documentation changes.
 
 ## Verification
 
 - `npm exec -- vitest run tests/proof-freshness.test.ts tests/release-workflow.test.ts` — passed, 17/17.
 - Ambient-config reproduction of `tests/publish.test.ts` — passed, 44/44 after the isolation fix.
+- `npm test -- --run tests/publish.test.ts` — passed, 44/44 with the exact reviewer command.
 - `npm run release:check` — passed with exit 0 on the completed working tree:
   - proof freshness: 6 claims, 6 receipts
   - build and typecheck: passed

--- a/docs/pluxx-self-hosted-core-four-proof.md
+++ b/docs/pluxx-self-hosted-core-four-proof.md
@@ -2,7 +2,7 @@
 
 Last updated: 2026-05-12
 
-Proof status: **historical**. Tier: `installed-runtime`. Observed: 2026-05-12 against v0.1.28-era state. The run predates host-version, installed-path, and artifact-hash receipts and therefore must not be presented as current v0.1.31 evidence. See [proof freshness](./proof-freshness.md) and [proof manifest](./proof-manifest.json).
+Proof status: **historical**. Tier: `installed-runtime`. Observed: 2026-05-12 against v0.1.28-era state. The run predates host-version, installed-path, and artifact-hash receipts and therefore must not be presented as current v0.1.32 evidence. See [proof freshness](./proof-freshness.md) and [proof manifest](./proof-manifest.json).
 
 ## Doc Links
 

--- a/docs/proof-and-install.md
+++ b/docs/proof-and-install.md
@@ -30,9 +30,9 @@ This is the shortest current repo-native path to:
 
 For the fuller release/distribution boundary, including publish commands and deferred marketplace/trust-layer work, use [docs/release-distribution-proof-map.md](./release-distribution-proof-map.md).
 
-Proof labels and freshness come from [proof-freshness.md](./proof-freshness.md) and [proof-manifest.json](./proof-manifest.json). The May self-hosted run and April Firecrawl connector run are preserved as historical environment evidence; they are not current host receipts for `0.1.31`.
+Proof labels and freshness come from [proof-freshness.md](./proof-freshness.md) and [proof-manifest.json](./proof-manifest.json). The May self-hosted run and April Firecrawl connector run are preserved as historical environment evidence; they are not current host receipts for `0.1.32`.
 
-The current v0.1.31 receipts prove the `bundle-contract` and `fake-home-install` tiers. No current receipt claims installed-runtime or real-host behavior.
+Fresh v0.1.32 receipts must be generated from the committed release-prep state before the `bundle-contract` and `fake-home-install` tiers are described as current. No current receipt claims installed-runtime or real-host behavior.
 
 ## The Story In One Screen
 
@@ -208,7 +208,7 @@ curl -fsSL https://raw.githubusercontent.com/orchidautomation/pluxx/main/example
 
 Current release note:
 
-- the canonical repository release is `@orchid-labs/pluxx@0.1.31` with expected tag `v0.1.31`; `package.json` remains authoritative for repository docs
+- the canonical repository version is `@orchid-labs/pluxx@0.1.32` in release prep with expected tag `v0.1.32`; the historical published baseline remains 0.1.31 until the coordinator completes the release workflow
 - the published CLI runtime is Node `>=18`; see [runtime contract](./runtime-contract.md)
 - the published package includes the Claude plugin-agent manifest fix and packaged Node runtime verification
 - the public `pluxx test --install --trust --behavioral` path now matches the repo-local Exa proof state

--- a/docs/proof-and-install.md
+++ b/docs/proof-and-install.md
@@ -1,6 +1,6 @@
 # Proof And Install
 
-Last updated: 2026-07-07
+Last updated: 2026-07-13
 
 ## Doc Links
 
@@ -32,7 +32,7 @@ For the fuller release/distribution boundary, including publish commands and def
 
 Proof labels and freshness come from [proof-freshness.md](./proof-freshness.md) and [proof-manifest.json](./proof-manifest.json). The May self-hosted run and April Firecrawl connector run are preserved as historical environment evidence; they are not current host receipts for `0.1.32`.
 
-Fresh v0.1.32 receipts must be generated from the committed release-prep state before the `bundle-contract` and `fake-home-install` tiers are described as current. No current receipt claims installed-runtime or real-host behavior.
+The current v0.1.32 receipts prove the `bundle-contract` and `fake-home-install` tiers from committed release-prep state after `npm run release:check` passed. No current receipt claims installed-runtime or real-host behavior.
 
 ## The Story In One Screen
 

--- a/docs/proof-freshness.md
+++ b/docs/proof-freshness.md
@@ -4,7 +4,7 @@ Last updated: 2026-07-12
 
 This document defines how Pluxx distinguishes repeatable repository checks from installed and real-host evidence. The machine-readable source is [proof-manifest.json](./proof-manifest.json), validated by `npm run proof:check`.
 
-The v0.1.31 repository-validation and fake-home-install receipts are historical after the 0.1.32 version bump. Fresh 0.1.32 current receipts must be generated only after their named checks pass against committed release-prep state. Neither tier is installed-runtime or real-host behavior evidence.
+Current reviewed receipts for v0.1.32 are `v0.1.32-repository-validation` (`bundle-contract`, `current`) and `v0.1.32-fake-home-install` (`fake-home-install`, `current`). They cite committed release-prep state only after `npm run release:check` passed. The v0.1.31 receipts remain historical. Neither current tier is installed-runtime or real-host behavior evidence.
 
 ## Version And Freshness Policy
 

--- a/docs/proof-freshness.md
+++ b/docs/proof-freshness.md
@@ -4,7 +4,7 @@ Last updated: 2026-07-12
 
 This document defines how Pluxx distinguishes repeatable repository checks from installed and real-host evidence. The machine-readable source is [proof-manifest.json](./proof-manifest.json), validated by `npm run proof:check`.
 
-Current reviewed receipts for v0.1.31 are `v0.1.31-repository-validation` (`bundle-contract`, `current`) and `v0.1.31-fake-home-install` (`fake-home-install`, `current`). Neither is installed-runtime or real-host behavior evidence.
+The v0.1.31 repository-validation and fake-home-install receipts are historical after the 0.1.32 version bump. Fresh 0.1.32 current receipts must be generated only after their named checks pass against committed release-prep state. Neither tier is installed-runtime or real-host behavior evidence.
 
 ## Version And Freshness Policy
 

--- a/docs/proof-manifest.json
+++ b/docs/proof-manifest.json
@@ -1,25 +1,25 @@
 {
   "schemaVersion": 1,
-  "canonicalVersion": "0.1.31",
-  "expectedTag": "v0.1.31",
-  "releaseState": "released",
+  "canonicalVersion": "0.1.32",
+  "expectedTag": "v0.1.32",
+  "releaseState": "release-prep",
   "policy": {
     "environmentReceiptMaxAgeDays": 30
   },
   "claims": [
     {
       "id": "v0.1.31-repository-validation",
-      "summary": "The reviewed v0.1.31 commit passes proof governance, typecheck, build, and the official serial suite.",
+      "summary": "The reviewed v0.1.31 commit retains historical proof governance, typecheck, build, and official serial-suite evidence.",
       "tier": "bundle-contract",
-      "freshness": "current",
+      "freshness": "historical",
       "evidencePath": "tests/proof-freshness.test.ts",
       "receiptId": "v0.1.31-repository-validation"
     },
     {
       "id": "v0.1.31-fake-home-install",
-      "summary": "Maintained examples pass core-four bundle and isolated fake-home install verification.",
+      "summary": "The v0.1.31 maintained examples retain historical core-four bundle and isolated fake-home install evidence.",
       "tier": "fake-home-install",
-      "freshness": "current",
+      "freshness": "historical",
       "evidencePath": "tests/release-smoke.test.ts",
       "receiptId": "v0.1.31-fake-home-install"
     },
@@ -92,7 +92,7 @@
     {
       "id": "v0.1.31-repository-validation",
       "tier": "bundle-contract",
-      "freshness": "current",
+      "freshness": "historical",
       "commitSha": "5066ee4764c2679cdf10f40156f756da51fb89b3",
       "packageVersion": "0.1.31",
       "timestamp": "2026-07-12T11:50:11.851Z",
@@ -127,7 +127,7 @@
     {
       "id": "v0.1.31-fake-home-install",
       "tier": "fake-home-install",
-      "freshness": "current",
+      "freshness": "historical",
       "commands": [
         {
           "command": "bun test tests/release-smoke.test.ts",

--- a/docs/proof-manifest.json
+++ b/docs/proof-manifest.json
@@ -24,6 +24,22 @@
       "receiptId": "v0.1.31-fake-home-install"
     },
     {
+      "id": "v0.1.32-repository-validation",
+      "summary": "The committed v0.1.32 release-prep state passes the complete repository release gate.",
+      "tier": "bundle-contract",
+      "freshness": "current",
+      "evidencePath": "tests/proof-freshness.test.ts",
+      "receiptId": "v0.1.32-repository-validation"
+    },
+    {
+      "id": "v0.1.32-fake-home-install",
+      "summary": "Maintained examples pass core-four bundle and isolated fake-home install verification in the v0.1.32 release gate.",
+      "tier": "fake-home-install",
+      "freshness": "current",
+      "evidencePath": "tests/release-smoke.test.ts",
+      "receiptId": "v0.1.32-fake-home-install"
+    },
+    {
       "id": "self-hosted-core-four-history",
       "summary": "The May self-hosted core-four run remains useful historical installed-runtime evidence.",
       "tier": "installed-runtime",
@@ -128,6 +144,9 @@
       "id": "v0.1.31-fake-home-install",
       "tier": "fake-home-install",
       "freshness": "historical",
+      "commitSha": "5066ee4764c2679cdf10f40156f756da51fb89b3",
+      "packageVersion": "0.1.31",
+      "timestamp": "2026-07-12T11:50:12.286Z",
       "commands": [
         {
           "command": "bun test tests/release-smoke.test.ts",
@@ -142,10 +161,53 @@
           "sha256": null,
           "outcome": "passed"
         }
+      ]
+    },
+    {
+      "id": "v0.1.32-repository-validation",
+      "tier": "bundle-contract",
+      "freshness": "current",
+      "commitSha": "f2b7cd4eafccaa42df64041cff9a4c5de96b0fd0",
+      "packageVersion": "0.1.32",
+      "timestamp": "2026-07-13T01:54:26.817Z",
+      "commands": [
+        {
+          "command": "npm run release:check",
+          "outcome": "passed"
+        }
       ],
-      "commitSha": "5066ee4764c2679cdf10f40156f756da51fb89b3",
-      "packageVersion": "0.1.31",
-      "timestamp": "2026-07-12T11:50:12.286Z"
+      "targets": [
+        {
+          "target": "repository",
+          "hostVersion": null,
+          "installedPath": null,
+          "sha256": null,
+          "outcome": "passed"
+        }
+      ]
+    },
+    {
+      "id": "v0.1.32-fake-home-install",
+      "tier": "fake-home-install",
+      "freshness": "current",
+      "commands": [
+        {
+          "command": "npm run release:check",
+          "outcome": "passed"
+        }
+      ],
+      "targets": [
+        {
+          "target": "claude-code,cursor,codex,opencode",
+          "hostVersion": null,
+          "installedPath": null,
+          "sha256": null,
+          "outcome": "passed"
+        }
+      ],
+      "commitSha": "f2b7cd4eafccaa42df64041cff9a4c5de96b0fd0",
+      "packageVersion": "0.1.32",
+      "timestamp": "2026-07-13T01:54:26.958Z"
     }
   ]
 }

--- a/docs/proof-receipts/v0.1.31-repository-validation.json
+++ b/docs/proof-receipts/v0.1.31-repository-validation.json
@@ -1,7 +1,7 @@
 {
   "id": "v0.1.31-repository-validation",
   "tier": "bundle-contract",
-  "freshness": "current",
+  "freshness": "historical",
   "commands": [
     {
       "command": "npm run proof:check",

--- a/docs/proof-receipts/v0.1.32-fake-home-install.json
+++ b/docs/proof-receipts/v0.1.32-fake-home-install.json
@@ -1,10 +1,10 @@
 {
-  "id": "v0.1.31-fake-home-install",
+  "id": "v0.1.32-fake-home-install",
   "tier": "fake-home-install",
-  "freshness": "historical",
+  "freshness": "current",
   "commands": [
     {
-      "command": "bun test tests/release-smoke.test.ts",
+      "command": "npm run release:check",
       "outcome": "passed"
     }
   ],

--- a/docs/proof-receipts/v0.1.32-repository-validation.json
+++ b/docs/proof-receipts/v0.1.32-repository-validation.json
@@ -1,0 +1,20 @@
+{
+  "id": "v0.1.32-repository-validation",
+  "tier": "bundle-contract",
+  "freshness": "current",
+  "commands": [
+    {
+      "command": "npm run release:check",
+      "outcome": "passed"
+    }
+  ],
+  "targets": [
+    {
+      "target": "repository",
+      "hostVersion": null,
+      "installedPath": null,
+      "sha256": null,
+      "outcome": "passed"
+    }
+  ]
+}

--- a/docs/release-distribution-proof-map.md
+++ b/docs/release-distribution-proof-map.md
@@ -26,7 +26,7 @@ Last updated: 2026-07-12
 
 This is the short release/distribution map for what Pluxx can ship today, what is locally proven, and what still belongs to later marketplace or trust-layer work.
 
-Proof state is governed by [proof-freshness.md](./proof-freshness.md) and the machine-readable [proof manifest](./proof-manifest.json). The canonical repository release is `0.1.31` / `v0.1.31`. Older environment runs linked below are historical unless a current receipt says otherwise.
+Proof state is governed by [proof-freshness.md](./proof-freshness.md) and the machine-readable [proof manifest](./proof-manifest.json). The canonical repository version is `0.1.32` in release prep with expected tag `v0.1.32`; the historical published baseline remains 0.1.31 until the coordinator completes the release workflow. Older environment runs linked below are historical unless a current receipt says otherwise.
 
 ## Current Primary Fronts
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -76,13 +76,13 @@ See [docs/orchid/decisions/2026-06-26-pluxx-next-ship-review.md](./orchid/decisi
 
 The transactional install-ownership slice is now implemented across the core-four local and generated release-installer paths. It stages and validates candidate bundles, retains rollback backups through post-install work, hashes owned files, preserves modified/unowned content, adds conservative Codex config unapply, and makes verification content-aware even when versions match.
 
-The v0.1.31 audit remediation also closes a core authoring-safety gap: `init`, `sync`, `migrate`, and `build` now stage and validate mutations before publication, restore prior state after thrown apply failures, retain recovery metadata for unresolved interruptions, and expose additive versioned mutation/conflict manifests.
+The full v0.1.31 audit-remediation tranche is merged. Main now includes safer ingestion, reliable Autopilot checkpoints and write boundaries, stronger semantic evaluation and field-level translation truth, atomic authoring/build mutations, transactional ownership-aware installs, hardened release recovery, and proof freshness governance.
 
 ## Current Priority Order
 
 Proof governance now distinguishes unit, bundle-contract, fake-home install, installed-runtime, and real-host behavior evidence. Canonical version/freshness checks run in CI through [proof-freshness.md](./proof-freshness.md) and [proof-manifest.json](./proof-manifest.json); historical April/May proof stays available without being treated as current.
 
-The remaining active v0.1.31 audit-remediation slice is PLUXX-314 Autopilot reliability. Its merge gate is current serial test, CI, and review proof for checkpoint recovery, fail-stop Agent Mode boundaries, and structured review output; the implementation is not release truth until that PR lands.
+The active audit closeout slice is PLUXX-322: prepare the focused 0.1.32 release PR from exact merged main, create fresh repository-owned proof, and reach GitHub CLEAN. Merge, tag, publish, public artifact verification, and archive remain coordinator-owned.
 
 ### 1. Product clarity and source-of-truth coherence
 
@@ -228,7 +228,7 @@ The closure plan is now narrower than it was before:
 - historical release-gate evidence from 2026-05-19 remains available but is not current proof:
   - `npm test` passed
   - `npm run release:check` passed
-- the canonical repository release is `@orchid-labs/pluxx@0.1.31` with expected tag `v0.1.31`
+- the canonical repository version is `@orchid-labs/pluxx@0.1.32` in release prep with expected tag `v0.1.32`; the historical published baseline remains 0.1.31
 - the release/distribution/proof boundary is now explicit:
   - [docs/release-distribution-proof-map.md](./release-distribution-proof-map.md)
   - [docs/core-four-primitive-proof-ledger.md](./core-four-primitive-proof-ledger.md)
@@ -388,16 +388,15 @@ This is for learning and proof, not for prematurely building the full trust laye
 
 ### 6. Next release
 
-The canonical repository release is `0.1.31` / `v0.1.31`. The next npm cut begins from that source of truth and must regenerate or explicitly demote proof receipts before making current host claims.
+The canonical repository version is `0.1.32` in release prep with expected tag `v0.1.32`; the historical published baseline remains 0.1.31. This npm cut must regenerate current repository-owned receipts rather than carrying historical 0.1.31 proof forward.
 
 The next npm cut should stay primarily an operations step rather than a code-confidence rescue step.
 
-- start from the current repo version
-- rerun `npm run release:check`
-- bump `package.json` and `package-lock.json` to the next version
-- commit and push release-prep fixes and source-of-truth updates
-- push the matching `vX.Y.Z` tag to trigger the GitHub Actions publish workflow
-- verify the npm package version, GitHub release, and attached tarball after the workflow completes
+- prepare and review the 0.1.32 package, proof, and source-of-truth changes in PLUXX-322
+- run targeted proof/version/release checks, official serial `npm test`, and `npm run release:check`
+- merge the release-prep PR after GitHub reports CLEAN
+- push `v0.1.32` to trigger the GitHub Actions publish workflow
+- verify the npm package version, GitHub release, attached tarball, and CLI after the workflow completes
 
 ## What This Roadmap Is Optimizing For
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -388,7 +388,7 @@ This is for learning and proof, not for prematurely building the full trust laye
 
 ### 6. Next release
 
-The canonical repository version is `0.1.32` in release prep with expected tag `v0.1.32`; the historical published baseline remains 0.1.31. This npm cut must regenerate current repository-owned receipts rather than carrying historical 0.1.31 proof forward.
+The canonical repository version is `0.1.32` in release prep with expected tag `v0.1.32`; the historical published baseline remains 0.1.31. Current repository-validation and fake-home-install receipts were regenerated from committed 0.1.32 state after the complete release gate passed; historical 0.1.31 proof was not carried forward as current.
 
 The next npm cut should stay primarily an operations step rather than a code-confidence rescue step.
 

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -541,7 +541,7 @@ Run two lanes in parallel:
 
 The canonical repository version is `0.1.32` in release prep with expected tag `v0.1.32`. The historical published baseline remains 0.1.31 until the coordinator merges this release PR, pushes the tag, and verifies public artifacts. `package.json` is the source of truth for repository docs, while [proof-manifest.json](./proof-manifest.json) records release state and whether evidence is current or historical.
 
-For the next release, start from the current version, rerun `npm run release:check`, bump the package version, push `main`, push the matching `vX.Y.Z` tag, and verify npm plus GitHub release artifacts after the workflow completes.
+For v0.1.32, finish review and reach GitHub `CLEAN`, merge the focused release PR, push `v0.1.32`, then verify npm, GitHub, the published tarball, and CLI behavior. Future releases should repeat the version bump and release-prep proof work on a focused PR before tagging.
 
 ## Working Rules
 

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -39,7 +39,7 @@ If you want the shortest public proof and install path after this file, use [doc
 
 If you want the current release, distribution, and proof boundary, use [docs/release-distribution-proof-map.md](./release-distribution-proof-map.md).
 
-If you need to know whether a proof claim is current, historical, repository-only, installed, or real-host evidence, use [docs/proof-freshness.md](./proof-freshness.md) and [docs/proof-manifest.json](./proof-manifest.json). Canonical repository version truth is `package.json` (`0.1.31`) with expected tag `v0.1.31`.
+If you need to know whether a proof claim is current, historical, repository-only, installed, or real-host evidence, use [docs/proof-freshness.md](./proof-freshness.md) and [docs/proof-manifest.json](./proof-manifest.json). Canonical repository version truth is `package.json` (`0.1.32`) with expected tag `v0.1.32`; this branch is release prep, not proof that the tag or public release exists.
 
 If you want the primitive-by-host proof ledger behind the core-four native shipping claim, use [docs/core-four-primitive-proof-ledger.md](./core-four-primitive-proof-ledger.md).
 
@@ -99,7 +99,7 @@ The goal of this layer is simple:
 
 The CLI is the engine, but the self-hosted Pluxx plugin is part of the real product surface for average users.
 
-The PLUXX-314 audit-remediation branch adds fail-closed Autopilot checkpoints, compatible resume/rollback, enforced Agent Mode write boundaries, and structured review gating. It remains a PR candidate until its current CI and review proof lands; do not treat it as released solely from these docs.
+All nine PLUXX-313 through PLUXX-321 audit remediations are merged. The combined 0.1.32 release-prep state now includes safer ingestion and replay records, fail-closed Autopilot recovery and Agent Mode boundaries, stronger semantic evaluation and translation/YAML truth, atomic authoring/build mutations, transactional ownership-aware installs, release integrity/recovery, and proof freshness governance. These repository claims do not prove that v0.1.32 has been tagged or published.
 
 That means near-term product quality is not only about compiler depth.
 It is also about making the plugin-guided path feel obvious, safe, and understandable on top of the same CLI truth.
@@ -369,7 +369,7 @@ The repo already proves a lot.
 - historical release-gate evidence from 2026-05-19 remains available but is not current proof:
   - `npm test` passed
   - `npm run release:check` passed
-- the canonical repository release is `@orchid-labs/pluxx@0.1.31` with expected tag `v0.1.31`
+- the canonical repository version is `@orchid-labs/pluxx@0.1.32` in release prep with expected tag `v0.1.32`; the historical published baseline remains 0.1.31
 - marketplace submission APIs, a managed trust/distribution control plane, automatic rollback/unpublish orchestration, and real authenticated publish plus rollback proof remain explicit release gaps, not hidden shipped capabilities:
   - `docs/release-distribution-proof-map.md`
   - “automatic rollback” here means remote release rollback/unpublish; generated local installers now restore the prior bundle when staged setup fails
@@ -539,7 +539,7 @@ Run two lanes in parallel:
 
 ### 6. Release State
 
-The canonical repository release is `0.1.31` with expected tag `v0.1.31`. `package.json` is the source of truth for repository docs, while [proof-manifest.json](./proof-manifest.json) records whether evidence is current or historical.
+The canonical repository version is `0.1.32` in release prep with expected tag `v0.1.32`. The historical published baseline remains 0.1.31 until the coordinator merges this release PR, pushes the tag, and verifies public artifacts. `package.json` is the source of truth for repository docs, while [proof-manifest.json](./proof-manifest.json) records release state and whether evidence is current or historical.
 
 For the next release, start from the current version, rerun `npm run release:check`, bump the package version, push `main`, push the matching `vX.Y.Z` tag, and verify npm plus GitHub release artifacts after the workflow completes.
 

--- a/docs/strategy/firecrawl-connector-docs-ingestion-proof.md
+++ b/docs/strategy/firecrawl-connector-docs-ingestion-proof.md
@@ -2,7 +2,7 @@
 
 Last updated: 2026-04-23
 
-Proof status: **historical**. Tier: `real-host-behavior`. Observed: 2026-04-23 against v0.1.28-era state. This connector run predates complete host-version, installed-path, and artifact-hash receipts and is not current v0.1.31 evidence. See [proof freshness](../proof-freshness.md) and [proof manifest](../proof-manifest.json).
+Proof status: **historical**. Tier: `real-host-behavior`. Observed: 2026-04-23 against v0.1.28-era state. This connector run predates complete host-version, installed-path, and artifact-hash receipts and is not current v0.1.32 evidence. See [proof freshness](../proof-freshness.md) and [proof manifest](../proof-manifest.json).
 
 This note captures the first real Firecrawl-backed docs-ingestion comparison on the current fixture set.
 

--- a/docs/todo/master-backlog.md
+++ b/docs/todo/master-backlog.md
@@ -85,9 +85,9 @@ Proof governance is now explicit: [proof-freshness.md](../proof-freshness.md) de
 ### 0. v0.1.32 release preparation
 
 - [x] Merge all nine PLUXX-313 through PLUXX-321 audit-remediation PRs into main at `f92e3cc`
-- [~] Prepare 0.1.32 in PLUXX-322 with synchronized package, proof, planning, and release truth
-- [ ] Generate fresh repository-validation and fake-home-install receipts from committed 0.1.32 state
-- [ ] Pass the official serial suite and complete release gate
+- [x] Prepare 0.1.32 in PLUXX-322 with synchronized package, proof, planning, and release truth
+- [x] Generate fresh repository-validation and fake-home-install receipts from committed 0.1.32 state
+- [x] Pass the official 751/751 serial suite and complete release gate
 - [ ] Reach a ready, autofix-enabled, GitHub-CLEAN release PR with no actionable review threads
 - [ ] Coordinator: merge, tag v0.1.32, verify npm/GitHub/tarball/CLI, then archive the completed batch
 
@@ -449,8 +449,8 @@ Open work:
 
 - [x] Merge the nine v0.1.31 audit-remediation PRs
 - [~] Prepare the focused v0.1.32 release PR under PLUXX-322
-- [ ] Refresh current repository/fake-home receipts from committed 0.1.32 state
-- [ ] Pass targeted checks, official serial `npm test`, and `npm run release:check`
+- [x] Refresh current repository/fake-home receipts from committed 0.1.32 state
+- [x] Pass targeted checks, official serial 751/751 `npm test`, and `npm run release:check`
 - [ ] Merge the release-prep PR to `main`
 - [ ] Push `v0.1.32` so the GitHub Actions release workflow publishes to npm
 - [ ] Verify `@orchid-labs/pluxx@0.1.32`, GitHub release assets, tarball contents, and CLI behavior

--- a/docs/todo/master-backlog.md
+++ b/docs/todo/master-backlog.md
@@ -82,14 +82,14 @@ Any person or agent should be able to enter the repo and answer:
 
 Proof governance is now explicit: [proof-freshness.md](../proof-freshness.md) defines the five evidence tiers and freshness rules, while [proof-manifest.json](../proof-manifest.json) keeps machine-readable receipts and current/historical claim state aligned with `package.json`.
 
-### 0. Remaining v0.1.31 audit remediation
+### 0. v0.1.32 release preparation
 
-- [~] Land PLUXX-314 Autopilot reliability after focused PR proof:
-  - baseline doctor/test before semantic mutation
-  - checkpoint-backed fail-stop stages, compatible resume, and local rollback
-  - enforced taxonomy/instructions/review write boundaries
-  - structured review artifacts and fail-closed gating
-  - serial official `npm test` plus current CI/review evidence
+- [x] Merge all nine PLUXX-313 through PLUXX-321 audit-remediation PRs into main at `f92e3cc`
+- [~] Prepare 0.1.32 in PLUXX-322 with synchronized package, proof, planning, and release truth
+- [ ] Generate fresh repository-validation and fake-home-install receipts from committed 0.1.32 state
+- [ ] Pass the official serial suite and complete release gate
+- [ ] Reach a ready, autofix-enabled, GitHub-CLEAN release PR with no actionable review threads
+- [ ] Coordinator: merge, tag v0.1.32, verify npm/GitHub/tarball/CLI, then archive the completed batch
 
 ### 1. Product clarity and front-door coherence
 
@@ -447,15 +447,13 @@ Open work:
 
 ### 7. Next release readiness
 
-- [x] Validate the current self-hosting flow end to end
-- [x] Run tests, release smoke, and the packaged-runtime release gate before the next cut
-- [x] Restore example parity for `examples/prospeo-mcp` so release smoke and the real package agree again
-- [x] Bump `package.json` and `package-lock.json` from `0.1.27` to `0.1.28`
-- [x] Rerun the release gate before tagging
-- [ ] Merge release-prep fixes to `main`
-- [ ] Push the matching `v0.1.28` tag so the GitHub Actions release workflow publishes to npm
-- [ ] Publish and verify `@orchid-labs/pluxx@0.1.28`
-- [ ] Verify the published npm version and GitHub release artifacts after the workflow completes
+- [x] Merge the nine v0.1.31 audit-remediation PRs
+- [~] Prepare the focused v0.1.32 release PR under PLUXX-322
+- [ ] Refresh current repository/fake-home receipts from committed 0.1.32 state
+- [ ] Pass targeted checks, official serial `npm test`, and `npm run release:check`
+- [ ] Merge the release-prep PR to `main`
+- [ ] Push `v0.1.32` so the GitHub Actions release workflow publishes to npm
+- [ ] Verify `@orchid-labs/pluxx@0.1.32`, GitHub release assets, tarball contents, and CLI behavior
 
 ## Next
 

--- a/docs/todo/queue.md
+++ b/docs/todo/queue.md
@@ -55,13 +55,7 @@ For broader context, use:
 
 ## Current Truth
 
-PLUXX-314 Autopilot reliability is implemented on its focused remediation branch and is moving through PR proof:
-
-- deterministic baseline doctor/test runs before agent mutation
-- durable stage checkpoints with compatible `--resume` and local `--rollback`
-- pass-specific Agent Mode write boundaries with unauthorized-change restoration
-- structured, fail-closed review output before later verification
-- current proof must come from this branch's serial `npm test` and CI, not the older April/May audit baseline
+All nine PLUXX-313 through PLUXX-321 audit remediations are merged into main at `f92e3cc`. PLUXX-322 now owns the focused 0.1.32 release-prep PR; the coordinator retains merge, tag, publish, public artifact verification, and archive ownership.
 
 The core-four compiler sprint is done.
 
@@ -194,7 +188,7 @@ The initial author-once hardening tranche is also materially done.
 The public baseline is also real.
 
 - npm package is live as `@orchid-labs/pluxx`
-- the canonical repository release is `@orchid-labs/pluxx@0.1.31` with expected tag `v0.1.31`
+- the canonical repository version is `@orchid-labs/pluxx@0.1.32` in release prep with expected tag `v0.1.32`; the historical published baseline remains 0.1.31
 - proof claims now use [docs/proof-freshness.md](../proof-freshness.md) and [docs/proof-manifest.json](../proof-manifest.json) so historical host runs cannot masquerade as current evidence
 - published CLI runtime is Node `>=18`
 - published CLI lifecycle ergonomics are now stronger for global installs:
@@ -501,7 +495,25 @@ Open work:
   - native bundles across the core four
   - install verification and truthful compatibility
 
-### 6. Historical v0.1.28 release checklist
+### 6. v0.1.32 release preparation
+
+Current work:
+
+- [~] PLUXX-322 prepares the focused release PR from exact post-audit main `f92e3cc`
+- [x] bump `package.json` and `package-lock.json` to 0.1.32
+- [~] refresh canonical release, planning, and proof truth without carrying old evidence forward as current
+- [ ] generate fresh repository-validation and fake-home-install receipts from committed 0.1.32 state
+- [ ] pass the official serial suite and `npm run release:check`
+- [ ] reach a ready, autofix-enabled, GitHub-CLEAN PR with no actionable review threads
+
+Coordinator-owned after this task:
+
+- merge the release PR
+- push `v0.1.32`
+- monitor publishing and verify npm, GitHub, tarball, and CLI surfaces
+- archive completed tasks
+
+### 7. Historical v0.1.28 release checklist
 
 Historical context:
 

--- a/docs/todo/queue.md
+++ b/docs/todo/queue.md
@@ -501,9 +501,9 @@ Current work:
 
 - [~] PLUXX-322 prepares the focused release PR from exact post-audit main `f92e3cc`
 - [x] bump `package.json` and `package-lock.json` to 0.1.32
-- [~] refresh canonical release, planning, and proof truth without carrying old evidence forward as current
-- [ ] generate fresh repository-validation and fake-home-install receipts from committed 0.1.32 state
-- [ ] pass the official serial suite and `npm run release:check`
+- [x] refresh canonical release, planning, and proof truth without carrying old evidence forward as current
+- [x] generate fresh repository-validation and fake-home-install receipts from committed 0.1.32 state
+- [x] pass the official serial 751/751 suite and `npm run release:check`
 - [ ] reach a ready, autofix-enabled, GitHub-CLEAN PR with no actionable review threads
 
 Coordinator-owned after this task:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orchid-labs/pluxx",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchid-labs/pluxx",
-      "version": "0.1.31",
+      "version": "0.1.32",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orchid-labs/pluxx",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "description": "Build AI agent plugins once. Prime-time on Claude Code, Cursor, Codex, and OpenCode, with beta generators for additional hosts.",
   "type": "module",
   "main": "dist/index.js",

--- a/scripts/check-proof-freshness.ts
+++ b/scripts/check-proof-freshness.ts
@@ -40,6 +40,7 @@ const tagExists = git('tag', '--list', expectedTag) === expectedTag
 const problems = validateProofManifest(manifest, {
   packageVersion: packageJson.version,
   expectedTagExists: tagExists,
+  releaseTagUnderValidation: process.env.PLUXX_RELEASE_TAG,
   now: new Date(),
   isCommitReachable: (sha) => {
     try {

--- a/src/cli/publish.ts
+++ b/src/cli/publish.ts
@@ -2350,6 +2350,18 @@ const entriesEqual = (expected, actual) => {
   }
   return true
 }
+const movePath = (source, destination) => {
+  try {
+    fs.renameSync(source, destination)
+    return
+  } catch (error) {
+    if (!error || error.code !== 'EXDEV') throw error
+  }
+  const stats = fs.lstatSync(source)
+  if (stats.isDirectory()) fs.cpSync(source, destination, { recursive: true, verbatimSymlinks: true })
+  else fs.copyFileSync(source, destination)
+  fs.rmSync(source, { recursive: true, force: true })
+}
 for (const candidate of candidates) {
   const ledgerPath = path.join(ledgerRoot, 'opencode--' + candidate.surface + '.json')
   candidate.ledgerPath = ledgerPath
@@ -2378,7 +2390,7 @@ try {
     const backup = path.join(path.dirname(candidate.destination), '.' + pluginName + '.pluxx-companion-backup-' + nonce + '-' + journal.moves.length)
     journal.moves.push({ destination: candidate.destination, backup })
     if (fs.existsSync(candidate.destination)) fs.renameSync(candidate.destination, backup)
-    if (!candidate.remove) fs.renameSync(candidate.source, candidate.destination)
+    if (!candidate.remove) movePath(candidate.source, candidate.destination)
     saveJournal()
   }
   for (const candidate of candidates) {

--- a/src/proof-freshness.ts
+++ b/src/proof-freshness.ts
@@ -77,6 +77,7 @@ export type ProofReceiptSpec = z.infer<typeof ProofReceiptSpecSchema>
 export interface ProofValidationContext {
   packageVersion: string
   expectedTagExists: boolean
+  releaseTagUnderValidation?: string
   now: Date
   isCommitReachable: (sha: string) => boolean
 }
@@ -123,7 +124,12 @@ export function validateProofManifest(
   if (manifest.expectedTag !== expectedTag) {
     problems.push(`Manifest expectedTag is ${manifest.expectedTag}; expected ${expectedTag}.`)
   }
-  if (context.expectedTagExists && manifest.releaseState !== 'released') {
+  const isExpectedTagReleaseCheck = context.releaseTagUnderValidation === expectedTag
+  if (
+    context.expectedTagExists
+    && manifest.releaseState !== 'released'
+    && !(manifest.releaseState === 'release-prep' && isExpectedTagReleaseCheck)
+  ) {
     problems.push(`Manifest releaseState is ${manifest.releaseState} but tag ${expectedTag} exists; use released.`)
   }
   if (!context.expectedTagExists && manifest.releaseState !== 'release-prep') {

--- a/tests/proof-freshness.test.ts
+++ b/tests/proof-freshness.test.ts
@@ -14,6 +14,7 @@ import {
 
 const CURRENT_SHA = '561385059b8544c52ee7329063bb0574be394280'
 const ROOT = resolve(import.meta.dir, '..')
+const PACKAGE_VERSION = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf8')).version as string
 
 function currentManifest(): ProofManifest {
   return {
@@ -121,7 +122,7 @@ describe('proof freshness manifest', () => {
 
     const updated = ProofManifestSchema.parse(JSON.parse(readFileSync(manifestPath, 'utf8')))
     expect(updated.receipts.find((receipt) => receipt.id === 'cli-generated')).toMatchObject({
-      packageVersion: '0.1.31',
+      packageVersion: PACKAGE_VERSION,
       tier: 'bundle-contract',
       freshness: 'current',
     })

--- a/tests/proof-freshness.test.ts
+++ b/tests/proof-freshness.test.ts
@@ -270,6 +270,28 @@ describe('proof freshness manifest', () => {
       isCommitReachable: () => true,
     })).toContain('Manifest releaseState is released but tag v0.1.31 does not exist; use release-prep.')
   })
+
+  it('allows release-prep only while validating the exact tag publish event', () => {
+    const manifest = { ...currentManifest(), releaseState: 'release-prep' as const }
+    const context = {
+      packageVersion: '0.1.31',
+      expectedTagExists: true,
+      now: new Date('2026-07-12T13:00:00.000Z'),
+      isCommitReachable: () => true,
+    }
+
+    expect(validateProofManifest(manifest, context)).toContain(
+      'Manifest releaseState is release-prep but tag v0.1.31 exists; use released.',
+    )
+    expect(validateProofManifest(manifest, {
+      ...context,
+      releaseTagUnderValidation: 'v0.1.30',
+    })).toContain('Manifest releaseState is release-prep but tag v0.1.31 exists; use released.')
+    expect(validateProofManifest(manifest, {
+      ...context,
+      releaseTagUnderValidation: 'v0.1.31',
+    })).not.toContain('Manifest releaseState is release-prep but tag v0.1.31 exists; use released.')
+  })
 })
 
 describe('canonical proof/version docs', () => {

--- a/tests/publish.test.ts
+++ b/tests/publish.test.ts
@@ -273,6 +273,21 @@ interface GeneratedInstallerRunResult {
   }
 }
 
+function configEnvironmentVariables(value: unknown, variables = new Set<string>()): Set<string> {
+  if (typeof value === 'string') {
+    if (/^[A-Z][A-Z0-9_]*_[A-Z0-9_]+$/.test(value)) variables.add(value)
+    return variables
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) configEnvironmentVariables(entry, variables)
+    return variables
+  }
+  if (value && typeof value === 'object') {
+    for (const entry of Object.values(value)) configEnvironmentVariables(entry, variables)
+  }
+  return variables
+}
+
 function getGeneratedInstallerPaths(platform: TargetPlatform, rootDir: string): {
   installDir: string
   pluginInstallDir: string
@@ -385,8 +400,10 @@ function runGeneratedInstaller(
         options.mutateArchive?.(archivePath!, resolve(archivePath!, '..'))
         publishedAssets = new Map(fileArgs.map((filepath) => [filepath.split('/').pop()!, readFileSync(filepath)]))
 
+        const ambientEnv = { ...process.env }
+        for (const envVar of configEnvironmentVariables(config)) delete ambientEnv[envVar]
         const env: Record<string, string> = {
-          ...process.env,
+          ...ambientEnv,
           HOME: resolve(rootDir, 'home'),
           ...paths.env,
           ...preparedEnv,

--- a/tests/publish.test.ts
+++ b/tests/publish.test.ts
@@ -337,8 +337,13 @@ function runGeneratedInstaller(
   options: GeneratedInstallerRunOptions = {},
 ): GeneratedInstallerRunResult {
   const rootDir = resolve(ROOT, `generated-installer-${platform}-${generatedInstallerRunCount++}`)
+  rmSync(rootDir, { recursive: true, force: true })
   const config = options.config ?? makeUserConfigInstallerConfig(platform)
   const paths = getGeneratedInstallerPaths(platform, rootDir)
+  const homeDir = resolve(rootDir, 'home')
+  const tempDir = resolve(rootDir, 'tmp')
+  mkdirSync(homeDir, { recursive: true })
+  mkdirSync(tempDir, { recursive: true })
   const fixtureFiles = {
     ...GENERATED_INSTALLER_FIXTURE_FILES[platform],
     ...(options.extraFiles ?? {}),
@@ -391,7 +396,10 @@ function runGeneratedInstaller(
 
         const env: Record<string, string> = {
           ...isolatedInstallerEnvironment(process.env),
-          HOME: resolve(rootDir, 'home'),
+          HOME: homeDir,
+          TMPDIR: tempDir,
+          TMP: tempDir,
+          TEMP: tempDir,
           ...paths.env,
           ...preparedEnv,
           ...options.env,
@@ -1472,7 +1480,7 @@ with tarfile.open(archive, 'w:gz') as tf:
         },
       })
 
-      expect(run.status).toBe(0)
+      expect(run.status, `${platform} installer failed:\n${run.stderr}\n${run.stdout}`).toBe(0)
       expect(run.stderr).toBe('')
       expect(run.stdout).toContain('Found existing publish-plugin config; reusing saved install values.')
       if (platform === 'codex') {
@@ -1515,7 +1523,7 @@ with tarfile.open(archive, 'w:gz') as tf:
         extraFiles: stdioMcpFileForPlatform(platform),
       })
 
-      expect(run.status).toBe(0)
+      expect(run.status, `${platform} installer failed:\n${run.stderr}\n${run.stdout}`).toBe(0)
       expect(run.stderr).toBe('')
       expect(run.stdout).not.toContain('reusing saved install values')
       expect(run.installerContent).not.toContain('pluxx_prompt_text_config "workspace-')
@@ -1546,7 +1554,7 @@ with tarfile.open(archive, 'w:gz') as tf:
         env: { SENDLENS_INSTANTLY_API_KEY: 'fresh-env-key' },
       })
 
-      expect(run.status).toBe(0)
+      expect(run.status, `${platform} installer failed:\n${run.stderr}\n${run.stdout}`).toBe(0)
       expect(run.stderr).toBe('')
       expect(run.stdout).not.toContain('reusing saved install values')
       if (platform === 'codex') {

--- a/tests/publish.test.ts
+++ b/tests/publish.test.ts
@@ -273,19 +273,8 @@ interface GeneratedInstallerRunResult {
   }
 }
 
-function configEnvironmentVariables(value: unknown, variables = new Set<string>()): Set<string> {
-  if (typeof value === 'string') {
-    if (/^[A-Z][A-Z0-9_]*_[A-Z0-9_]+$/.test(value)) variables.add(value)
-    return variables
-  }
-  if (Array.isArray(value)) {
-    for (const entry of value) configEnvironmentVariables(entry, variables)
-    return variables
-  }
-  if (value && typeof value === 'object') {
-    for (const entry of Object.values(value)) configEnvironmentVariables(entry, variables)
-  }
-  return variables
+function isolatedInstallerEnvironment(source: Record<string, string | undefined>): Record<string, string> {
+  return { PATH: source.PATH ?? '/usr/bin:/bin' }
 }
 
 function getGeneratedInstallerPaths(platform: TargetPlatform, rootDir: string): {
@@ -400,10 +389,8 @@ function runGeneratedInstaller(
         options.mutateArchive?.(archivePath!, resolve(archivePath!, '..'))
         publishedAssets = new Map(fileArgs.map((filepath) => [filepath.split('/').pop()!, readFileSync(filepath)]))
 
-        const ambientEnv = { ...process.env }
-        for (const envVar of configEnvironmentVariables(config)) delete ambientEnv[envVar]
         const env: Record<string, string> = {
-          ...ambientEnv,
+          ...isolatedInstallerEnvironment(process.env),
           HOME: resolve(rootDir, 'home'),
           ...paths.env,
           ...preparedEnv,
@@ -1497,6 +1484,14 @@ with tarfile.open(archive, 'w:gz') as tf:
         expect(run.installedUserConfig?.env?.SENDLENS_INSTANTLY_API_KEY).toBe('saved-instantly-key')
       }
     }
+  })
+
+  it('does not pass ambient runner config into generated installer fixtures', () => {
+    expect(isolatedInstallerEnvironment({
+      PATH: '/fixture/bin',
+      SENDLENS_INSTANTLY_API_KEY: 'ambient-runner-key',
+      WORKSPACE_MARKER: 'ambient-workspace',
+    })).toEqual({ PATH: '/fixture/bin' })
   })
 
   it('does not bake core-host stdio runtime env into generated global installs', () => {

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -32,8 +32,12 @@ describe('release workflow', () => {
   })
 
   it('runs the release integrity gates in production order', () => {
-    const workflow = parse(releaseWorkflow) as { jobs: { publish: { steps: Array<{ name?: string }> } } }
+    const workflow = parse(releaseWorkflow) as {
+      jobs: { publish: { steps: Array<{ name?: string; run?: string; env?: Record<string, string> }> } }
+    }
     const names = workflow.jobs.publish.steps.map((step) => step.name)
+    const releaseCheck = workflow.jobs.publish.steps.find((step) => step.name === 'Run release checks')
+    expect(releaseCheck?.env?.PLUXX_RELEASE_TAG).toBe('${{ github.ref_name }}')
     expect(names.indexOf('Pack release tarball')).toBeLessThan(names.indexOf('Verify packaged Node runtime'))
     expect(names.indexOf('Verify packaged Node runtime')).toBeLessThan(names.indexOf('Publish to npm'))
     expect(names.indexOf('Publish to npm')).toBeLessThan(names.indexOf('Verify npm publication'))


### PR DESCRIPTION
Linear: https://linear.app/orchid-automation/issue/PLUXX-322/prepare-pluxx-v0132-patch-release

## Summary
- prepare @orchid-labs/pluxx 0.1.32 from the nine merged audit remediations
- refresh canonical release, planning, proof claims, and current receipts without promoting historical evidence
- make the proof gate safe for the exact tag-triggered publish transition while preserving strict ordinary validation
- make generated-installer release tests hermetic against ambient config, reused workspaces, and sandbox temp policy
- handle OpenCode companion moves across filesystem boundaries via transactional EXDEV fallback
- stop at release PR readiness; no merge, tag, publish, or archive work is included

## Verification
- fresh npm ci
- focused proof/package/release checks: passed
- exact npm test -- --run tests/publish.test.ts: 44/44 passed
- final combined-head npm run release:check: exit 0; 61 files and 753/753 tests passed, packed Node runtime verification passed, dry-run package produced @orchid-labs/pluxx@0.1.32 (192 files, 707.9 kB)
- GitHub CI on c75e586cb35d2d95e784a6fe9055cdbe1286c5cf: verify passed in 11m40s; verify-node-runtime passed in 33s
- Blocks PR Review on c75e586cb35d2d95e784a6fe9055cdbe1286c5cf: passed in 16m27s; no actionable threads remain
- CE code/doc/release review: all actionable findings resolved

## Release boundary
The coordinator owns merge, v0.1.32 tag, npm/GitHub publishing, public tarball/CLI verification, and task archival.

## External gate note
GitHub reports MERGEABLE but UNSTABLE solely because Orchid Merge Gate timed out at 14m1s while Blocks was still running; Blocks completed successfully about 1m40s later. The stale risk label is removed. Supported same-head command and settled enrollment retriggers did not create a replacement check.