### PR TITLE
fix(migrate): make mature plugin intake transactional

### DIFF
--- a/docs/orchid/plans/2026-07-14-pluxx-324-transactional-migrate.md
+++ b/docs/orchid/plans/2026-07-14-pluxx-324-transactional-migrate.md
@@ -1,0 +1,102 @@
+---
+title: PLUXX-324 Transactional Mature-Plugin Migration - Plan
+type: fix
+date: 2026-07-14
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: linear-pluxx-324
+execution: code
+origin: docs/orchid/requirements/2026-07-13-compound-engineering-primitive-audit.md
+---
+
+# PLUXX-324 Transactional Mature-Plugin Migration - Plan
+
+## Goal Capsule
+
+Make `pluxx migrate` publish a schema-valid canonical project or fail before changing the destination. PLUXX-324 is authoritative. Orchestration IR, generators, installs, releases, new hosts, and remote repository operations are out of scope.
+
+## Product Contract
+
+### Requirements
+
+- **R1:** Validate the complete staged project with the current Pluxx config loader/schema before publication.
+- **R2:** Validation or reconciliation failure publishes no new or partially replaced destination files.
+- **R3:** Reproduce and fix the pinned Compound Engineering 3.19.0 `brand.displayName` false-success.
+- **R4:** Discover all recognized manifests in deterministic order and merge compatible canonical truth.
+- **R5:** Refuse conflicting scalar truth with a diagnostic naming the field and source manifests.
+- **R6:** Persist deterministic manifest and field provenance in a migration receipt.
+- **R7:** Preserve existing single-host, dry-run, collision, and rollback behavior.
+- **R8:** Synchronize migration truth in repo docs and Linear.
+
+### Acceptance Examples
+
+- The pinned CE fixture combines Claude, Cursor, and Codex metadata, loads successfully, and records all manifest sources.
+- Conflicting descriptions fail with both manifest paths and leave the destination unchanged.
+- Invalid staged config fails in dry-run and apply before destination mutation.
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- **KTD1:** Replace first-match manifest selection with fixed-order discovery; keep a primary platform only for existing adjunct parsing.
+- **KTD2:** Require identity-scalar agreement, stable-union arrays, and resolve brand scalars with explicit `opencode < claude-code < cursor < codex` precedence; refuse identity ambiguity.
+- **KTD3:** Parse every manifest under its own platform rules so Codex/Cursor metadata survives a Claude primary source.
+- **KTD4:** Reuse `loadConfig(stagedRoot)` as schema authority and `applyFileMutations` as the publication transaction.
+- **KTD5:** Write the same versioned provenance to the migration receipt and machine-readable summary, including policy, chosen field sources, and all candidates.
+- **KTD6:** Commit a bounded CE fixture with upstream SHA provenance rather than vendoring the full plugin.
+
+## Implementation Units
+
+### U1. Add failing migration contracts
+
+**Requirements:** R1-R7
+
+**Files:** `tests/migrate.test.ts`, `tests/fixtures/compound-engineering-3.19.0/**`
+
+**Approach:** Add the CE regression, ambiguity refusal, receipt, and no-publication tests; run them before implementation.
+
+**Test Scenarios:** CE brand enrichment and valid load; deterministic receipt; conflicting field names both manifests; invalid staged config leaves no output.
+
+**Verification:** `bun test tests/migrate.test.ts`
+
+### U2. Reconcile manifests and validate the stage
+
+**Requirements:** R1-R7
+
+**Files:** `src/cli/migrate.ts`, `tests/migrate.test.ts`
+
+**Approach:** Discover and reconcile recognized manifests with provenance, generate the receipt, then load the staged config before mutation planning/application.
+
+**Test Scenarios:** fixed discovery order; equal-value provenance; keyword union; host metadata merge; deterministic conflict diagnostics; single-host compatibility; apply/dry-run validity gate.
+
+**Verification:** `bun test tests/migrate.test.ts tests/fs-transaction.test.ts tests/schema.test.ts`
+
+### U3. Synchronize truth and close out locally
+
+**Requirements:** R8
+
+**Files:** `docs/start-here.md`, `docs/todo/queue.md`, `docs/todo/master-backlog.md`, `docs/roadmap.md`, `docs/orchid/requirements/2026-07-13-compound-engineering-primitive-audit.md`, `docs/orchid/reviews/2026-07-14-pluxx-324-review.md`
+
+**Approach:** Record local Phase 0 behavior and proof while keeping Phase 1 unshipped; update PLUXX-324 and its parent execution index.
+
+**Verification:** focused tests, full gates, independent CE review, and reviewer subagent.
+
+## Verification Contract
+
+1. Red proof: `bun test tests/migrate.test.ts`.
+2. Focused: `bun test tests/migrate.test.ts tests/fs-transaction.test.ts tests/schema.test.ts`.
+3. Manual pinned CE source after verifying SHA `f871e4b4308f5a175b38ccada51d80dd67bab4fc`.
+4. Full gates: `npm test`, `npm run typecheck`, `npm run build`.
+5. `package.json` has no repository lint script; report that explicitly.
+6. Run `ce-code-review`, then the required reviewer subagent, and rerun affected gates.
+
+## Definition of Done
+
+- R1-R8 are implemented and proven.
+- CE fails on baseline behavior and passes after the fix.
+- Identity conflicts are refused; supported brand conflicts follow the recorded host-precedence policy.
+- Validation precedes publication in dry-run and apply.
+- Focused and full gates pass.
+- Docs and Linear reflect local Phase 0 truth and the Phase 1 handoff.
+- Review findings are resolved or recorded as residual risk.
+- Local commits exist on `codex/pluxx-324-transactional-migrate`; no remote mutation occurs.

--- a/docs/orchid/requirements/2026-07-13-compound-engineering-primitive-audit.md
+++ b/docs/orchid/requirements/2026-07-13-compound-engineering-primitive-audit.md
@@ -18,7 +18,7 @@ It does preserve the complete Compound Engineering skill tree across all 11 gene
 
 That packaging success explains why an already-Codex-aware Compound Engineering skill can continue to launch agents reliably after being copied. It does not prove that Pluxx can derive or translate the behavior. The orchestration contract remains encoded in prompt prose and is opaque to the compiler.
 
-The most severe import finding is separate: migrating the Compound Engineering repository reported success with zero warnings but emitted an invalid Pluxx config. That means Pluxx cannot currently claim a safe author-once intake path for this class of multi-host plugin.
+The audit's most severe import finding was separate: migrating the Compound Engineering repository reported success with zero warnings but emitted an invalid Pluxx config. PLUXX-324 now closes that Phase 0 defect by reconciling supported manifests with provenance, validating the complete staged project against the current schema, and publishing only after validation succeeds. Broader semantic adjunct and orchestration recovery remain open.
 
 ## Decision Update
 
@@ -160,6 +160,8 @@ The instruction-size warning appears to inspect the source repository's root `AG
 
 `pluxx migrate` was run against the pinned Compound Engineering source in an empty temporary destination.
 
+The findings below describe the original `1c028b4` baseline reproduction. The PLUXX-324 implementation update follows them.
+
 ### What it recovered
 
 - package identity and version
