### PR TITLE
fix(release): recover v0.1.32 publication safely

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,13 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing release tag to recover from the trusted main workflow
+        required: true
+        default: v0.1.32
+        type: string
 
 permissions:
   contents: write
@@ -16,6 +23,9 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v5
@@ -29,9 +39,40 @@ jobs:
       - name: Resolve release version
         id: version
         shell: bash
+        env:
+          REQUESTED_RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
         run: |
           set -euo pipefail
-          TAG_NAME="${GITHUB_REF_NAME}"
+          TAG_NAME="${REQUESTED_RELEASE_TAG}"
+
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && "${GITHUB_REF}" != "refs/heads/main" ]]; then
+            echo "Release recovery must be dispatched from main so workflow code is trusted." >&2
+            exit 1
+          fi
+          if [[ ! "${TAG_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release tag ${TAG_NAME} must use vX.Y.Z format." >&2
+            exit 1
+          fi
+          if ! git show-ref --verify --quiet "refs/tags/${TAG_NAME}"; then
+            echo "Release tag ${TAG_NAME} does not exist." >&2
+            exit 1
+          fi
+
+          TAG_COMMIT="$(git rev-parse "${TAG_NAME}^{commit}")"
+          HEAD_COMMIT="$(git rev-parse HEAD)"
+          if [[ "${TAG_COMMIT}" != "${HEAD_COMMIT}" ]]; then
+            echo "Checked-out commit ${HEAD_COMMIT} does not match ${TAG_NAME} commit ${TAG_COMMIT}." >&2
+            exit 1
+          fi
+
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            TRUSTED_MAIN_COMMIT="$(git rev-parse "${GITHUB_SHA}^{commit}")"
+            if ! git merge-base --is-ancestor "${TAG_COMMIT}" "${TRUSTED_MAIN_COMMIT}"; then
+              echo "Release tag ${TAG_NAME} is not contained in trusted main commit ${TRUSTED_MAIN_COMMIT}." >&2
+              exit 1
+            fi
+          fi
+
           PACKAGE_VERSION="$(node -p "require('./package.json').version")"
 
           if [ "${TAG_NAME#v}" != "${PACKAGE_VERSION}" ]; then
@@ -40,10 +81,11 @@ jobs:
           fi
 
           echo "package_version=${PACKAGE_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "release_tag=${TAG_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Run release checks
         env:
-          PLUXX_RELEASE_TAG: ${{ github.ref_name }}
+          PLUXX_RELEASE_TAG: ${{ steps.version.outputs.release_tag }}
         run: npm run release:check
 
       - name: Pack release tarball
@@ -103,6 +145,7 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v3
         with:
+          tag_name: ${{ steps.version.outputs.release_tag }}
           generate_release_notes: true
           files: ${{ steps.pack.outputs.package_file }}
           name: v${{ steps.version.outputs.package_version }}

--- a/docs/orchid/plans/2026-07-13-pluxx-322-release-recovery.md
+++ b/docs/orchid/plans/2026-07-13-pluxx-322-release-recovery.md
@@ -1,0 +1,62 @@
+---
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+product_contract_source: linear-pluxx-322
+linear_issue: PLUXX-322
+created: 2026-07-13
+---
+
+# PLUXX-322 v0.1.32 Release Recovery
+
+## Goal capsule
+
+Recover the existing immutable `v0.1.32` release after GitHub Actions run `29223240724` failed before publication because shallow checkout made proof receipt commit `f2b7cd4` unreachable. Preserve the tag at release merge `188527eb03b2ad31d3536ba461aef73ae3315649`; the coordinator owns merge and dispatch.
+
+## Requirements
+
+- R1. Release checkout fetches full history so committed proof receipts remain reachable.
+- R2. Normal `v*` tag pushes keep using the existing release pipeline.
+- R3. A required `workflow_dispatch` input selects an existing semver release tag while workflow code is dispatched from `main`.
+- R4. Both trigger paths resolve one tag, verify it exists, verify checkout identity, match `package.json`, and pass that tag to `release:check` and GitHub Release creation.
+- R5. Recovery dispatch rejects a tag outside the trusted `main` history.
+- R6. No task action moves a tag, publishes locally, dispatches the workflow, merges, archives, or force-pushes.
+
+## Scope boundaries
+
+- Do not change package or installer behavior.
+- Do not weaken proof freshness or npm provenance checks.
+- Do not claim npm or GitHub publication before the coordinator completes and verifies the recovery run.
+- Do not create a second release pipeline; reuse the existing ordered check, pack, publish, and verification steps.
+
+## Implementation units
+
+### U1. Hermetic tag resolution
+
+Add full-history checkout and one resolved-tag output shared by tag-push and manual recovery triggers. Validate trigger/ref, tag format and existence, checked-out commit identity, trusted-main ancestry for dispatch, and package version.
+
+### U2. Pipeline reuse
+
+Pass the resolved tag to `PLUXX_RELEASE_TAG` and `softprops/action-gh-release` while leaving the existing release-check, npm reconciliation, provenance, and artifact verification order intact.
+
+### U3. Proof and review
+
+Add focused workflow tests, update only affected release/proof/planning truth, run the focused suite and full `npm run release:check`, then complete CE code/doc/release review.
+
+### U4. Recovery PR
+
+Commit and push `codex/pluxx-0.1.32-release-recovery`, open a ready PLUXX-322-linked PR, add `ai:autofix-enabled`, and monitor substantive CI/review to green without merging or dispatching.
+
+## Verification contract
+
+- Focused release-workflow and proof-freshness tests.
+- `PLUXX_RELEASE_TAG=v0.1.32 npm run release:check` from full repository history.
+- CE code/doc/release review with no actionable residuals.
+- Ready recovery PR with current-head CI and Blocks review green.
+
+## Definition of done
+
+- The recovery workflow is safe for the existing tag and unchanged for future tag pushes.
+- Canonical docs distinguish tag existence from successful public publication.
+- PLUXX-322, PLUXX-312, and the project link the recovery PR and exact proof.
+- Coordinator receives a no-merge/no-dispatch/no-publish handoff.

--- a/docs/proof-and-install.md
+++ b/docs/proof-and-install.md
@@ -208,7 +208,7 @@ curl -fsSL https://raw.githubusercontent.com/orchidautomation/pluxx/main/example
 
 Current release note:
 
-- the canonical repository version is `@orchid-labs/pluxx@0.1.32` in release prep with expected tag `v0.1.32`; the historical published baseline remains 0.1.31 until the coordinator completes the release workflow
+- the canonical repository version is `@orchid-labs/pluxx@0.1.32`, tagged as `v0.1.32` at `188527e`; the first release run did not publish npm or create a GitHub release, so the historical published baseline remains 0.1.31 until recovery completes
 - the published CLI runtime is Node `>=18`; see [runtime contract](./runtime-contract.md)
 - the published package includes the Claude plugin-agent manifest fix and packaged Node runtime verification
 - the public `pluxx test --install --trust --behavioral` path now matches the repo-local Exa proof state

--- a/docs/proof-freshness.md
+++ b/docs/proof-freshness.md
@@ -10,7 +10,7 @@ Current reviewed receipts for v0.1.32 are `v0.1.32-repository-validation` (`bund
 
 - `package.json` is the canonical repository version.
 - The expected release tag is `v<packageVersion>`.
-- `releaseState` is `released` when that tag exists and `release-prep` when it does not. Release-prep docs must not describe the pending version as already released.
+- `releaseState` is `released` when that tag exists and `release-prep` when it does not. This field records immutable tag state, not successful npm or GitHub publication; public release claims still require publication verification. Release-prep docs must not describe the pending version as already tagged or released.
 - Unit, bundle-contract, and fake-home receipts are current only when their package version matches `package.json` and their tested commit is reachable from the current branch.
 - Installed-runtime and real-host receipts must also be 30 days old or newer. Older environment evidence is historical even when its package version still matches.
 - Historical receipts remain available, but canonical current-proof claims must label them historical and may not use them as current compatibility evidence.

--- a/docs/proof-manifest.json
+++ b/docs/proof-manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "canonicalVersion": "0.1.32",
   "expectedTag": "v0.1.32",
-  "releaseState": "release-prep",
+  "releaseState": "released",
   "policy": {
     "environmentReceiptMaxAgeDays": 30
   },

--- a/docs/release-distribution-proof-map.md
+++ b/docs/release-distribution-proof-map.md
@@ -26,7 +26,7 @@ Last updated: 2026-07-12
 
 This is the short release/distribution map for what Pluxx can ship today, what is locally proven, and what still belongs to later marketplace or trust-layer work.
 
-Proof state is governed by [proof-freshness.md](./proof-freshness.md) and the machine-readable [proof manifest](./proof-manifest.json). The canonical repository version is `0.1.32` in release prep with expected tag `v0.1.32`; the historical published baseline remains 0.1.31 until the coordinator completes the release workflow. Older environment runs linked below are historical unless a current receipt says otherwise.
+Proof state is governed by [proof-freshness.md](./proof-freshness.md) and the machine-readable [proof manifest](./proof-manifest.json). The canonical repository version is `0.1.32`, tagged as `v0.1.32` at `188527e`; the first release run failed before npm publication or GitHub release creation, so the historical published baseline remains 0.1.31 until recovery completes. Older host runs linked below are historical unless a current receipt says otherwise.
 
 ## Current Primary Fronts
 

--- a/docs/releasing-pluxx.md
+++ b/docs/releasing-pluxx.md
@@ -18,6 +18,8 @@ When you push a tag like `v0.1.1`, GitHub Actions will:
 
 That means GitHub pushes do **not** update npm by themselves. Only a versioned tag release does.
 
+The workflow also has a maintainer-only recovery dispatch for an existing release tag. Dispatch it from the `main` workflow ref and provide the existing `vX.Y.Z` tag. The workflow checks out that tag with full history, verifies that it exists, resolves to the checked-out commit, belongs to the trusted `main` history, and matches `package.json`, then runs the same release-check, pack, publish, and verification pipeline used by a normal tag push. It does not create or move tags.
+
 Do not publish this package from a local shell. The package lifecycle now refuses local `npm publish` and only allows the trusted GitHub release workflow on a matching `vX.Y.Z` tag. This keeps npm provenance intact and avoids depending on local npm auth.
 
 That package-release rule is separate from `pluxx publish`, which packages a user's built plugin bundles and generated installers for distribution.
@@ -66,6 +68,8 @@ git tag v0.1.1
 git push origin v0.1.1
 ```
 
+If the trusted release workflow fails before publication for a recoverable infrastructure reason, do not move or recreate the tag and do not publish locally. Merge a reviewed workflow fix to `main`, then dispatch `Release` from `main` with the existing tag. The default recovery input is currently `v0.1.32`.
+
 You can use `patch`, `minor`, or `major` depending on the release.
 
 ## Runtime Cost Guard
@@ -94,6 +98,8 @@ Check:
 The workflow intentionally fails if:
 
 - the tag does not match `package.json` version
+- a recovery dispatch does not run from `main`
+- the requested recovery tag is missing, malformed, not checked out, or not contained in trusted `main` history
 - `npm run release:check` fails
 - npm auth is not configured correctly
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -82,7 +82,7 @@ The full v0.1.31 audit-remediation tranche is merged. Main now includes safer in
 
 Proof governance now distinguishes unit, bundle-contract, fake-home install, installed-runtime, and real-host behavior evidence. Canonical version/freshness checks run in CI through [proof-freshness.md](./proof-freshness.md) and [proof-manifest.json](./proof-manifest.json); historical April/May proof stays available without being treated as current.
 
-The active audit closeout slice is PLUXX-322: prepare the focused 0.1.32 release PR from exact merged main, create fresh repository-owned proof, and reach GitHub CLEAN. Merge, tag, publish, public artifact verification, and archive remain coordinator-owned.
+The active audit closeout slice is PLUXX-322 release recovery. The 0.1.32 release PR is merged and immutable tag `v0.1.32` exists at `188527e`, but the first release run failed before publication because its shallow checkout could not reach the proof receipt commit. The focused recovery PR restores full history and a controlled existing-tag dispatch; merge, dispatch, public artifact verification, and archive remain coordinator-owned.
 
 ### 1. Product clarity and source-of-truth coherence
 
@@ -228,7 +228,7 @@ The closure plan is now narrower than it was before:
 - historical release-gate evidence from 2026-05-19 remains available but is not current proof:
   - `npm test` passed
   - `npm run release:check` passed
-- the canonical repository version is `@orchid-labs/pluxx@0.1.32` in release prep with expected tag `v0.1.32`; the historical published baseline remains 0.1.31
+- the canonical repository version is `@orchid-labs/pluxx@0.1.32`, tagged as `v0.1.32` at `188527e`; the historical published baseline remains 0.1.31 while release recovery is pending
 - the release/distribution/proof boundary is now explicit:
   - [docs/release-distribution-proof-map.md](./release-distribution-proof-map.md)
   - [docs/core-four-primitive-proof-ledger.md](./core-four-primitive-proof-ledger.md)
@@ -388,14 +388,14 @@ This is for learning and proof, not for prematurely building the full trust laye
 
 ### 6. Next release
 
-The canonical repository version is `0.1.32` in release prep with expected tag `v0.1.32`; the historical published baseline remains 0.1.31. Current repository-validation and fake-home-install receipts were regenerated from committed 0.1.32 state after the complete release gate passed; historical 0.1.31 proof was not carried forward as current.
+The canonical repository version is `0.1.32`, and immutable tag `v0.1.32` exists at `188527e`; the historical published baseline remains 0.1.31. The first release run failed before npm publication or GitHub release creation because its shallow checkout could not reach the current receipt commit. Current repository-validation and fake-home-install receipts remain tied to committed 0.1.32 state; historical 0.1.31 proof was not carried forward as current.
 
 The next npm cut should stay primarily an operations step rather than a code-confidence rescue step.
 
 - prepare and review the 0.1.32 package, proof, and source-of-truth changes in PLUXX-322
 - run targeted proof/version/release checks, official serial `npm test`, and `npm run release:check`
-- merge the release-prep PR after GitHub reports CLEAN
-- push `v0.1.32` to trigger the GitHub Actions publish workflow
+- merge the focused recovery PR after substantive checks and review are green
+- dispatch the existing `v0.1.32` tag through the trusted main workflow without moving or recreating it
 - verify the npm package version, GitHub release, attached tarball, and CLI after the workflow completes
 
 ## What This Roadmap Is Optimizing For

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -39,7 +39,7 @@ If you want the shortest public proof and install path after this file, use [doc
 
 If you want the current release, distribution, and proof boundary, use [docs/release-distribution-proof-map.md](./release-distribution-proof-map.md).
 
-If you need to know whether a proof claim is current, historical, repository-only, installed, or real-host evidence, use [docs/proof-freshness.md](./proof-freshness.md) and [docs/proof-manifest.json](./proof-manifest.json). Canonical repository version truth is `package.json` (`0.1.32`) with expected tag `v0.1.32`; this branch is release prep, not proof that the tag or public release exists.
+If you need to know whether a proof claim is current, historical, repository-only, installed, or real-host evidence, use [docs/proof-freshness.md](./proof-freshness.md) and [docs/proof-manifest.json](./proof-manifest.json). Canonical repository version truth is `package.json` (`0.1.32`), and tag `v0.1.32` exists at `188527e`; the failed first release run did not publish npm or create the GitHub release.
 
 If you want the primitive-by-host proof ledger behind the core-four native shipping claim, use [docs/core-four-primitive-proof-ledger.md](./core-four-primitive-proof-ledger.md).
 
@@ -99,7 +99,7 @@ The goal of this layer is simple:
 
 The CLI is the engine, but the self-hosted Pluxx plugin is part of the real product surface for average users.
 
-All nine PLUXX-313 through PLUXX-321 audit remediations are merged. The combined 0.1.32 release-prep state now includes safer ingestion and replay records, fail-closed Autopilot recovery and Agent Mode boundaries, stronger semantic evaluation and translation/YAML truth, atomic authoring/build mutations, transactional ownership-aware installs, release integrity/recovery, and proof freshness governance. These repository claims do not prove that v0.1.32 has been tagged or published.
+All nine PLUXX-313 through PLUXX-321 audit remediations are merged. The combined 0.1.32 tagged state now includes safer ingestion and replay records, fail-closed Autopilot recovery and Agent Mode boundaries, stronger semantic evaluation and translation/YAML truth, atomic authoring/build mutations, transactional ownership-aware installs, release integrity/recovery, and proof freshness governance. Tag existence does not prove npm publication or a GitHub release; both remain unverified after the failed first release run.
 
 That means near-term product quality is not only about compiler depth.
 It is also about making the plugin-guided path feel obvious, safe, and understandable on top of the same CLI truth.
@@ -369,7 +369,7 @@ The repo already proves a lot.
 - historical release-gate evidence from 2026-05-19 remains available but is not current proof:
   - `npm test` passed
   - `npm run release:check` passed
-- the canonical repository version is `@orchid-labs/pluxx@0.1.32` in release prep with expected tag `v0.1.32`; the historical published baseline remains 0.1.31
+- the canonical repository version is `@orchid-labs/pluxx@0.1.32`, tagged as `v0.1.32` at `188527e`; the historical published baseline remains 0.1.31 while release recovery is pending
 - marketplace submission APIs, a managed trust/distribution control plane, automatic rollback/unpublish orchestration, and real authenticated publish plus rollback proof remain explicit release gaps, not hidden shipped capabilities:
   - `docs/release-distribution-proof-map.md`
   - “automatic rollback” here means remote release rollback/unpublish; generated local installers now restore the prior bundle when staged setup fails
@@ -539,9 +539,9 @@ Run two lanes in parallel:
 
 ### 6. Release State
 
-The canonical repository version is `0.1.32` in release prep with expected tag `v0.1.32`. The historical published baseline remains 0.1.31 until the coordinator merges this release PR, pushes the tag, and verifies public artifacts. `package.json` is the source of truth for repository docs, while [proof-manifest.json](./proof-manifest.json) records release state and whether evidence is current or historical.
+The canonical repository version is `0.1.32`, and tag `v0.1.32` exists at `188527e`. The first release run failed before npm publication or GitHub release creation because its shallow checkout could not reach the receipt commit. The historical published baseline remains 0.1.31 until the coordinator merges the recovery PR, dispatches the existing tag through the trusted main workflow, and verifies public artifacts. `package.json` is the source of truth for repository docs, while [proof-manifest.json](./proof-manifest.json) records tag state and proof freshness.
 
-For v0.1.32, finish review and reach GitHub `CLEAN`, merge the focused release PR, push `v0.1.32`, then verify npm, GitHub, the published tarball, and CLI behavior. Future releases should repeat the version bump and release-prep proof work on a focused PR before tagging.
+For v0.1.32, finish review and reach substantive green, merge the focused recovery PR, dispatch the existing `v0.1.32` tag through the trusted workflow, then verify npm, GitHub, the published tarball, and CLI behavior. Do not move or recreate the tag. Future releases should repeat the version bump and release-prep proof work on a focused PR before tagging.
 
 ## Working Rules
 

--- a/docs/todo/master-backlog.md
+++ b/docs/todo/master-backlog.md
@@ -82,14 +82,15 @@ Any person or agent should be able to enter the repo and answer:
 
 Proof governance is now explicit: [proof-freshness.md](../proof-freshness.md) defines the five evidence tiers and freshness rules, while [proof-manifest.json](../proof-manifest.json) keeps machine-readable receipts and current/historical claim state aligned with `package.json`.
 
-### 0. v0.1.32 release preparation
+### 0. v0.1.32 release recovery
 
 - [x] Merge all nine PLUXX-313 through PLUXX-321 audit-remediation PRs into main at `f92e3cc`
 - [x] Prepare 0.1.32 in PLUXX-322 with synchronized package, proof, planning, and release truth
 - [x] Generate fresh repository-validation and fake-home-install receipts from committed 0.1.32 state
 - [x] Pass the official 751/751 serial suite and complete release gate
-- [ ] Reach a ready, autofix-enabled, GitHub-CLEAN release PR with no actionable review threads
-- [ ] Coordinator: merge, tag v0.1.32, verify npm/GitHub/tarball/CLI, then archive the completed batch
+- [x] Merge the release PR and push immutable tag `v0.1.32` at `188527e`
+- [ ] Merge the focused workflow-recovery PR after substantive checks and review are green
+- [ ] Coordinator: dispatch the existing tag through the trusted main workflow, verify npm/GitHub/tarball/CLI, then archive the completed batch
 
 ### 1. Product clarity and front-door coherence
 
@@ -448,11 +449,11 @@ Open work:
 ### 7. Next release readiness
 
 - [x] Merge the nine v0.1.31 audit-remediation PRs
-- [~] Prepare the focused v0.1.32 release PR under PLUXX-322
+- [x] Prepare and merge the focused v0.1.32 release PR under PLUXX-322
 - [x] Refresh current repository/fake-home receipts from committed 0.1.32 state
 - [x] Pass targeted checks, official serial 751/751 `npm test`, and `npm run release:check`
-- [ ] Merge the release-prep PR to `main`
-- [ ] Push `v0.1.32` so the GitHub Actions release workflow publishes to npm
+- [x] Merge the release-prep PR and push `v0.1.32` at `188527e`
+- [ ] Merge the workflow-recovery PR, then dispatch the existing tag through the trusted main workflow
 - [ ] Verify `@orchid-labs/pluxx@0.1.32`, GitHub release assets, tarball contents, and CLI behavior
 
 ## Next

--- a/docs/todo/queue.md
+++ b/docs/todo/queue.md
@@ -55,7 +55,7 @@ For broader context, use:
 
 ## Current Truth
 
-All nine PLUXX-313 through PLUXX-321 audit remediations are merged into main at `f92e3cc`. PLUXX-322 now owns the focused 0.1.32 release-prep PR; the coordinator retains merge, tag, publish, public artifact verification, and archive ownership.
+All nine PLUXX-313 through PLUXX-321 audit remediations are merged, and the 0.1.32 release PR is merged at `188527e`. Tag `v0.1.32` exists there, but the first release run failed before npm publication or GitHub release creation because its checkout could not reach the proof receipt commit. PLUXX-322 now owns the focused workflow-recovery PR; the coordinator retains merge, recovery dispatch, public artifact verification, and archive ownership.
 
 The core-four compiler sprint is done.
 
@@ -188,7 +188,7 @@ The initial author-once hardening tranche is also materially done.
 The public baseline is also real.
 
 - npm package is live as `@orchid-labs/pluxx`
-- the canonical repository version is `@orchid-labs/pluxx@0.1.32` in release prep with expected tag `v0.1.32`; the historical published baseline remains 0.1.31
+- the canonical repository version is `@orchid-labs/pluxx@0.1.32`, tagged as `v0.1.32` at `188527e`; the historical published baseline remains 0.1.31 while recovery is pending
 - proof claims now use [docs/proof-freshness.md](../proof-freshness.md) and [docs/proof-manifest.json](../proof-manifest.json) so historical host runs cannot masquerade as current evidence
 - published CLI runtime is Node `>=18`
 - published CLI lifecycle ergonomics are now stronger for global installs:
@@ -495,21 +495,22 @@ Open work:
   - native bundles across the core four
   - install verification and truthful compatibility
 
-### 6. v0.1.32 release preparation
+### 6. v0.1.32 release recovery
 
 Current work:
 
-- [~] PLUXX-322 prepares the focused release PR from exact post-audit main `f92e3cc`
+- [x] PLUXX-322 prepared and merged the focused release PR at `188527e`
 - [x] bump `package.json` and `package-lock.json` to 0.1.32
 - [x] refresh canonical release, planning, and proof truth without carrying old evidence forward as current
 - [x] generate fresh repository-validation and fake-home-install receipts from committed 0.1.32 state
 - [x] pass the official serial 751/751 suite and `npm run release:check`
-- [ ] reach a ready, autofix-enabled, GitHub-CLEAN PR with no actionable review threads
+- [x] push immutable tag `v0.1.32` at `188527e`
+- [ ] merge the focused workflow-recovery PR after substantive checks and review are green
 
 Coordinator-owned after this task:
 
-- merge the release PR
-- push `v0.1.32`
+- merge the workflow-recovery PR
+- dispatch the existing `v0.1.32` tag through the trusted main workflow without moving or recreating it
 - monitor publishing and verify npm, GitHub, tarball, and CLI surfaces
 - archive completed tasks
 

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -9,6 +9,48 @@ const releaseWorkflow = readFileSync(resolve(ROOT, '.github/workflows/release.ym
 const ciWorkflow = readFileSync(resolve(ROOT, '.github/workflows/ci.yml'), 'utf-8')
 
 describe('release workflow', () => {
+  it('supports a controlled full-history recovery dispatch for an existing release tag', () => {
+    const workflow = parse(releaseWorkflow) as {
+      on: {
+        push: { tags: string[] }
+        workflow_dispatch: {
+          inputs: { release_tag: { required: boolean; default: string; type: string } }
+        }
+      }
+      jobs: {
+        publish: {
+          steps: Array<{
+            name?: string
+            uses?: string
+            run?: string
+            env?: Record<string, string>
+            with?: Record<string, string | number>
+          }>
+        }
+      }
+    }
+    const checkout = workflow.jobs.publish.steps.find((step) => step.name === 'Check out repository')
+    const version = workflow.jobs.publish.steps.find((step) => step.name === 'Resolve release version')
+    const release = workflow.jobs.publish.steps.find((step) => step.name === 'Create GitHub release')
+
+    expect(workflow.on.push.tags).toEqual(['v*'])
+    expect(workflow.on.workflow_dispatch.inputs.release_tag).toEqual({
+      description: 'Existing release tag to recover from the trusted main workflow',
+      required: true,
+      default: 'v0.1.32',
+      type: 'string',
+    })
+    expect(checkout?.with?.['fetch-depth']).toBe(0)
+    expect(checkout?.with?.ref).toBe("${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref }}")
+    expect(version?.env?.REQUESTED_RELEASE_TAG).toBe("${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}")
+    expect(version?.run).toContain('Release recovery must be dispatched from main')
+    expect(version?.run).toContain('git show-ref --verify --quiet "refs/tags/${TAG_NAME}"')
+    expect(version?.run).toContain('git merge-base --is-ancestor "${TAG_COMMIT}" "${TRUSTED_MAIN_COMMIT}"')
+    expect(version?.run).toContain('Checked-out commit ${HEAD_COMMIT} does not match ${TAG_NAME} commit ${TAG_COMMIT}.')
+    expect(version?.run).toContain('echo "release_tag=${TAG_NAME}" >> "$GITHUB_OUTPUT"')
+    expect(release?.with?.tag_name).toBe('${{ steps.version.outputs.release_tag }}')
+  })
+
   it('uses GitHub Actions runtime versions that avoid the Node 20 deprecation path', () => {
     expect(releaseWorkflow).toMatch(/uses:\s+actions\/checkout@v5/)
     expect(releaseWorkflow).toMatch(/uses:\s+actions\/setup-node@v5/)
@@ -37,7 +79,7 @@ describe('release workflow', () => {
     }
     const names = workflow.jobs.publish.steps.map((step) => step.name)
     const releaseCheck = workflow.jobs.publish.steps.find((step) => step.name === 'Run release checks')
-    expect(releaseCheck?.env?.PLUXX_RELEASE_TAG).toBe('${{ github.ref_name }}')
+    expect(releaseCheck?.env?.PLUXX_RELEASE_TAG).toBe('${{ steps.version.outputs.release_tag }}')
     expect(names.indexOf('Pack release tarball')).toBeLessThan(names.indexOf('Verify packaged Node runtime'))
     expect(names.indexOf('Verify packaged Node runtime')).toBeLessThan(names.indexOf('Publish to npm'))
     expect(names.indexOf('Publish to npm')).toBeLessThan(names.indexOf('Verify npm publication'))


### PR DESCRIPTION
## Summary

- recover the existing immutable v0.1.32 tag after Release run 29223240724 failed before npm publication or GitHub release creation
- fetch full history so proof receipt commit f2b7cd4 is reachable
- add a controlled main-only recovery dispatch for an existing semver tag
- verify tag existence, checked-out identity, trusted-main ancestry, and package version before reusing the existing release pipeline
- pass the resolved tag to release:check and GitHub Release creation while preserving normal tag-push behavior

## Safety boundary

- does not move, recreate, or delete v0.1.32
- does not publish locally or dispatch the workflow
- keeps npm provenance and the existing check, pack, publish, and verification order
- coordinator owns merge, recovery dispatch, and public artifact verification

## Proof

- npm test -- --run tests/release-workflow.test.ts tests/proof-freshness.test.ts: 18/18 passed
- PLUXX_RELEASE_TAG=v0.1.32 npm run proof:check: 6 claims and 6 receipts passed
- PLUXX_RELEASE_TAG=v0.1.32 npm run release:check: exit 0; 61 files and 754 tests passed; installed-package runtime verification passed; dry-run tarball contained 192 files at 707.9 kB

## Tracking

[PLUXX-322](https://linear.app/orchid-automation/issue/PLUXX-322)