@@ -192,6 +194,21 @@ brand.displayName: Required
 ```
 
 The migrated brand object contains only `websiteURL`. This is a P0 migration correctness gap because downstream build fails after a successful, warning-free intake.
+
+### PLUXX-324 implementation update
+
+Phase 0 now treats mature supported manifests as one reconciled source set instead of selecting the first match:
+
+- Claude, Cursor, Codex, and qualifying OpenCode manifests are discovered in a fixed order
+- compatible identity values merge, keyword catalogs union deterministically, and richer host branding follows recorded `opencode < claude-code < cursor < codex` precedence
+- contradictory canonical identity fields fail with the field and responsible manifest paths
+- malformed secondary manifests name the responsible source path
+- the full staged project loads through the current Pluxx config schema before dry-run success or destination mutation
+- schema or reconciliation failure leaves the destination unchanged
+- a versioned migration receipt and dry-run summary record the resolution policy, primary platform, recognized manifests, chosen field sources, and all candidates
+- non-dry-run migration holds the existing workspace mutation lock across staging, validation, planning, and publication
+
+The pinned Compound Engineering source at `f871e4b4308f5a175b38ccada51d80dd67bab4fc` now migrates to a config with `brand.displayName: Compound Engineering` and a three-manifest provenance receipt. Repository-development instruction classification, release-script classification, non-MCP scaffold semantics, OpenCode/Pi adapter recovery, workflow configuration, and orchestration relationships remain outside this Phase 0 fix.
 
 ## Host Portfolio Delta
 

--- a/docs/orchid/reviews/2026-07-14-pluxx-324-review.md
+++ b/docs/orchid/reviews/2026-07-14-pluxx-324-review.md
@@ -1,0 +1,59 @@
+# PLUXX-324 Phase 0 Review
+
+## Scope
+
+This review covers only transactional, schema-valid migration for mature multi-host plugins. Orchestration IR, generators, installation, releases, host expansion, and distribution remain out of scope.
+
+## Test-First Proof
+
+The initial regression run reproduced three failures before implementation:
+
+- the bounded Compound Engineering fixture produced a config rejected for missing `brand.displayName`
+- conflicting canonical manifest truth was accepted instead of refused
+- schema-invalid staged output returned success instead of failing before publication
+
+The implementation now discovers all recognized manifests, validates the complete staged project, publishes under the workspace mutation lock, and returns the same versioned provenance in the receipt and machine-readable summary.
+
+## Reconciliation Contract
+
+- identity scalars require agreement or migration refuses with field and source paths
+- arrays use deterministic stable union
+- brand scalars use explicit `opencode < claude-code < cursor < codex` precedence
+- provenance records the policy, chosen source for each field, all candidate sources, and all recognized manifests
+- only the primary platform drives existing adjunct parsing; cross-manifest adjunct semantics remain Phase 1 work
+
+## Independent Review
+
+Compound Engineering `ce-code-review` ran in report-only mode with correctness, testing, maintainability, project standards, API contract, reliability, adversarial, agent-native, and learnings lenses. Run artifacts are under `/tmp/compound-engineering/ce-code-review/20260714-1112-pluxx324/`.
+
+Applied findings:
+
+- buffered all generated/success output until validation and publication complete
+- replaced implicit brand overwrites with an explicit policy plus chosen/candidate provenance
+- rejected non-array or non-string manifest keywords with source attribution
+- documented mature multi-host behavior in CLI usage and covered it at the built-CLI boundary
+- returned provenance from successful dry-run JSON paths instead of deleting the only copy with the stage
+- held the workspace mutation lock across the entire non-dry-run migration boundary
+- reused typed identity fields, standard set deduplication, and POSIX receipt paths
+
+The separate simplification pass found no efficiency issues. A proposed extraction from the already-large migration module was not taken because it would broaden this correctness slice into a move-only refactor; the new policy remains localized and typed.
+
+The independent cross-model adversarial helper attempted Anthropic, xAI, and Cursor routes, but none returned usable schema-shaped output. In-process CE adversarial review completed and its concurrency and iterable-field findings were fixed.
+
+The separately requested final reviewer rechecked the complete diff and the replacement clean pinned-source proof, independently passed the 133 focused tests, and reported no remaining actionable P0-P2 findings.
+
+## Validation
+
+- focused migration, filesystem transaction, mutation-lock, schema, built-CLI, and lint regressions: 133 passed
+- full repository suite: 61 files and 762 tests passed
+- TypeScript typecheck: passed
+- build and declaration emission: passed
+- clean pinned full Compound Engineering source at `f871e4b4308f5a175b38ccada51d80dd67bab4fc`: passed with three manifests, schema-valid branding, chosen/candidate provenance, and recorded precedence policy
+- repository has no standalone root lint script; the 56 lint/lint-CLI tests pass
+
+## Residual Risk And Phase 1 Handoff
+
+- the committed CE fixture is deliberately bounded; the exact full pinned checkout is covered by manual proof rather than vendored into the repository
+- source files can change while they are being read; destination publication is locked and transactional, but source snapshot locking is not part of Phase 0
+- secondary-host MCP, hook, instruction, workflow, and orchestration semantics remain primary-host-biased or unrecovered by design
+- the next slice is the PLUXX-323 Phase 1 orchestration IR and compiler contract, using the now-green migration gate as its prerequisite

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -30,6 +30,7 @@ Last updated: 2026-07-14
   - [Orchestration reference-pattern audit](./orchid/requirements/2026-07-14-orchestration-reference-patterns.md)
   - [Accepted orchestration decision](./orchid/decisions/2026-07-14-orchestration-primitive.md)
   - [Compound Engineering parity plan](./orchid/plans/2026-07-13-compound-engineering-parity-plan.md)
+  - [PLUXX-324 transactional migrate plan](./orchid/plans/2026-07-14-pluxx-324-transactional-migrate.md)
   - [Linear](https://linear.app/orchid-automation)
 - Update together:
   - [docs/start-here.md](./start-here.md)
@@ -416,7 +417,7 @@ These matter, but they are not the immediate center:
 
 - use Compound Engineering 3.19.0, Hyperframes, and Superpowers as pinned reference fixtures
 - preserve its reliable Codex skill-owned generic-subagent behavior
-- restore trustworthy migration before expanding the canonical model
+- keep the restored PLUXX-324 migration gate green: deterministic supported-manifest reconciliation, provenance, staged schema validation, and no destination publication on failure
 - implement the accepted ninth `orchestration` bucket without overloading standalone `agents`
 - represent typed artifact dataflow, bounded dispatch, artifact completion, and targeted repair from Hyperframes
 - represent lifecycle activation/re-injection, reachable versus orphaned roles, mandatory gates, durable progress/resume, and review loops from Superpowers

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -25,6 +25,7 @@ Last updated: 2026-07-14
   - [docs/orchid/requirements/2026-07-14-orchestration-reference-patterns.md](./orchid/requirements/2026-07-14-orchestration-reference-patterns.md)
   - [docs/orchid/decisions/2026-07-14-orchestration-primitive.md](./orchid/decisions/2026-07-14-orchestration-primitive.md)
   - [docs/orchid/plans/2026-07-13-compound-engineering-parity-plan.md](./orchid/plans/2026-07-13-compound-engineering-parity-plan.md)
+  - [docs/orchid/plans/2026-07-14-pluxx-324-transactional-migrate.md](./orchid/plans/2026-07-14-pluxx-324-transactional-migrate.md)
   - [docs/orchid/decisions/2026-06-26-pluxx-next-ship-review.md](./orchid/decisions/2026-06-26-pluxx-next-ship-review.md)
   - [docs/pluxx-self-hosted-core-four-proof.md](./pluxx-self-hosted-core-four-proof.md)
   - [README.md](../README.md)
@@ -47,7 +48,7 @@ If you need to know whether a proof claim is current, historical, repository-onl
 
 If you want the primitive-by-host proof ledger behind the core-four native shipping claim, use [docs/core-four-primitive-proof-ledger.md](./core-four-primitive-proof-ledger.md).
 
-If you want the current pressure test for skill-owned subagent orchestration, mature multi-host import, and best-effort output across all 11 generators, use the [Compound Engineering primitive audit](./orchid/requirements/2026-07-13-compound-engineering-primitive-audit.md), [three-reference comparison](./orchid/requirements/2026-07-14-orchestration-reference-patterns.md), [accepted decision](./orchid/decisions/2026-07-14-orchestration-primitive.md), and [phased parity plan](./orchid/plans/2026-07-13-compound-engineering-parity-plan.md). The canonical product direction now has nine buckets, including `orchestration`; the current compiler still implements eight and preserves orchestration mostly as opaque skill content.
+If you want the current pressure test for skill-owned subagent orchestration, mature multi-host import, and best-effort output across all 11 generators, use the [Compound Engineering primitive audit](./orchid/requirements/2026-07-13-compound-engineering-primitive-audit.md), [three-reference comparison](./orchid/requirements/2026-07-14-orchestration-reference-patterns.md), [accepted decision](./orchid/decisions/2026-07-14-orchestration-primitive.md), [phased parity plan](./orchid/plans/2026-07-13-compound-engineering-parity-plan.md), and [PLUXX-324 implementation plan](./orchid/plans/2026-07-14-pluxx-324-transactional-migrate.md). Mature multi-manifest migration now reconciles supported manifests with provenance and validates the complete stage before transactional publication. The canonical product direction still has nine buckets, including `orchestration`; the current compiler implements eight and preserves orchestration mostly as opaque skill content.
 
 ## What Pluxx Is
 
@@ -449,7 +450,7 @@ That includes:
   - [docs/core-four-translation-hit-list.md](./core-four-translation-hit-list.md) now functions mainly as a maintenance and packaging tracker rather than a list of unresolved core row mappings
 - use the Compound Engineering audit as the next mature-plugin pressure test:
   - preserve its reliable Codex generic-subagent behavior
-  - fix warning-free migration that emits invalid canonical config before treating CE-class intake as credible
+  - keep the completed Phase 0 migration gate intact: supported manifests reconcile deterministically, staged schema validation precedes publication, and failures publish nothing
   - implement the accepted `orchestration` bucket without overloading standalone `agents`
   - use Hyperframes to cover typed artifact pipelines, bounded dispatch, completion, and targeted repair
   - use Superpowers to cover lifecycle activation, mandatory gates, progress/resume, and review loops

--- a/docs/todo/master-backlog.md
+++ b/docs/todo/master-backlog.md
@@ -41,6 +41,7 @@ This is not the same thing as the short queue.
   - [Orchestration reference-pattern audit](../orchid/requirements/2026-07-14-orchestration-reference-patterns.md)
   - [Accepted orchestration decision](../orchid/decisions/2026-07-14-orchestration-primitive.md)
   - [Compound Engineering parity plan](../orchid/plans/2026-07-13-compound-engineering-parity-plan.md)
+  - [PLUXX-324 transactional migrate plan](../orchid/plans/2026-07-14-pluxx-324-transactional-migrate.md)
   - [author-once-hardening.md](./author-once-hardening.md)
   - [Linear](https://linear.app/orchid-automation)
 - Update together:
@@ -183,7 +184,7 @@ Proof governance is now explicit: [proof-freshness.md](../proof-freshness.md) de
   - `pluxx build` now checks generated manifests and package outputs for source version drift and missing referenced bundle files before publish
 - [~] Implement the mature-plugin orchestration boundary accepted in [the decision record](../orchid/decisions/2026-07-14-orchestration-primitive.md):
   - preserve the working CE 3.19.0 Codex generic-subagent baseline
-  - fix migrate's warning-free invalid-config result and multi-manifest first-match behavior before claiming CE-class intake
+  - [x] fix migrate's warning-free invalid-config result and multi-manifest first-match behavior with staged schema validation, deterministic reconciliation, provenance, and no-publication failure tests
   - [x] accept `orchestration` as the ninth canonical bucket rather than overloading standalone `agents`
   - model skill-owned specialist roles, dispatch, fan-out, wait/follow-up, synthesis, task/input coordination, workflow modes, and capability fallback
   - model Hyperframes-style typed artifact dataflow, bounded packets, file ownership, completion predicates, and targeted repair

--- a/docs/todo/queue.md
+++ b/docs/todo/queue.md
@@ -28,6 +28,7 @@ Last updated: 2026-07-14
   - [Orchestration reference-pattern audit](../orchid/requirements/2026-07-14-orchestration-reference-patterns.md)
   - [Accepted orchestration decision](../orchid/decisions/2026-07-14-orchestration-primitive.md)
   - [Compound Engineering parity plan](../orchid/plans/2026-07-13-compound-engineering-parity-plan.md)
+  - [PLUXX-324 transactional migrate plan](../orchid/plans/2026-07-14-pluxx-324-transactional-migrate.md)
   - [author-once-hardening.md](./author-once-hardening.md)
   - [Linear](https://linear.app/orchid-automation)
 - Update together:
@@ -233,7 +234,7 @@ Open work:
 - keep [docs/start-here.md](../start-here.md), this queue, the master backlog, and Linear aligned
 - use [the Compound Engineering primitive audit](../orchid/requirements/2026-07-13-compound-engineering-primitive-audit.md), [three-reference comparison](../orchid/requirements/2026-07-14-orchestration-reference-patterns.md), [accepted decision](../orchid/decisions/2026-07-14-orchestration-primitive.md), and [phased parity plan](../orchid/plans/2026-07-13-compound-engineering-parity-plan.md) as the current mature-plugin pressure test:
   - treat CE 3.19.0's reliable Codex generic-subagent workflow as behavior to preserve
-  - pull the warning-free invalid migration result forward as a correctness defect independent of the larger architecture decision
+  - keep PLUXX-324's completed Phase 0 correctness contract covered: reconcile supported manifests with provenance, validate the full stage before publication, and leave destinations unchanged on failure
   - specify the accepted ninth `orchestration` bucket while keeping standalone executable identities in `agents`
   - cover Hyperframes typed artifacts, bounded dispatch, artifact completion, and targeted repair
   - cover Superpowers lifecycle activation/re-injection, role reachability, durable progress/resume, and review loops

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3963,7 +3963,7 @@ async function runMigrate() {
   if (!inputPath) {
     console.error('Usage: pluxx migrate <path> [--dry-run] [--json]')
     console.error('')
-    console.error('  Import an existing single-platform plugin into a pluxx.config.ts.')
+    console.error('  Import an existing single- or multi-host plugin into a pluxx.config.ts.')
     console.error('  Pass the path to a plugin directory containing .claude-plugin/,')
     console.error('  .cursor-plugin/, .codex-plugin/, or a package.json with @opencode-ai/plugin.')
     process.exit(1)

--- a/src/cli/migrate.ts
+++ b/src/cli/migrate.ts
@@ -1,4 +1,4 @@
-import { basename, dirname, relative, resolve } from 'path'
+import { basename, dirname, posix, relative, resolve } from 'path'
 import { existsSync, readdirSync, mkdirSync, mkdtempSync, cpSync, readFileSync, readlinkSync, rmSync, statSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import {
@@ -17,6 +17,8 @@ import { getCanonicalSkillMetadata, parseSkillMarkdown, readCanonicalSkillFiles,
 import { buildNativeMcpPlatformOverrides } from '../mcp-native-overrides'
 import { parseTomlValue, stripTomlComment } from '../toml-lite'
 import { writeTextFile } from '../text-files'
+import { loadConfig } from '../config/load'
+import { withWorkspaceMutationLock } from './mutation-lock'
 import {
   applyFileMutations,
   copyProjectForStaging,
@@ -34,6 +36,18 @@ interface DetectionResult {
   manifestPath?: string
 }
 
+interface ManifestSource {
+  platform: DetectedPlatform
+  path: string
+}
+
+interface ManifestReconciliation {
+  manifest: ParsedManifest
+  sources: ManifestSource[]
+  fieldSources: Record<string, string[]>
+  fieldCandidates: Record<string, string[]>
+}
+
 interface ParsedManifest {
   name?: string
   version?: string
@@ -45,6 +59,8 @@ interface ParsedManifest {
   brand?: Record<string, unknown>
   platforms?: Record<string, Record<string, unknown>>
 }
+
+type ManifestIdentityField = 'name' | 'version' | 'description' | 'repository' | 'license'
 
 interface ParsedMcp {
   [serverName: string]: {
@@ -95,21 +111,26 @@ interface MigrateResult {
   compilerIntent?: CompilerIntentFile
   warnings: string[]
   extraCopyPaths: string[]
+  manifestSources: ManifestSource[]
+  manifestFieldSources: Record<string, string[]>
+  manifestFieldCandidates: Record<string, string[]>
 }
 
 // ── Platform Detection ──────────────────────────────────────────
 
-function detectPlatform(pluginDir: string): DetectionResult | null {
+function detectPlatforms(pluginDir: string): DetectionResult[] {
   const checks: Array<{ dir: string; platform: DetectedPlatform }> = [
     { dir: '.claude-plugin', platform: 'claude-code' },
     { dir: '.cursor-plugin', platform: 'cursor' },
     { dir: '.codex-plugin', platform: 'codex' },
   ]
 
+  const detections: DetectionResult[] = []
+
   for (const check of checks) {
     const manifestPath = resolve(pluginDir, check.dir, 'plugin.json')
     if (existsSync(manifestPath)) {
-      return { platform: check.platform, manifestPath }
+      detections.push({ platform: check.platform, manifestPath })
     }
   }
 
@@ -124,18 +145,18 @@ function detectPlatform(pluginDir: string): DetectionResult | null {
         ...pkg.peerDependencies,
       }
       if (deps && '@opencode-ai/plugin' in deps) {
-        return { platform: 'opencode', manifestPath: pkgPath }
+        detections.push({ platform: 'opencode', manifestPath: pkgPath })
       }
     } catch {
       // not valid JSON, skip
     }
   }
 
-  if (existsSync(resolve(pluginDir, 'CLAUDE.md'))) {
-    return { platform: 'claude-code' }
+  if (detections.length === 0 && existsSync(resolve(pluginDir, 'CLAUDE.md'))) {
+    detections.push({ platform: 'claude-code' })
   }
 
-  return null
+  return detections
 }
 
 // ── Manifest Parsing ────────────────────────────────────────────
@@ -155,7 +176,12 @@ function parseManifest(detection: DetectionResult): ParsedManifest {
   if (raw.version) result.version = raw.version
   if (raw.description) result.description = raw.description
   if (raw.license) result.license = raw.license
-  if (raw.keywords) result.keywords = raw.keywords
+  if (raw.keywords !== undefined) {
+    if (!Array.isArray(raw.keywords) || !raw.keywords.every((value: unknown) => typeof value === 'string')) {
+      throw new Error('keywords must be an array of strings')
+    }
+    result.keywords = raw.keywords
+  }
   if (raw.repository) {
     result.repository = typeof raw.repository === 'string'
       ? raw.repository
@@ -176,6 +202,7 @@ function parseManifest(detection: DetectionResult): ParsedManifest {
 
   const homepage = typeof raw.homepage === 'string' ? raw.homepage : undefined
   if (homepage) brand.websiteURL = homepage
+  if (typeof raw.displayName === 'string') brand.displayName = raw.displayName
   if (typeof raw.icon === 'string') brand.icon = raw.icon
   if (typeof raw.logo === 'string') {
     brand.logo = raw.logo
@@ -278,6 +305,133 @@ function parseManifest(detection: DetectionResult): ParsedManifest {
 }
 
 // ── MCP Parsing ─────────────────────────────────────────────────
+
+const MANIFEST_PRECEDENCE: Record<DetectedPlatform, number> = {
+  opencode: 1,
+  'claude-code': 2,
+  cursor: 3,
+  codex: 4,
+}
+const MANIFEST_PRECEDENCE_ORDER: DetectedPlatform[] = ['opencode', 'claude-code', 'cursor', 'codex']
+
+function addManifestFieldSource(
+  fieldSources: Record<string, string[]>,
+  field: string,
+  sourcePath: string,
+): void {
+  fieldSources[field] = [...new Set([...(fieldSources[field] ?? []), sourcePath])]
+}
+
+function reconcileManifests(
+  pluginDir: string,
+  detections: DetectionResult[],
+): ManifestReconciliation {
+  const manifest: ParsedManifest = {}
+  const fieldSources: Record<string, string[]> = {}
+  const fieldCandidates: Record<string, string[]> = {}
+  const sources: ManifestSource[] = detections.flatMap((detection) => detection.manifestPath
+    ? [{ platform: detection.platform, path: relative(pluginDir, detection.manifestPath) }]
+    : [])
+  const selectedBrandRanks: Record<string, number> = {}
+  const mergeIdentityScalar = <Field extends ManifestIdentityField>(
+    field: Field,
+    value: ParsedManifest[Field],
+    sourcePath: string,
+  ) => {
+    if (value === undefined) return
+    const existing = manifest[field]
+    addManifestFieldSource(fieldCandidates, field, sourcePath)
+    addManifestFieldSource(fieldSources, field, sourcePath)
+    if (existing !== undefined && existing !== value) {
+      throw new Error(
+        `Ambiguous manifest field "${field}" from ${fieldSources[field].join(', ')}. `
+        + 'Make the source manifests agree before migration.',
+      )
+    }
+    manifest[field] = value
+  }
+
+  for (const detection of detections) {
+    const sourcePath = detection.manifestPath
+      ? relative(pluginDir, detection.manifestPath)
+      : '(manifest-less source)'
+    let parsed: ParsedManifest
+    try {
+      parsed = parseManifest(detection)
+    } catch (error) {
+      throw new Error(
+        `Failed to parse source manifest "${sourcePath}": ${error instanceof Error ? error.message : String(error)}`,
+      )
+    }
+
+    for (const field of ['name', 'version', 'description', 'repository', 'license'] as const) {
+      mergeIdentityScalar(field, parsed[field], sourcePath)
+    }
+
+    if (parsed.author) {
+      const author = manifest.author ?? { name: '' }
+      for (const field of ['name', 'url', 'email'] as const) {
+        const value = parsed.author[field]
+        if (value === undefined) continue
+        const fieldName = `author.${field}`
+        const existing = author[field]
+        addManifestFieldSource(fieldCandidates, fieldName, sourcePath)
+        addManifestFieldSource(fieldSources, fieldName, sourcePath)
+        if (existing && existing !== value) {
+          throw new Error(
+            `Ambiguous manifest field "${fieldName}" from ${fieldSources[fieldName].join(', ')}. `
+            + 'Make the source manifests agree before migration.',
+          )
+        }
+        author[field] = value
+      }
+      manifest.author = author
+    }
+
+    if (parsed.keywords) {
+      addManifestFieldSource(fieldCandidates, 'keywords', sourcePath)
+      addManifestFieldSource(fieldSources, 'keywords', sourcePath)
+      manifest.keywords = [...new Set([...(manifest.keywords ?? []), ...parsed.keywords])]
+    }
+
+    if (parsed.brand) {
+      const brand = manifest.brand ?? {}
+      for (const [field, value] of Object.entries(parsed.brand)) {
+        const fieldName = `brand.${field}`
+        addManifestFieldSource(fieldCandidates, fieldName, sourcePath)
+        if (Array.isArray(value)) {
+          addManifestFieldSource(fieldSources, fieldName, sourcePath)
+          const existing = Array.isArray(brand[field]) ? brand[field] as unknown[] : []
+          brand[field] = [...new Set([...existing, ...value])]
+          continue
+        }
+        const rank = MANIFEST_PRECEDENCE[detection.platform]
+        if (brand[field] === undefined || rank >= (selectedBrandRanks[field] ?? -1)) {
+          brand[field] = value
+          selectedBrandRanks[field] = rank
+          fieldSources[fieldName] = [sourcePath]
+        }
+      }
+      manifest.brand = brand
+    }
+
+    if (parsed.platforms) {
+      for (const platform of Object.keys(parsed.platforms)) {
+        addManifestFieldSource(fieldCandidates, `platforms.${platform}`, sourcePath)
+        addManifestFieldSource(fieldSources, `platforms.${platform}`, sourcePath)
+      }
+      manifest.platforms = mergePlatformOverrideMaps(manifest.platforms, parsed.platforms)
+    }
+  }
+
+  if (manifest.brand && !manifest.brand.displayName && manifest.name) {
+    manifest.brand.displayName = titleCaseFromDirName(manifest.name)
+    fieldSources['brand.displayName'] = [...(fieldSources.name ?? [])]
+    fieldCandidates['brand.displayName'] = [...(fieldCandidates.name ?? [])]
+  }
+
+  return { manifest, sources, fieldSources, fieldCandidates }
+}
 
 function parseMcp(pluginDir: string, detection: DetectionResult): {
   servers: ParsedMcp
@@ -2067,6 +2221,40 @@ export interface MigrateSummary {
   warnings: string[]
   dryRun: boolean
   mutation: MutationManifest
+  provenance?: MigrationProvenance
+}
+
+export interface MigrationProvenance {
+  version: 1
+  primaryPlatform: DetectedPlatform
+  manifests: ManifestSource[]
+  resolutionPolicy: {
+    identityScalars: 'agreement-or-refusal'
+    arrays: 'stable-union'
+    brandScalars: 'host-precedence'
+    manifestPrecedence: DetectedPlatform[]
+  }
+  fieldSources: Record<string, string[]>
+  fieldCandidates: Record<string, string[]>
+}
+
+function buildMigrationProvenance(result: MigrateResult): MigrationProvenance {
+  const sortFields = (fields: Record<string, string[]>) => Object.fromEntries(
+    Object.entries(fields).sort(([left], [right]) => left.localeCompare(right)),
+  )
+  return {
+    version: 1,
+    primaryPlatform: result.platform,
+    manifests: result.manifestSources,
+    resolutionPolicy: {
+      identityScalars: 'agreement-or-refusal',
+      arrays: 'stable-union',
+      brandScalars: 'host-precedence',
+      manifestPrecedence: [...MANIFEST_PRECEDENCE_ORDER],
+    },
+    fieldSources: sortFields(result.manifestFieldSources),
+    fieldCandidates: sortFields(result.manifestFieldCandidates),
+  }
 }
 
 const MIGRATE_SNAPSHOT_IGNORES = new Set(['.git', 'node_modules', 'dist'])
@@ -2117,8 +2305,45 @@ function planStagedFileMutations(rootDir: string, stagedRoot: string): FileMutat
   })
 }
 
+function formatStagedConfigError(error: unknown): string {
+  if (error && typeof error === 'object' && 'issues' in error) {
+    const issues = (error as { issues?: unknown }).issues
+    if (Array.isArray(issues)) {
+      return issues.map((issue) => {
+        if (!issue || typeof issue !== 'object') return String(issue)
+        const candidate = issue as { path?: unknown; message?: unknown }
+        const path = Array.isArray(candidate.path) ? candidate.path.join('.') : '(config)'
+        const message = typeof candidate.message === 'string' ? candidate.message : 'Invalid value'
+        return `${path}: ${message}`
+      }).join('\n')
+    }
+  }
+  return error instanceof Error ? error.message : String(error)
+}
+
 export async function migrate(inputPath: string, options: MigrateOptions = {}): Promise<MigrateSummary> {
   const outputDir = process.cwd()
+  if (options.dryRun) return migrateUnlocked(inputPath, options, outputDir)
+
+  const metadataDir = resolve(outputDir, dirname(MCP_TAXONOMY_PATH))
+  const metadataDirExisted = existsSync(metadataDir)
+  try {
+    return await withWorkspaceMutationLock(
+      outputDir,
+      () => migrateUnlocked(inputPath, options, outputDir),
+    )
+  } finally {
+    if (!metadataDirExisted && existsSync(metadataDir) && readdirSync(metadataDir).length === 0) {
+      rmSync(metadataDir, { recursive: true, force: true })
+    }
+  }
+}
+
+async function migrateUnlocked(
+  inputPath: string,
+  options: MigrateOptions,
+  outputDir: string,
+): Promise<MigrateSummary> {
   const configPath = resolve(outputDir, 'pluxx.config.ts')
   if (existsSync(configPath)) {
     const conflict = { path: 'pluxx.config.ts', reason: 'destination-exists' }
@@ -2143,9 +2368,16 @@ export async function migrate(inputPath: string, options: MigrateOptions = {}): 
     const messages: string[] = []
     const log = (message: string) => {
       messages.push(message)
-      if (!options.quiet) console.log(message)
     }
     const result = await migrateInPlace(inputPath, stagedRoot, log)
+    try {
+      await loadConfig(stagedRoot)
+    } catch (error) {
+      const manifests = result.manifestSources.map((source) => source.path).join(', ') || '(manifest-less source)'
+      throw new Error(
+        `Staged migration validation failed for pluxx.config.ts from ${manifests}:\n${formatStagedConfigError(error)}`,
+      )
+    }
     const mutations = planStagedFileMutations(outputDir, stagedRoot)
     const destinationConflicts = messages.flatMap((message) => {
       const match = message.match(/^\s*skip \.\/(.+?)(?:\/)? \(already exists\)$/)
@@ -2166,11 +2398,25 @@ export async function migrate(inputPath: string, options: MigrateOptions = {}): 
     if (!options.dryRun) {
       applyFileMutations(outputDir, mutations, options.mutationHooks)
     }
+    log('')
+    if (options.dryRun) {
+      log('Migration dry run complete. The staged project is schema-valid; no destination files were published.')
+    } else {
+      log('Migration complete! Next steps:')
+      log('  1. Review pluxx.config.ts and fill in any TODOs')
+      log('  2. Run: pluxx doctor')
+      log('  3. Run: pluxx eval')
+      log('  4. Run: pluxx build')
+    }
+    if (!options.quiet) {
+      for (const message of messages) console.log(message)
+    }
     return {
       platform: result.platform,
       warnings: result.warnings,
       dryRun: options.dryRun ?? false,
       mutation,
+      provenance: buildMigrationProvenance(result),
     }
   } finally {
     rmSync(tempRoot, { recursive: true, force: true })
@@ -2191,15 +2437,20 @@ async function migrateInPlace(
   log(`Scanning ${pluginDir} ...`)
 
   // 1. Detect platform
-  const detection = detectPlatform(pluginDir)
+  const detections = detectPlatforms(pluginDir)
+  const detection = detections[0]
   if (!detection) {
     throw new Error('Could not detect plugin platform. Expected .claude-plugin/plugin.json, CLAUDE.md, .cursor-plugin/plugin.json, .codex-plugin/plugin.json, or package.json with @opencode-ai/plugin.')
   }
 
   log(`Detected: ${detection.platform} plugin`)
+  if (detections.length > 1) {
+    log(`  manifests: ${detections.flatMap((candidate) => candidate.manifestPath ? [relative(pluginDir, candidate.manifestPath)] : []).join(', ')}`)
+  }
 
   // 2. Parse manifest
-  const manifest = parseManifest(detection)
+  const reconciledManifest = reconcileManifests(pluginDir, detections)
+  const manifest = reconciledManifest.manifest
   log(`  name: ${manifest.name ?? '(none)'}`)
   log(`  version: ${manifest.version ?? '(none)'}`)
 
@@ -2290,6 +2541,9 @@ async function migrateInPlace(
       ...instructionSources.extraPaths,
       ...openCodeDistributionSources.extraPaths,
     ])].sort(),
+    manifestSources: reconciledManifest.sources,
+    manifestFieldSources: reconciledManifest.fieldSources,
+    manifestFieldCandidates: reconciledManifest.fieldCandidates,
     ...(inferredPermissions.skillPolicies.length > 0
       ? {
           compilerIntent: {
@@ -2346,6 +2600,7 @@ async function migrateInPlace(
   // 11. Create synthetic migration metadata/taxonomy so Agent Mode and evals work.
   const taxonomyPath = resolve(outputDir, MCP_TAXONOMY_PATH)
   const metadataPath = resolve(outputDir, MCP_SCAFFOLD_METADATA_PATH)
+  const migrationReceiptPath = posix.join(posix.dirname(MCP_TAXONOMY_PATH), 'migration.json')
   mkdirSync(resolve(outputDir, '.pluxx'), { recursive: true })
   await writeTextFile(taxonomyPath, `${JSON.stringify(result.persistedSkills, null, 2)}\n`)
   if (result.compilerIntent) {
@@ -2354,10 +2609,15 @@ async function migrateInPlace(
       `${JSON.stringify(result.compilerIntent, null, 2)}\n`,
     )
   }
+  await writeTextFile(
+    resolve(outputDir, migrationReceiptPath),
+    `${JSON.stringify(buildMigrationProvenance(result), null, 2)}\n`,
+  )
   await writeTextFile(metadataPath, `${JSON.stringify(buildMigratedScaffoldMetadata(result, outputDir), null, 2)}\n`)
   const generatedPluxxFiles = [
     MCP_TAXONOMY_PATH,
     ...(result.compilerIntent ? [PLUXX_COMPILER_INTENT_PATH] : []),
+    migrationReceiptPath,
     MCP_SCAFFOLD_METADATA_PATH,
   ]
   log(`Generated: ${generatedPluxxFiles.join(', ')}`)
@@ -2370,11 +2630,5 @@ async function migrateInPlace(
     }
   }
 
-  log('')
-  log('Migration complete! Next steps:')
-  log('  1. Review pluxx.config.ts and fill in any TODOs')
-  log('  2. Run: pluxx doctor')
-  log('  3. Run: pluxx eval')
-  log('  4. Run: pluxx build')
   return result
 }

--- a/tests/fixtures/compound-engineering-3.19.0/README.md
+++ b/tests/fixtures/compound-engineering-3.19.0/README.md
@@ -1,0 +1,5 @@
+# Compound Engineering 3.19.0 migration fixture
+
+Bounded manifest fixture distilled from `EveryInc/compound-engineering-plugin` commit `f871e4b4308f5a175b38ccada51d80dd67bab4fc`.
+
+The Claude manifest exposes website branding without a display name, while the Codex manifest carries the required display name and richer interface metadata. The Cursor manifest carries a host-specific keyword catalog. This reproduces the mature multi-manifest intake defect without vendoring the upstream plugin.

--- a/tests/fixtures/compound-engineering-3.19.0/claude-plugin.json
+++ b/tests/fixtures/compound-engineering-3.19.0/claude-plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "compound-engineering",
+  "version": "3.19.0",
+  "description": "Brainstorm, plan, debug, review, and compound learnings with AI agents",
+  "homepage": "https://every.to/source-code/my-ai-had-already-fixed-the-code-before-i-saw-it",
+  "keywords": ["brainstorming", "code-review", "compound-engineering"]
+}

--- a/tests/fixtures/compound-engineering-3.19.0/codex-plugin.json
+++ b/tests/fixtures/compound-engineering-3.19.0/codex-plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "compound-engineering",
+  "version": "3.19.0",
+  "keywords": ["brainstorming", "workflow-automation"],
+  "interface": {
+    "displayName": "Compound Engineering",
+    "category": "Coding",
+    "websiteURL": "https://github.com/EveryInc/compound-engineering-plugin"
+  }
+}

--- a/tests/fixtures/compound-engineering-3.19.0/cursor-plugin.json
+++ b/tests/fixtures/compound-engineering-3.19.0/cursor-plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "compound-engineering",
+  "displayName": "Compound Engineering",
+  "version": "3.19.0",
+  "keywords": ["cursor", "plugin", "compound-engineering"]
+}

--- a/tests/meta-cli.test.ts
+++ b/tests/meta-cli.test.ts
@@ -135,4 +135,15 @@ describe('CLI lifecycle helpers', () => {
     expect(stdout).toContain('--offline')
     expect(stderr).toBe('')
   })
+
+  it('describes mature multi-host plugin migration in command usage', async () => {
+    const proc = spawnCli(['migrate'])
+    const stdout = await new Response(proc.stdout).text()
+    const stderr = await new Response(proc.stderr).text()
+    const exitCode = await proc.exited
+
+    expect(exitCode).toBe(1)
+    expect(stdout).toBe('')
+    expect(stderr).toContain('single- or multi-host plugin')
+  })
 })

--- a/tests/migrate.test.ts
+++ b/tests/migrate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
-import { mkdirSync, rmSync, existsSync, readFileSync, symlinkSync, writeFileSync } from 'fs'
+import { copyFileSync, mkdirSync, rmSync, existsSync, readFileSync, symlinkSync, writeFileSync } from 'fs'
 import { resolve } from 'path'
 import { migrate } from '../src/cli/migrate'
 import { planAgentPrepare } from '../src/cli/agent'
@@ -8,6 +8,25 @@ import { loadConfig } from '../src/config/load'
 import { build } from '../src/generators'
 
 const TEST_DIR = resolve(import.meta.dir, '.migrate-fixture')
+const HIDDEN_PREFIX = '.'
+const PLUXX_METADATA_DIR = `${HIDDEN_PREFIX}pluxx`
+
+function setupCompoundEngineeringSource() {
+  const fixtureDir = resolve(import.meta.dir, 'fixtures/compound-engineering-3.19.0')
+  const sourceDir = resolve(TEST_DIR, 'source-compound-engineering')
+  const pluginDir = (host: string) => `${HIDDEN_PREFIX}${host}-plugin`
+  const manifests = [
+    [pluginDir('claude'), 'claude-plugin.json'],
+    [pluginDir('cursor'), 'cursor-plugin.json'],
+    [pluginDir('codex'), 'codex-plugin.json'],
+  ] as const
+  for (const [manifestDir, fixtureName] of manifests) {
+    const destinationDir = resolve(sourceDir, manifestDir)
+    mkdirSync(destinationDir, { recursive: true })
+    copyFileSync(resolve(fixtureDir, fixtureName), resolve(destinationDir, 'plugin.json'))
+  }
+  return sourceDir
+}
 
 function writeJson(path: string, data: unknown) {
   return Bun.write(path, JSON.stringify(data, null, 2) + '\n')
@@ -747,6 +766,198 @@ describe('migrate', () => {
       expect(existsSync(resolve(outputDir, '.pluxx/mcp.json'))).toBe(false)
     } finally {
       process.chdir(previousCwd)
+    }
+  })
+
+  it('refuses a concurrent workspace mutation before staging or publication', async () => {
+    const sourceDir = setupCompoundEngineeringSource()
+    const outputDir = resolve(TEST_DIR, 'out-concurrent-migrate')
+    const metadataDir = resolve(outputDir, PLUXX_METADATA_DIR)
+    mkdirSync(metadataDir, { recursive: true })
+    writeFileSync(
+      resolve(metadataDir, 'mutation.lock'),
+      `${JSON.stringify({ pid: process.pid, owner: 'another-run', createdAt: new Date().toISOString() })}\n`,
+    )
+
+    const previousCwd = process.cwd()
+    process.chdir(outputDir)
+    try {
+      await expect(migrate(sourceDir, { quiet: true })).rejects.toThrow(/another mutating pluxx run/i)
+    } finally {
+      process.chdir(previousCwd)
+    }
+    expect(existsSync(resolve(outputDir, 'pluxx.config.ts'))).toBe(false)
+  })
+
+  it('migrates the pinned Compound Engineering manifests into a schema-valid project with provenance', async () => {
+    const sourceDir = setupCompoundEngineeringSource()
+    const outputDir = resolve(TEST_DIR, 'out-compound-engineering')
+    await runMigrate(sourceDir, outputDir)
+
+    const config = await loadConfig(outputDir)
+    expect(config.brand?.displayName).toBe('Compound Engineering')
+    expect(config.brand?.category).toBe('Coding')
+    expect(config.keywords).toEqual([
+      'brainstorming',
+      'code-review',
+      'compound-engineering',
+      'cursor',
+      'plugin',
+      'workflow-automation',
+    ])
+
+    const receipt = JSON.parse(readFileSync(resolve(outputDir, PLUXX_METADATA_DIR, 'migration.json'), 'utf-8'))
+    expect(receipt).toMatchObject({
+      version: 1,
+      primaryPlatform: 'claude-code',
+      manifests: [
+        { platform: 'claude-code', path: '.claude-plugin/plugin.json' },
+        { platform: 'cursor', path: '.cursor-plugin/plugin.json' },
+        { platform: 'codex', path: '.codex-plugin/plugin.json' },
+      ],
+    })
+    expect(receipt.fieldSources.name).toEqual([
+      '.claude-plugin/plugin.json',
+      '.cursor-plugin/plugin.json',
+      '.codex-plugin/plugin.json',
+    ])
+    expect(receipt.fieldSources['brand.displayName']).toEqual(['.codex-plugin/plugin.json'])
+    expect(receipt.fieldSources['brand.websiteURL']).toEqual(['.codex-plugin/plugin.json'])
+    expect(receipt.fieldCandidates['brand.displayName']).toEqual([
+      '.cursor-plugin/plugin.json',
+      '.codex-plugin/plugin.json',
+    ])
+    expect(receipt.resolutionPolicy).toEqual({
+      identityScalars: 'agreement-or-refusal',
+      arrays: 'stable-union',
+      brandScalars: 'host-precedence',
+      manifestPrecedence: ['opencode', 'claude-code', 'cursor', 'codex'],
+    })
+
+    const dryRunOutput = resolve(TEST_DIR, 'out-compound-engineering-dry-run')
+    mkdirSync(dryRunOutput, { recursive: true })
+    const previousCwd = process.cwd()
+    process.chdir(dryRunOutput)
+    try {
+      const summary = await migrate(sourceDir, { dryRun: true, quiet: true })
+      expect(summary.provenance).toEqual(receipt)
+    } finally {
+      process.chdir(previousCwd)
+    }
+    expect(existsSync(resolve(dryRunOutput, PLUXX_METADATA_DIR))).toBe(false)
+  })
+
+  it('refuses ambiguous manifest scalars before publishing destination files', async () => {
+    const sourceDir = setupCompoundEngineeringSource()
+    const cursorManifest = resolve(sourceDir, '.cursor-plugin/plugin.json')
+    const cursor = JSON.parse(readFileSync(cursorManifest, 'utf-8'))
+    writeFileSync(cursorManifest, `${JSON.stringify({ ...cursor, description: 'Conflicting description' }, null, 2)}\n`)
+
+    const outputDir = resolve(TEST_DIR, 'out-ambiguous-manifests')
+    mkdirSync(outputDir, { recursive: true })
+    writeFileSync(resolve(outputDir, 'user-notes.md'), 'keep me\n')
+    const previousCwd = process.cwd()
+    process.chdir(outputDir)
+    try {
+      await expect(migrate(sourceDir, { quiet: true })).rejects.toThrow(
+        /Ambiguous manifest field "description".*\.claude-plugin\/plugin\.json.*\.cursor-plugin\/plugin\.json/,
+      )
+    } finally {
+      process.chdir(previousCwd)
+    }
+
+    expect(readFileSync(resolve(outputDir, 'user-notes.md'), 'utf-8')).toBe('keep me\n')
+    expect(existsSync(resolve(outputDir, 'pluxx.config.ts'))).toBe(false)
+  })
+
+  it('reconciles conflicting brand scalars with explicit host precedence and chosen-source provenance', async () => {
+    const sourceDir = setupCompoundEngineeringSource()
+    const codexManifest = resolve(sourceDir, '.codex-plugin/plugin.json')
+    const codex = JSON.parse(readFileSync(codexManifest, 'utf-8'))
+    writeFileSync(codexManifest, `${JSON.stringify({
+      ...codex,
+      interface: { ...codex.interface, displayName: 'Conflicting Brand' },
+    }, null, 2)}\n`)
+
+    const outputDir = resolve(TEST_DIR, 'out-brand-precedence')
+    await runMigrate(sourceDir, outputDir)
+
+    const config = await loadConfig(outputDir)
+    expect(config.brand?.displayName).toBe('Conflicting Brand')
+    const receipt = JSON.parse(readFileSync(resolve(outputDir, PLUXX_METADATA_DIR, 'migration.json'), 'utf-8'))
+    expect(receipt.fieldSources['brand.displayName']).toEqual(['.codex-plugin/plugin.json'])
+  })
+
+  it('names the responsible source manifest when a secondary manifest is malformed', async () => {
+    const sourceDir = setupCompoundEngineeringSource()
+    writeFileSync(resolve(sourceDir, '.cursor-plugin/plugin.json'), '{ invalid json\n')
+    const outputDir = resolve(TEST_DIR, 'out-malformed-manifest')
+    mkdirSync(outputDir, { recursive: true })
+    const previousCwd = process.cwd()
+    process.chdir(outputDir)
+    try {
+      await expect(migrate(sourceDir, { quiet: true })).rejects.toThrow(
+        /Failed to parse source manifest "\.cursor-plugin\/plugin\.json"/,
+      )
+    } finally {
+      process.chdir(previousCwd)
+    }
+    expect(existsSync(resolve(outputDir, 'pluxx.config.ts'))).toBe(false)
+  })
+
+  it('refuses invalid iterable manifest fields instead of silently normalizing them', async () => {
+    const sourceDir = setupCompoundEngineeringSource()
+    const cursorManifest = resolve(sourceDir, '.cursor-plugin/plugin.json')
+    const cursor = JSON.parse(readFileSync(cursorManifest, 'utf-8'))
+    writeFileSync(cursorManifest, `${JSON.stringify({ ...cursor, keywords: 'not-an-array' }, null, 2)}\n`)
+
+    for (const dryRun of [false, true]) {
+      const outputDir = resolve(TEST_DIR, `out-invalid-keywords-${dryRun ? 'dry' : 'apply'}`)
+      mkdirSync(outputDir, { recursive: true })
+      const previousCwd = process.cwd()
+      process.chdir(outputDir)
+      try {
+        await expect(migrate(sourceDir, { dryRun, quiet: true })).rejects.toThrow(
+          /Failed to parse source manifest "\.cursor-plugin\/plugin\.json": keywords must be an array of strings/,
+        )
+      } finally {
+        process.chdir(previousCwd)
+      }
+      expect(existsSync(resolve(outputDir, 'pluxx.config.ts'))).toBe(false)
+    }
+  })
+
+  it('rejects a schema-invalid staged config before apply or dry-run can report success', async () => {
+    const sourceDir = resolve(TEST_DIR, 'source-invalid-schema')
+    const manifestDir = resolve(sourceDir, '.claude-plugin')
+    mkdirSync(manifestDir, { recursive: true })
+    await writeJson(resolve(manifestDir, 'plugin.json'), {
+      name: 'Invalid Name',
+      version: '1.0.0',
+      description: 'Invalid canonical name fixture.',
+    })
+
+    for (const dryRun of [false, true]) {
+      const outputDir = resolve(TEST_DIR, `out-invalid-schema-${dryRun ? 'dry' : 'apply'}`)
+      mkdirSync(outputDir, { recursive: true })
+      writeFileSync(resolve(outputDir, 'user-notes.md'), 'keep me\n')
+      const previousCwd = process.cwd()
+      const originalLog = console.log
+      const logs: string[] = []
+      process.chdir(outputDir)
+      console.log = (...args: unknown[]) => logs.push(args.map(String).join(' '))
+      try {
+        await expect(migrate(sourceDir, { dryRun })).rejects.toThrow(
+          /Staged migration validation failed for pluxx\.config\.ts.*name/s,
+        )
+      } finally {
+        console.log = originalLog
+        process.chdir(previousCwd)
+      }
+      expect(readFileSync(resolve(outputDir, 'user-notes.md'), 'utf-8')).toBe('keep me\n')
+      expect(existsSync(resolve(outputDir, 'pluxx.config.ts'))).toBe(false)
+      expect(existsSync(resolve(outputDir, PLUXX_METADATA_DIR))).toBe(false)
+      expect(logs.join('\n')).not.toMatch(/Generated|Migration complete|dry run complete/i)
     }
   })
 


### PR DESCRIPTION
## Summary

`pluxx migrate` now either produces a schema-valid canonical project or refuses the migration before publishing anything. Mature plugins with several host manifests no longer depend on first-match-wins discovery, and unresolved identity disagreement is reported instead of silently discarded.

## User journey

A maintainer points Pluxx at a mature plugin such as Compound Engineering. Pluxx discovers every supported manifest, reconciles compatible identity and provenance, stages the entire result, validates it with the current schema, and only then publishes it transactionally.

If two manifests genuinely disagree, the maintainer receives an actionable ambiguity error and the destination remains untouched. The old failure mode—warning-free success followed by an invalid or partially written project—is removed.

## Design decisions

- Validation happens against the staged project, not after destination mutation.
- Multi-manifest fields are reconciled deterministically with explicit provenance; identity ambiguity fails closed.
- Publication uses transactional mutation and refuses destination symlink hazards.
- The CE regression fixture contains only three small manifest shapes, not the upstream plugin.

## Validation

- Focused migration suite: 133/133.
- Full suite: 762/762.
- Typecheck, build/declarations, focused CLI lint, and a clean pinned CE migration proof passed.
- Independent review found no remaining P0–P2 issues.

Stack position: **2 of 7**. Base: the orchestration decision chapter.

Fixes PLUXX-324.

## Review stack

1. [#434 — define the portable workflow primitive](https://github.com/orchidautomation/pluxx/pull/434) — ready
2. [#435 — make mature plugin intake transactional](https://github.com/orchidautomation/pluxx/pull/435) — ready
3. [#436 — add the canonical workflow contract](https://github.com/orchidautomation/pluxx/pull/436) — draft, blocked on PLUXX-332
4. [#437 — compile honest core-four companions](https://github.com/orchidautomation/pluxx/pull/437) — draft, blocked on PLUXX-332
5. [#438 — prove installed core-four evidence](https://github.com/orchidautomation/pluxx/pull/438) — draft, blocked on PLUXX-330 and PLUXX-332
6. [#439 — recover native adjuncts for core four](https://github.com/orchidautomation/pluxx/pull/439) — draft, transitively blocked
7. [#440 — gate the frozen core-four proof](https://github.com/orchidautomation/pluxx/pull/440) — draft, transitively blocked

Review and merge in order. PLUXX-330 (receipt compaction) and PLUXX-332 (late-fix restack) may proceed in parallel; only the first two PRs are ready now.