### PR TITLE
Fix trusted legacy installer adoption

### DIFF
--- a/docs/core-four-install-update-lifecycle.md
+++ b/docs/core-four-install-update-lifecycle.md
@@ -1,6 +1,6 @@
 # Core-Four Install And Update Lifecycle
 
-Last updated: 2026-07-11
+Last updated: 2026-07-16
 
 This doc explains the practical install, update, and reload behavior for the four primary Pluxx targets:
 
@@ -80,6 +80,14 @@ pluxx install --target codex --dry-run --json
 ```
 
 then `targetSelection.selectedTargets` stays `["codex"]` even if Pluxx also detects Cursor or OpenCode locally. Detection can suggest install targets for planning and generated installer UX, but it does not override `--target` or rewrite host configs just because a host exists.
+
+## Legacy Pre-Ownership Upgrade Rule
+
+Generated release installers are conservative when upgrading installs that predate `pluxx.install-ownership.v1`. They may adopt and replace a legacy install once only when the installed host manifest parses and its plugin/package identity matches the trusted candidate bundle for that same host. The installer still preserves `.pluxx-user.json`, keeps install-scoped locking/staging/rollback behavior, and writes the normal ownership ledger only after a successful commit.
+
+For OpenCode, the same adoption path recognizes Pluxx-generated wrapper files and namespaced skill companions, then migrates them into owned companion ledgers. Unrecognized wrapper or skill collisions still fail closed instead of being overwritten.
+
+Missing, malformed, or mismatched legacy manifests, arbitrary directories, and modified/missing/extra content in already ownership-managed installs remain refusal cases.
 
 ## Important Distinction
 

--- a/docs/orchid/qa/2026-07-16-pluxx-333-legacy-installer-adoption.md
+++ b/docs/orchid/qa/2026-07-16-pluxx-333-legacy-installer-adoption.md
@@ -1,0 +1,22 @@
+# PLUXX-333 Legacy Installer Adoption QA
+
+## Scope
+
+Release-blocking fix for generated GitHub Release installers that refused to upgrade trusted pre-ownership plugin installs without `pluxx.install-ownership.v1` ledgers.
+
+## Regression Coverage
+
+- `tests/publish.test.ts` now proves trusted legacy adoption for Claude Code, Cursor, Codex, and OpenCode using fake HOME generated-installer fixtures.
+- Negative coverage keeps missing, malformed, and mismatched legacy manifests fail-closed.
+- OpenCode coverage migrates recognized generated wrapper and namespaced skill companions, while unrelated skill collisions still fail closed.
+
+## Validation
+
+- `bun test tests/publish.test.ts --timeout 120000` — passed locally during implementation.
+- `bun test tests/install-ownership.test.ts --timeout 120000` — passed locally during implementation.
+- `npm run typecheck` — passed locally after dependency install.
+- `npm run build` — passed locally after dependency install.
+- `npm test` — passed locally on 2026-07-16: 61 files / 758 tests.
+- `npm run release:check` — passed locally on 2026-07-16, including proof freshness, build, typecheck, full test suite, node package runtime verification, and dry-run npm pack for `@orchid-labs/pluxx@0.1.33`.
+
+CI, PR review, merge, tag, npm publication, and GitHub release verification remain pending until the branch is pushed and reviewed.

--- a/docs/proof-and-install.md
+++ b/docs/proof-and-install.md
@@ -1,6 +1,6 @@
 # Proof And Install
 
-Last updated: 2026-07-13
+Last updated: 2026-07-16
 
 ## Doc Links
 
@@ -30,9 +30,9 @@ This is the shortest current repo-native path to:
 
 For the fuller release/distribution boundary, including publish commands and deferred marketplace/trust-layer work, use [docs/release-distribution-proof-map.md](./release-distribution-proof-map.md).
 
-Proof labels and freshness come from [proof-freshness.md](./proof-freshness.md) and [proof-manifest.json](./proof-manifest.json). The May self-hosted run and April Firecrawl connector run are preserved as historical environment evidence; they are not current host receipts for `0.1.32`.
+Proof labels and freshness come from [proof-freshness.md](./proof-freshness.md) and [proof-manifest.json](./proof-manifest.json). The May self-hosted run, April Firecrawl connector run, and previous 0.1.32 release evidence are preserved as historical environment evidence; they are not current host receipts for `0.1.33`.
 
-The current v0.1.32 receipts prove the `bundle-contract` and `fake-home-install` tiers from committed release-prep state after `npm run release:check` passed. No current receipt claims installed-runtime or real-host behavior.
+The current v0.1.33 receipts prove the `bundle-contract` and generated-installer `fake-home-install` tiers from release-prep state, including trusted legacy installer adoption across the core four. No current receipt claims installed-runtime or real-host behavior.
 
 ## The Story In One Screen
 
@@ -208,7 +208,7 @@ curl -fsSL https://raw.githubusercontent.com/orchidautomation/pluxx/main/example
 
 Current release note:
 
-- the canonical repository version is `@orchid-labs/pluxx@0.1.32`, tagged as `v0.1.32` at `188527e`; the first release run did not publish npm or create a GitHub release, so the historical published baseline remains 0.1.31 until recovery completes
+- the canonical repository version is `@orchid-labs/pluxx@0.1.33` in release-prep for trusted legacy installer adoption; previous `v0.1.32` public release evidence is historical once this fix ships
 - the published CLI runtime is Node `>=18`; see [runtime contract](./runtime-contract.md)
 - the published package includes the Claude plugin-agent manifest fix and packaged Node runtime verification
 - the public `pluxx test --install --trust --behavioral` path now matches the repo-local Exa proof state

--- a/docs/proof-manifest.json
+++ b/docs/proof-manifest.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
-  "canonicalVersion": "0.1.32",
-  "expectedTag": "v0.1.32",
-  "releaseState": "released",
+  "canonicalVersion": "0.1.33",
+  "expectedTag": "v0.1.33",
+  "releaseState": "release-prep",
   "policy": {
     "environmentReceiptMaxAgeDays": 30
   },
@@ -27,7 +27,7 @@
       "id": "v0.1.32-repository-validation",
       "summary": "The committed v0.1.32 release-prep state passes the complete repository release gate.",
       "tier": "bundle-contract",
-      "freshness": "current",
+      "freshness": "historical",
       "evidencePath": "tests/proof-freshness.test.ts",
       "receiptId": "v0.1.32-repository-validation"
     },
@@ -35,7 +35,7 @@
       "id": "v0.1.32-fake-home-install",
       "summary": "Maintained examples pass core-four bundle and isolated fake-home install verification in the v0.1.32 release gate.",
       "tier": "fake-home-install",
-      "freshness": "current",
+      "freshness": "historical",
       "evidencePath": "tests/release-smoke.test.ts",
       "receiptId": "v0.1.32-fake-home-install"
     },
@@ -54,6 +54,22 @@
       "freshness": "historical",
       "evidencePath": "docs/strategy/firecrawl-connector-docs-ingestion-proof.md",
       "receiptId": "v0.1.28-firecrawl-history"
+    },
+    {
+      "id": "v0.1.33-repository-validation",
+      "summary": "The v0.1.33 release-prep state passes the repository release gate for legacy installer adoption.",
+      "tier": "bundle-contract",
+      "freshness": "current",
+      "evidencePath": "tests/proof-freshness.test.ts",
+      "receiptId": "v0.1.33-repository-validation"
+    },
+    {
+      "id": "v0.1.33-fake-home-install",
+      "summary": "Generated installer fake-home coverage proves trusted pre-ownership adoption across Claude Code, Cursor, Codex, and OpenCode for v0.1.33.",
+      "tier": "fake-home-install",
+      "freshness": "current",
+      "evidencePath": "tests/publish.test.ts",
+      "receiptId": "v0.1.33-fake-home-install"
     }
   ],
   "receipts": [
@@ -166,7 +182,7 @@
     {
       "id": "v0.1.32-repository-validation",
       "tier": "bundle-contract",
-      "freshness": "current",
+      "freshness": "historical",
       "commitSha": "f2b7cd4eafccaa42df64041cff9a4c5de96b0fd0",
       "packageVersion": "0.1.32",
       "timestamp": "2026-07-13T01:54:26.817Z",
@@ -189,7 +205,7 @@
     {
       "id": "v0.1.32-fake-home-install",
       "tier": "fake-home-install",
-      "freshness": "current",
+      "freshness": "historical",
       "commands": [
         {
           "command": "npm run release:check",
@@ -208,6 +224,52 @@
       "commitSha": "f2b7cd4eafccaa42df64041cff9a4c5de96b0fd0",
       "packageVersion": "0.1.32",
       "timestamp": "2026-07-13T01:54:26.958Z"
+    },
+    {
+      "id": "v0.1.33-repository-validation",
+      "tier": "bundle-contract",
+      "freshness": "current",
+      "commitSha": "faa7a3abb74d8e6696a7fccd40ba3fe850364ca0",
+      "packageVersion": "0.1.33",
+      "timestamp": "2026-07-16T21:00:02.883342Z",
+      "commands": [
+        {
+          "command": "npm run release:check",
+          "outcome": "passed"
+        }
+      ],
+      "targets": [
+        {
+          "target": "repository",
+          "hostVersion": null,
+          "installedPath": null,
+          "sha256": null,
+          "outcome": "passed"
+        }
+      ]
+    },
+    {
+      "id": "v0.1.33-fake-home-install",
+      "tier": "fake-home-install",
+      "freshness": "current",
+      "commitSha": "faa7a3abb74d8e6696a7fccd40ba3fe850364ca0",
+      "packageVersion": "0.1.33",
+      "timestamp": "2026-07-16T21:00:02.883342Z",
+      "commands": [
+        {
+          "command": "bun test tests/publish.test.ts --timeout 120000",
+          "outcome": "passed"
+        }
+      ],
+      "targets": [
+        {
+          "target": "claude-code,cursor,codex,opencode",
+          "hostVersion": null,
+          "installedPath": null,
+          "sha256": null,
+          "outcome": "passed"
+        }
+      ]
     }
   ]
 }

--- a/docs/proof-receipts/v0.1.32-repository-validation.json
+++ b/docs/proof-receipts/v0.1.32-repository-validation.json
@@ -1,7 +1,7 @@
 {
   "id": "v0.1.32-repository-validation",
   "tier": "bundle-contract",
-  "freshness": "current",
+  "freshness": "historical",
   "commands": [
     {
       "command": "npm run release:check",

--- a/docs/proof-receipts/v0.1.33-fake-home-install.json
+++ b/docs/proof-receipts/v0.1.33-fake-home-install.json
@@ -1,10 +1,10 @@
 {
-  "id": "v0.1.32-fake-home-install",
+  "id": "v0.1.33-fake-home-install",
   "tier": "fake-home-install",
-  "freshness": "historical",
+  "freshness": "current",
   "commands": [
     {
-      "command": "npm run release:check",
+      "command": "bun test tests/publish.test.ts --timeout 120000",
       "outcome": "passed"
     }
   ],

--- a/docs/proof-receipts/v0.1.33-repository-validation.json
+++ b/docs/proof-receipts/v0.1.33-repository-validation.json
@@ -1,7 +1,7 @@
 {
-  "id": "v0.1.32-fake-home-install",
-  "tier": "fake-home-install",
-  "freshness": "historical",
+  "id": "v0.1.33-repository-validation",
+  "tier": "bundle-contract",
+  "freshness": "current",
   "commands": [
     {
       "command": "npm run release:check",
@@ -10,7 +10,7 @@
   ],
   "targets": [
     {
-      "target": "claude-code,cursor,codex,opencode",
+      "target": "repository",
       "hostVersion": null,
       "installedPath": null,
       "sha256": null,

--- a/docs/release-distribution-proof-map.md
+++ b/docs/release-distribution-proof-map.md
@@ -1,6 +1,6 @@
 # Release Distribution Proof Map
 
-Last updated: 2026-07-12
+Last updated: 2026-07-16
 
 ## Doc Links
 
@@ -26,7 +26,7 @@ Last updated: 2026-07-12
 
 This is the short release/distribution map for what Pluxx can ship today, what is locally proven, and what still belongs to later marketplace or trust-layer work.
 
-Proof state is governed by [proof-freshness.md](./proof-freshness.md) and the machine-readable [proof manifest](./proof-manifest.json). The canonical repository version is `0.1.32`, tagged as `v0.1.32` at `188527e`; the first release run failed before npm publication or GitHub release creation, so the historical published baseline remains 0.1.31 until recovery completes. Older host runs linked below are historical unless a current receipt says otherwise.
+Proof state is governed by [proof-freshness.md](./proof-freshness.md) and the machine-readable [proof manifest](./proof-manifest.json). The canonical repository version is `0.1.33` in release-prep. The previous published `v0.1.32` release is historical once this fix ships; older host runs linked below are historical unless a current receipt says otherwise.
 
 ## Current Primary Fronts
 
@@ -49,7 +49,7 @@ Pluxx can ship the OSS authoring substrate today:
 - `pluxx install` can install built bundles locally for the primary fronts
 - `pluxx verify-install` checks the host-visible installed bundle, not only generated files in `dist/`
 - `pluxx test --install` runs source checks, build smoke, local install, and installed verification together
-- `pluxx publish --github-release` packages built bundles and generates primary-front installers that pin the tagged release, use bounded download retries/timeouts, verify release checksums, reject unsafe archives, enforce install-scoped locking and ownership before replacement, stage setup, and restore the prior bundle plus owned companion state when post-swap work fails or is interrupted; post-publish verification downloads remote assets and compares their bytes with the generated local files
+- `pluxx publish --github-release` packages built bundles and generates primary-front installers that pin the tagged release, use bounded download retries/timeouts, verify release checksums, reject unsafe archives, enforce install-scoped locking and ownership before replacement, stage setup, and restore the prior bundle plus owned companion state when post-swap work fails or is interrupted. Starting in the `0.1.33` release-prep lane, generated installers can also perform a one-time adoption of pre-ownership installs only when the existing host manifest identity matches the trusted candidate bundle for that exact host; post-publish verification downloads remote assets and compares their bytes with the generated local files
 - `pluxx publish --npm` covers the npm-backed OpenCode wrapper package path; publish validates source/built/package version identity, compares exact packed-tarball SRI before reconciling immutable npm versions, and reconciles existing GitHub releases to the exact asset set
 - `pluxx upgrade` reports invocation source and version direction, verifies the active PATH binary/version, and prints an exact rollback command
 - `pluxx discover-mcp` and `pluxx init --from-installed-mcp` can import already configured MCP servers from Claude Code, Cursor, Codex, and OpenCode without copying literal secret values

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Last updated: 2026-07-12
+Last updated: 2026-07-16
 
 ## Doc Links
 
@@ -82,7 +82,7 @@ The full v0.1.31 audit-remediation tranche is merged. Main now includes safer in
 
 Proof governance now distinguishes unit, bundle-contract, fake-home install, installed-runtime, and real-host behavior evidence. Canonical version/freshness checks run in CI through [proof-freshness.md](./proof-freshness.md) and [proof-manifest.json](./proof-manifest.json); historical April/May proof stays available without being treated as current.
 
-The active audit closeout slice is PLUXX-322 release recovery. The 0.1.32 release PR is merged and immutable tag `v0.1.32` exists at `188527e`, but the first release run failed before publication because its shallow checkout could not reach the proof receipt commit. The focused recovery PR restores full history and a controlled existing-tag dispatch; merge, dispatch, public artifact verification, and archive remain coordinator-owned.
+The active release-blocking slice is PLUXX-333 legacy installer adoption. The 0.1.33 release-prep branch fixes generated installers that rejected trusted pre-ownership installs, while keeping arbitrary or mismatched directories fail-closed.
 
 ### 1. Product clarity and source-of-truth coherence
 
@@ -119,7 +119,7 @@ The closure plan is now narrower than it was before:
 - the next concrete OSS-authoring robustness slice is Codex companion apply/verify:
   - make generated readiness, hook, MCP approval, and companion config artifacts operational and verifiable instead of advisory only
   - keep the work aligned with `PLUXX-226`, `PLUXX-264`, `PLUXX-248`, and [docs/orchid/decisions/2026-06-26-pluxx-next-ship-review.md](./orchid/decisions/2026-06-26-pluxx-next-ship-review.md)
-  - transactional install ownership now covers conservative reinstall/uninstall, rollback, and content drift across the core four
+  - transactional install ownership now covers conservative reinstall/uninstall, rollback, content drift, and trusted pre-ownership adoption across the core four
 - local stdio import quality is now stronger for the common "I already have an MCP" path:
   - `init --from-mcp` auto-recovers `passthrough` for project-relative runtimes such as `./build/index.js`
   - `lint` catches unbundled stdio runtime payloads earlier
@@ -228,7 +228,7 @@ The closure plan is now narrower than it was before:
 - historical release-gate evidence from 2026-05-19 remains available but is not current proof:
   - `npm test` passed
   - `npm run release:check` passed
-- the canonical repository version is `@orchid-labs/pluxx@0.1.32`, tagged as `v0.1.32` at `188527e`; the historical published baseline remains 0.1.31 while release recovery is pending
+- the canonical repository version is `@orchid-labs/pluxx@0.1.33` in release-prep; previous `v0.1.32` release evidence is historical once this fix ships
 - the release/distribution/proof boundary is now explicit:
   - [docs/release-distribution-proof-map.md](./release-distribution-proof-map.md)
   - [docs/core-four-primitive-proof-ledger.md](./core-four-primitive-proof-ledger.md)
@@ -388,14 +388,14 @@ This is for learning and proof, not for prematurely building the full trust laye
 
 ### 6. Next release
 
-The canonical repository version is `0.1.32`, and immutable tag `v0.1.32` exists at `188527e`; the historical published baseline remains 0.1.31. The first release run failed before npm publication or GitHub release creation because its shallow checkout could not reach the current receipt commit. Current repository-validation and fake-home-install receipts remain tied to committed 0.1.32 state; historical 0.1.31 proof was not carried forward as current.
+The canonical repository version is `0.1.33` in release-prep. Current repository-validation and fake-home-install receipts are tied to the PLUXX-333 legacy installer adoption fix; previous 0.1.32 proof is historical for the prior release baseline.
 
 The next npm cut should stay primarily an operations step rather than a code-confidence rescue step.
 
-- prepare and review the 0.1.32 package, proof, and source-of-truth changes in PLUXX-322
+- prepare and review the 0.1.33 package, proof, and source-of-truth changes in PLUXX-333
 - run targeted proof/version/release checks, official serial `npm test`, and `npm run release:check`
-- merge the focused recovery PR after substantive checks and review are green
-- dispatch the existing `v0.1.32` tag through the trusted main workflow without moving or recreating it
+- merge the focused legacy-installer-adoption PR after substantive checks and review are green
+- tag `v0.1.33` from main through the trusted release workflow
 - verify the npm package version, GitHub release, attached tarball, and CLI after the workflow completes
 
 ## What This Roadmap Is Optimizing For

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -1,6 +1,6 @@
 # Start Here
 
-Last updated: 2026-07-12
+Last updated: 2026-07-16
 
 ## Doc Links
 
@@ -39,7 +39,7 @@ If you want the shortest public proof and install path after this file, use [doc
 
 If you want the current release, distribution, and proof boundary, use [docs/release-distribution-proof-map.md](./release-distribution-proof-map.md).
 
-If you need to know whether a proof claim is current, historical, repository-only, installed, or real-host evidence, use [docs/proof-freshness.md](./proof-freshness.md) and [docs/proof-manifest.json](./proof-manifest.json). Canonical repository version truth is `package.json` (`0.1.32`), and tag `v0.1.32` exists at `188527e`; the failed first release run did not publish npm or create the GitHub release.
+If you need to know whether a proof claim is current, historical, repository-only, installed, or real-host evidence, use [docs/proof-freshness.md](./proof-freshness.md) and [docs/proof-manifest.json](./proof-manifest.json). Canonical repository version truth is `package.json` (`0.1.33`) and the proof manifest marks this branch as release-prep until tag `v0.1.33` is published. The previous `v0.1.32` tag and package are historical release evidence for the prior baseline.
 
 If you want the primitive-by-host proof ledger behind the core-four native shipping claim, use [docs/core-four-primitive-proof-ledger.md](./core-four-primitive-proof-ledger.md).
 
@@ -99,7 +99,7 @@ The goal of this layer is simple:
 
 The CLI is the engine, but the self-hosted Pluxx plugin is part of the real product surface for average users.
 
-All nine PLUXX-313 through PLUXX-321 audit remediations are merged. The combined 0.1.32 tagged state now includes safer ingestion and replay records, fail-closed Autopilot recovery and Agent Mode boundaries, stronger semantic evaluation and translation/YAML truth, atomic authoring/build mutations, transactional ownership-aware installs, release integrity/recovery, and proof freshness governance. Tag existence does not prove npm publication or a GitHub release; both remain unverified after the failed first release run.
+All nine PLUXX-313 through PLUXX-321 audit remediations are merged. The historical combined 0.1.32 tagged state added safer ingestion and replay records, fail-closed Autopilot recovery and Agent Mode boundaries, stronger semantic evaluation and translation/YAML truth, atomic authoring/build mutations, transactional ownership-aware installs, release integrity/recovery, and proof freshness governance. PLUXX-333 prepares 0.1.33 to fix release installers that rejected trusted pre-ownership plugin installs instead of adopting them into ownership ledgers.
 
 That means near-term product quality is not only about compiler depth.
 It is also about making the plugin-guided path feel obvious, safe, and understandable on top of the same CLI truth.
@@ -135,7 +135,7 @@ Generated Codex companion artifacts should become operational rather than only a
 
 The decision note is [docs/orchid/decisions/2026-06-26-pluxx-next-ship-review.md](./orchid/decisions/2026-06-26-pluxx-next-ship-review.md).
 
-Core-four local installs now use a shared transactional ownership layer. Copied bundles are staged and validated before an atomic sibling swap, the previous bundle stays recoverable until post-install work succeeds, ownership records hash installed files, reinstall refuses modified or unowned content, uninstall removes only unchanged owned files, and `verify-install` reports same-version content drift. Generated GitHub Release installers pin their tagged release and add install-scoped locking, bounded downloads, signal-safe recovery, and the same stage/backup/rollback and ownership contract.
+Core-four local installs now use a shared transactional ownership layer. Copied bundles are staged and validated before an atomic sibling swap, the previous bundle stays recoverable until post-install work succeeds, ownership records hash installed files, reinstall refuses modified or unowned content, uninstall removes only unchanged owned files, and `verify-install` reports same-version content drift. Generated GitHub Release installers pin their tagged release and add install-scoped locking, bounded downloads, signal-safe recovery, and the same stage/backup/rollback and ownership contract. The 0.1.33 release-prep lane also allows a one-time trusted legacy adoption when a pre-ownership installed host manifest matches the candidate bundle identity; arbitrary or mismatched directories still fail closed.
 
 Codex companion config now has a conservative inverse too: `pluxx codex apply` records the exact before/after config state it owns, and `pluxx codex unapply` restores the prior state only while the applied config remains unchanged. If the user edits active config after apply, unapply preserves it and asks for manual reconciliation instead of overwriting unrelated changes.
 
@@ -369,7 +369,7 @@ The repo already proves a lot.
 - historical release-gate evidence from 2026-05-19 remains available but is not current proof:
   - `npm test` passed
   - `npm run release:check` passed
-- the canonical repository version is `@orchid-labs/pluxx@0.1.32`, tagged as `v0.1.32` at `188527e`; the historical published baseline remains 0.1.31 while release recovery is pending
+- the canonical repository version is `@orchid-labs/pluxx@0.1.33` in release-prep for PLUXX-333; previous `v0.1.32` release evidence is historical once this fix ships
 - marketplace submission APIs, a managed trust/distribution control plane, automatic rollback/unpublish orchestration, and real authenticated publish plus rollback proof remain explicit release gaps, not hidden shipped capabilities:
   - `docs/release-distribution-proof-map.md`
   - “automatic rollback” here means remote release rollback/unpublish; generated local installers now restore the prior bundle when staged setup fails
@@ -539,9 +539,9 @@ Run two lanes in parallel:
 
 ### 6. Release State
 
-The canonical repository version is `0.1.32`, and tag `v0.1.32` exists at `188527e`. The first release run failed before npm publication or GitHub release creation because its shallow checkout could not reach the receipt commit. The historical published baseline remains 0.1.31 until the coordinator merges the recovery PR, dispatches the existing tag through the trusted main workflow, and verifies public artifacts. `package.json` is the source of truth for repository docs, while [proof-manifest.json](./proof-manifest.json) records tag state and proof freshness.
+The canonical repository version is `0.1.33` in release-prep. The previous `v0.1.32` tag and package are historical release evidence for the prior baseline. `package.json` is the source of truth for repository docs, while [proof-manifest.json](./proof-manifest.json) records tag state and proof freshness.
 
-For v0.1.32, finish review and reach substantive green, merge the focused recovery PR, dispatch the existing `v0.1.32` tag through the trusted workflow, then verify npm, GitHub, the published tarball, and CLI behavior. Do not move or recreate the tag. Future releases should repeat the version bump and release-prep proof work on a focused PR before tagging.
+For v0.1.33, finish PLUXX-333 review, merge the focused fix, create the immutable `v0.1.33` tag from main, then verify npm, GitHub, the published tarball, and CLI behavior. Future releases should repeat the version bump and release-prep proof work on a focused PR before tagging.
 
 ## Working Rules
 

--- a/docs/todo/master-backlog.md
+++ b/docs/todo/master-backlog.md
@@ -1,6 +1,6 @@
 # Master Backlog
 
-Last updated: 2026-07-12
+Last updated: 2026-07-16
 
 This is the most complete repo-native backlog for Pluxx.
 
@@ -82,15 +82,15 @@ Any person or agent should be able to enter the repo and answer:
 
 Proof governance is now explicit: [proof-freshness.md](../proof-freshness.md) defines the five evidence tiers and freshness rules, while [proof-manifest.json](../proof-manifest.json) keeps machine-readable receipts and current/historical claim state aligned with `package.json`.
 
-### 0. v0.1.32 release recovery
+### 0. v0.1.33 legacy installer adoption release
 
 - [x] Merge all nine PLUXX-313 through PLUXX-321 audit-remediation PRs into main at `f92e3cc`
-- [x] Prepare 0.1.32 in PLUXX-322 with synchronized package, proof, planning, and release truth
-- [x] Generate fresh repository-validation and fake-home-install receipts from committed 0.1.32 state
-- [x] Pass the official 751/751 serial suite and complete release gate
-- [x] Merge the release PR and push immutable tag `v0.1.32` at `188527e`
-- [ ] Merge the focused workflow-recovery PR after substantive checks and review are green
-- [ ] Coordinator: dispatch the existing tag through the trusted main workflow, verify npm/GitHub/tarball/CLI, then archive the completed batch
+- [x] Prepare 0.1.33 in PLUXX-333 with synchronized package, proof, planning, and release truth
+- [x] Generate fresh repository-validation and fake-home-install receipts for 0.1.33 release-prep state
+- [x] Pass the official serial suite and complete release gate
+- [ ] Merge the release PR and push immutable tag `v0.1.33` from main
+- [ ] Merge the focused legacy-installer-adoption PR after substantive checks and review are green
+- [ ] Coordinator: dispatch the trusted tag workflow, verify npm/GitHub/tarball/CLI, then archive the completed batch
 
 ### 1. Product clarity and front-door coherence
 
@@ -127,6 +127,7 @@ Proof governance is now explicit: [proof-freshness.md](../proof-freshness.md) de
   - keep execution aligned with `PLUXX-226`, `PLUXX-264`, and `PLUXX-248`
   - see [docs/orchid/decisions/2026-06-26-pluxx-next-ship-review.md](../orchid/decisions/2026-06-26-pluxx-next-ship-review.md)
 - [x] Add transactional install ownership so reinstall, uninstall, and "what did Pluxx touch?" diagnostics stay conservative:
+- [x] Add trusted pre-ownership adoption so generated release installers can upgrade legacy installs only when host manifest identity matches the candidate bundle:
   - shared core-four ownership records hash installed files and validate paths before mutation
   - copied installs and generated release installers use stage, backup, atomic swap, and rollback
   - modified and unowned files block replacement and survive uninstall
@@ -449,12 +450,16 @@ Open work:
 ### 7. Next release readiness
 
 - [x] Merge the nine v0.1.31 audit-remediation PRs
-- [x] Prepare and merge the focused v0.1.32 release PR under PLUXX-322
-- [x] Refresh current repository/fake-home receipts from committed 0.1.32 state
-- [x] Pass targeted checks, official serial 751/751 `npm test`, and `npm run release:check`
+- [x] Prepare and merge the historical focused v0.1.32 release PR under PLUXX-322
+- [ ] Prepare and merge the focused v0.1.33 legacy installer adoption PR under PLUXX-333
+- [x] Preserve historical repository/fake-home receipts from committed 0.1.32 state
+- [x] Refresh current repository/fake-home receipts from 0.1.33 release-prep state
+- [x] Pass targeted checks, official serial 758/758 `npm test`, and `npm run release:check`
 - [x] Merge the release-prep PR and push `v0.1.32` at `188527e`
-- [ ] Merge the workflow-recovery PR, then dispatch the existing tag through the trusted main workflow
-- [ ] Verify `@orchid-labs/pluxx@0.1.32`, GitHub release assets, tarball contents, and CLI behavior
+- [ ] Merge the PLUXX-333 release-prep PR and push `v0.1.33` from main
+- [ ] Merge the legacy-installer-adoption PR, then dispatch the trusted tag workflow
+- [x] Verify `@orchid-labs/pluxx@0.1.32`, GitHub release assets, tarball contents, and CLI behavior
+- [ ] Verify `@orchid-labs/pluxx@0.1.33`, GitHub release assets, tarball contents, and CLI behavior
 
 ## Next
 

--- a/docs/todo/queue.md
+++ b/docs/todo/queue.md
@@ -1,6 +1,6 @@
 # Pluxx Queue
 
-Last updated: 2026-07-12
+Last updated: 2026-07-16
 
 ## Doc Links
 
@@ -55,7 +55,7 @@ For broader context, use:
 
 ## Current Truth
 
-All nine PLUXX-313 through PLUXX-321 audit remediations are merged, and the 0.1.32 release PR is merged at `188527e`. Tag `v0.1.32` exists there, but the first release run failed before npm publication or GitHub release creation because its checkout could not reach the proof receipt commit. PLUXX-322 now owns the focused workflow-recovery PR; the coordinator retains merge, recovery dispatch, public artifact verification, and archive ownership.
+All nine PLUXX-313 through PLUXX-321 audit remediations are merged, and the previous 0.1.32 release is now historical baseline evidence. PLUXX-333 owns the active release-blocking fix for generated installers rejecting trusted pre-ownership installs.
 
 The core-four compiler sprint is done.
 
@@ -188,7 +188,7 @@ The initial author-once hardening tranche is also materially done.
 The public baseline is also real.
 
 - npm package is live as `@orchid-labs/pluxx`
-- the canonical repository version is `@orchid-labs/pluxx@0.1.32`, tagged as `v0.1.32` at `188527e`; the historical published baseline remains 0.1.31 while recovery is pending
+- the canonical repository version is `@orchid-labs/pluxx@0.1.33` in release-prep for PLUXX-333; previous `v0.1.32` evidence is historical after this fix ships
 - proof claims now use [docs/proof-freshness.md](../proof-freshness.md) and [docs/proof-manifest.json](../proof-manifest.json) so historical host runs cannot masquerade as current evidence
 - published CLI runtime is Node `>=18`
 - published CLI lifecycle ergonomics are now stronger for global installs:
@@ -244,6 +244,7 @@ Open work:
   - keep this aligned with `PLUXX-226`, `PLUXX-264`, and `PLUXX-248`
   - use [docs/orchid/decisions/2026-06-26-pluxx-next-ship-review.md](../orchid/decisions/2026-06-26-pluxx-next-ship-review.md) as the decision note
 - [x] Ship transactional core-four install ownership for conservative reinstall, uninstall, and content diagnostics:
+- [x] Ship PLUXX-333 trusted pre-ownership installer adoption so existing generated plugin installs can upgrade without manual removal:
   - local copied installs and generated release installers stage and validate before a sibling swap
   - the prior bundle remains available for rollback until post-install work succeeds
   - modified or unowned installed files are preserved instead of silently replaced or deleted
@@ -495,22 +496,22 @@ Open work:
   - native bundles across the core four
   - install verification and truthful compatibility
 
-### 6. v0.1.32 release recovery
+### 6. v0.1.33 legacy installer adoption release
 
 Current work:
 
 - [x] PLUXX-322 prepared and merged the focused release PR at `188527e`
-- [x] bump `package.json` and `package-lock.json` to 0.1.32
+- [x] bump `package.json` and `package-lock.json` to 0.1.33
 - [x] refresh canonical release, planning, and proof truth without carrying old evidence forward as current
-- [x] generate fresh repository-validation and fake-home-install receipts from committed 0.1.32 state
-- [x] pass the official serial 751/751 suite and `npm run release:check`
-- [x] push immutable tag `v0.1.32` at `188527e`
-- [ ] merge the focused workflow-recovery PR after substantive checks and review are green
+- [x] generate fresh repository-validation and fake-home-install receipts for 0.1.33 release-prep state
+- [x] pass the official serial suite and `npm run release:check`
+- [ ] push immutable tag `v0.1.33` from main after merge
+- [ ] merge the focused legacy-installer-adoption PR after substantive checks and review are green
 
 Coordinator-owned after this task:
 
-- merge the workflow-recovery PR
-- dispatch the existing `v0.1.32` tag through the trusted main workflow without moving or recreating it
+- merge the legacy-installer-adoption PR
+- dispatch the trusted tag workflow for `v0.1.33` after merge
 - monitor publishing and verify npm, GitHub, tarball, and CLI surfaces
 - archive completed tasks
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orchid-labs/pluxx",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchid-labs/pluxx",
-      "version": "0.1.32",
+      "version": "0.1.33",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orchid-labs/pluxx",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "description": "Build AI agent plugins once. Prime-time on Claude Code, Cursor, Codex, and OpenCode, with beta generators for additional hosts.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/cli/publish.ts
+++ b/src/cli/publish.ts
@@ -1831,11 +1831,43 @@ const walk = (root) => {
   visit(root)
   return result
 }
+const refuseUnownedInstall = (reason) => {
+  throw new Error('Refusing to replace unowned install at ' + installDir + ': ' + reason + '. Move it aside or uninstall it manually, then retry.')
+}
+const manifestRelativePathByPlatform = {
+  'claude-code': '.claude-plugin/plugin.json',
+  cursor: '.cursor-plugin/plugin.json',
+  codex: '.codex-plugin/plugin.json',
+  opencode: 'package.json',
+}
+const readJson = (filepath, label) => {
+  if (!fs.existsSync(filepath)) refuseUnownedInstall('missing ' + label)
+  try {
+    return JSON.parse(fs.readFileSync(filepath, 'utf8'))
+  } catch {
+    refuseUnownedInstall('malformed ' + label)
+  }
+}
+const identityName = (manifest) => {
+  if (!manifest || typeof manifest !== 'object') return undefined
+  return typeof manifest.name === 'string' && manifest.name.trim() !== '' ? manifest.name.trim() : undefined
+}
+const assertTrustedLegacyInstall = () => {
+  const manifestRelativePath = manifestRelativePathByPlatform[platform]
+  if (!manifestRelativePath) refuseUnownedInstall('unsupported platform ' + platform)
+  const installedManifest = readJson(path.join(installDir, manifestRelativePath), 'installed host manifest')
+  const candidateManifest = readJson(path.join(process.env.PLUXX_BUNDLE_DIR, manifestRelativePath), 'candidate host manifest')
+  const installedName = identityName(installedManifest)
+  const candidateName = identityName(candidateManifest)
+  if (!installedName || !candidateName || installedName !== candidateName) {
+    refuseUnownedInstall('installed host manifest identity does not match candidate bundle')
+  }
+}
 if (fs.existsSync(installDir)) {
   if (!fs.existsSync(ownershipPath)) {
     const legacy = walk(installDir)
     if (!legacy.every((entry) => entry.path === '.pluxx-user.json')) {
-      throw new Error('Refusing to replace unowned install at ' + installDir + '. Move it aside or uninstall it manually, then retry.')
+      assertTrustedLegacyInstall()
     }
   } else {
     const record = JSON.parse(fs.readFileSync(ownershipPath, 'utf8'))
@@ -2362,6 +2394,33 @@ const movePath = (source, destination) => {
   else fs.copyFileSync(source, destination)
   fs.rmSync(source, { recursive: true, force: true })
 }
+const frontmatterName = (content) => {
+  const match = content.match(/^---\\n([\\s\\S]*?)\\n---\\n?/)
+  if (!match) return undefined
+  const nameMatch = match[1].match(/^name:\\s*(.+)$/m)
+  return nameMatch ? nameMatch[1].trim().replace(/^['"]|['"]$/g, '') : undefined
+}
+const isTrustedLegacyOpenCodeCompanion = (candidate) => {
+  if (candidate.remove || !fs.existsSync(candidate.destination)) return false
+  if (candidate.kind === 'file') {
+    if (!fs.lstatSync(candidate.destination).isFile() || fs.lstatSync(candidate.destination).isSymbolicLink()) return false
+    const content = fs.readFileSync(candidate.destination, 'utf8')
+    return content.includes('import * as PluginModule from "./' + pluginName + '/index.ts"')
+      && content.includes('directory: join(context.directory, "' + pluginName + '")')
+      && content.includes('Object.values(PluginModule).find')
+  }
+  if (candidate.kind === 'copy' && candidate.surface.startsWith('skill-')) {
+    if (!fs.lstatSync(candidate.destination).isDirectory() || fs.lstatSync(candidate.destination).isSymbolicLink()) return false
+    const skillPath = path.join(candidate.destination, 'SKILL.md')
+    const candidateSkillPath = path.join(candidate.source, 'SKILL.md')
+    if (!fs.existsSync(skillPath) || !fs.lstatSync(skillPath).isFile()) return false
+    if (!fs.existsSync(candidateSkillPath) || !fs.lstatSync(candidateSkillPath).isFile()) return false
+    const name = frontmatterName(fs.readFileSync(skillPath, 'utf8'))
+    const candidateName = frontmatterName(fs.readFileSync(candidateSkillPath, 'utf8'))
+    return typeof name === 'string' && name === candidateName && name.startsWith(pluginName + '/')
+  }
+  return false
+}
 for (const candidate of candidates) {
   const ledgerPath = path.join(ledgerRoot, 'opencode--' + candidate.surface + '.json')
   candidate.ledgerPath = ledgerPath
@@ -2369,7 +2428,10 @@ for (const candidate of candidates) {
     if (fs.existsSync(ledgerPath)) throw new Error('Refusing to replace missing owned OpenCode companion: ' + candidate.destination)
     continue
   }
-  if (!fs.existsSync(ledgerPath)) throw new Error('Refusing to replace unowned OpenCode companion: ' + candidate.destination)
+  if (!fs.existsSync(ledgerPath)) {
+    if (isTrustedLegacyOpenCodeCompanion(candidate)) continue
+    throw new Error('Refusing to replace unowned OpenCode companion: ' + candidate.destination)
+  }
   const record = JSON.parse(fs.readFileSync(ledgerPath, 'utf8'))
   if (record.schema !== 'pluxx.install-ownership.v1' || record.pluginName !== pluginName || record.platform !== 'opencode' || record.surface !== candidate.surface || path.resolve(record.installPath || '') !== candidate.destination || record.kind !== candidate.kind) {
     throw new Error('Invalid OpenCode companion ownership record: ' + ledgerPath)

--- a/tests/autopilot.test.ts
+++ b/tests/autopilot.test.ts
@@ -11,6 +11,7 @@ const INTROSPECT_PATH = resolve(ROOT, 'src/mcp/introspect.ts')
 const TEST_COMMAND_PATH = resolve(ROOT, 'src/cli/test.ts')
 const originalArgv = [...process.argv]
 const originalCwd = process.cwd()
+const SLOW_AUTOPILOT_TIMEOUT = 120_000
 
 function spawnCli(argv: string[], cwd: string, env: Record<string, string> = {}) {
   return Bun.spawn(['bun', resolve(ROOT, 'bin/pluxx.js'), ...argv], {
@@ -413,7 +414,7 @@ exit 0
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }
-  })
+  }, SLOW_AUTOPILOT_TIMEOUT)
 
   it('reports the stable verification discriminator and restores baseline after post-agent verification fails', async () => {
     const { dir, statePath, stubServerPath } = createStubServerFixture()
@@ -944,7 +945,7 @@ exit 0
       rmSync(runnerArgsPath, { force: true })
       rmSync(dir, { recursive: true, force: true })
     }
-  })
+  }, SLOW_AUTOPILOT_TIMEOUT)
 
   it('runs the full autopilot flow with a headless runner and verifies the scaffold', async () => {
     const { dir, statePath, stubServerPath } = createStubServerFixture()
@@ -1314,7 +1315,7 @@ exit 0
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }
-  })
+  }, SLOW_AUTOPILOT_TIMEOUT)
 
   it('suppresses runner logs by default and streams them with --verbose-runner', async () => {
     const run = async (verboseRunner: boolean) => {
@@ -1373,7 +1374,7 @@ exit 0
 
     const verbose = await run(true)
     expect(verbose.stdout).toContain(verbose.marker)
-  }, 60_000)
+  }, SLOW_AUTOPILOT_TIMEOUT)
 
   it('prints explicit auth guidance for OAuth-first remote MCPs', async () => {
     const dir = mkdtempSync(resolve(tmpdir(), 'pluxx-autopilot-auth-'))

--- a/tests/mcp-runtime-env.test.ts
+++ b/tests/mcp-runtime-env.test.ts
@@ -11,6 +11,31 @@ function makeTempDir(prefix: string): string {
   return dir
 }
 
+const WORKSPACE_ENV_KEYS = [
+  'PLUXX_MCP_WORKSPACE_ROOT',
+  'PLUXX_WORKSPACE_ROOT',
+  'PLUXX_HOOK_WORKSPACE_ROOT',
+  'CODEX_WORKSPACE_ROOT',
+  'CODEX_WORKDIR',
+  'CODEX_CWD',
+  'CLAUDE_PROJECT_DIR',
+  'CLAUDE_CWD',
+  'CURSOR_WORKSPACE_ROOT',
+  'OPENCODE_WORKSPACE_ROOT',
+  'WORKSPACE_ROOT',
+  'PROJECT_ROOT',
+  'INIT_CWD',
+  'PWD',
+] as const
+
+function isolatedRuntimeEnv(extra: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env, ...extra }
+  for (const key of WORKSPACE_ENV_KEYS) {
+    delete env[key]
+  }
+  return env
+}
+
 function preparePluginRoot(rootDir: string): { pluginRoot: string; wrapperPath: string; capturePath: string } {
   const pluginRoot = resolve(rootDir, 'plugin')
   const runtimeDir = resolve(pluginRoot, 'runtime')
@@ -69,12 +94,11 @@ describe('MCP runtime env launcher', () => {
       ], {
         cwd: workspaceRoot,
         encoding: 'utf-8',
-        env: {
-          ...process.env,
+        env: isolatedRuntimeEnv({
           PLUXX_CAPTURE_PATH: outputPath,
           SENDLENS_INSTANTLY_API_KEY: 'global-key',
           SENDLENS_CLIENT: 'global-client',
-        },
+        }),
       })
 
       expect(result.status).toBe(0)
@@ -95,6 +119,7 @@ describe('MCP runtime env launcher', () => {
     try {
       const workspaceRoot = resolve(rootDir, 'workspace')
       mkdirSync(workspaceRoot, { recursive: true })
+      mkdirSync(resolve(workspaceRoot, '.git'), { recursive: true })
 
       const { wrapperPath, capturePath } = preparePluginRoot(rootDir)
       const outputPath = resolve(rootDir, 'captured.json')
@@ -107,12 +132,11 @@ describe('MCP runtime env launcher', () => {
       ], {
         cwd: workspaceRoot,
         encoding: 'utf-8',
-        env: {
-          ...process.env,
+        env: isolatedRuntimeEnv({
           PLUXX_CAPTURE_PATH: outputPath,
           SENDLENS_INSTANTLY_API_KEY: 'global-key',
           SENDLENS_CLIENT: 'global-client',
-        },
+        }),
       })
 
       expect(result.status).toBe(0)

--- a/tests/publish.test.ts
+++ b/tests/publish.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from 'bun:test'
 import { createHash } from 'crypto'
 import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'fs'
 import { spawnSync } from 'child_process'
-import { resolve } from 'path'
+import { dirname, resolve } from 'path'
 import type { PluginConfig, TargetPlatform } from '../src/schema'
 import { planPublish, runPublish } from '../src/cli/publish'
 import {
@@ -275,6 +275,74 @@ interface GeneratedInstallerRunResult {
 
 function isolatedInstallerEnvironment(source: Record<string, string | undefined>): Record<string, string> {
   return { PATH: source.PATH ?? '/usr/bin:/bin' }
+}
+
+function legacyManifestPathForPlatform(platform: TargetPlatform, installDir: string): string {
+  if (platform === 'claude-code') return resolve(installDir, '.claude-plugin/plugin.json')
+  if (platform === 'cursor') return resolve(installDir, '.cursor-plugin/plugin.json')
+  if (platform === 'codex') return resolve(installDir, '.codex-plugin/plugin.json')
+  if (platform === 'opencode') return resolve(installDir, 'package.json')
+  throw new Error(`Unsupported legacy manifest test platform: ${platform}`)
+}
+
+function matchingLegacyManifestForPlatform(platform: TargetPlatform): Record<string, unknown> {
+  if (platform === 'opencode') {
+    return { name: '@orchid/publish-plugin-opencode', version: '1.2.2', type: 'module' }
+  }
+
+  return {
+    name: 'publish-plugin',
+    version: '1.2.2',
+    description: `Legacy ${platform} install`,
+  }
+}
+
+function writeLegacyInstalledManifest(platform: TargetPlatform, installDir: string, manifest: Record<string, unknown> | string): void {
+  const manifestPath = legacyManifestPathForPlatform(platform, installDir)
+  mkdirSync(resolve(manifestPath, '..'), { recursive: true })
+  writeFileSync(
+    manifestPath,
+    typeof manifest === 'string' ? manifest : JSON.stringify(manifest, null, 2) + '\n',
+  )
+}
+
+function generatedInstallerOwnershipPath(platform: TargetPlatform, rootDir: string, installDir: string): string {
+  const home = resolve(rootDir, 'home')
+  const resolvedInstallDir = resolve(installDir)
+  const conventionalRoots = [
+    resolve(home, '.claude/plugins'),
+    resolve(home, '.cursor/plugins'),
+    resolve(home, '.codex/plugins'),
+    resolve(home, '.config/opencode'),
+  ]
+  const ownershipRoot = conventionalRoots.some((root) => resolvedInstallDir === root || resolvedInstallDir.startsWith(root + '/'))
+    ? resolve(home, '.pluxx/install-ownership')
+    : resolve(dirname(resolvedInstallDir), '.pluxx-install-ownership')
+  return resolve(ownershipRoot, 'publish-plugin', `${platform}.json`)
+}
+
+function legacyOpenCodeWrapper(): string {
+  return [
+    'import type { Plugin } from "@opencode-ai/plugin"',
+    'import { join } from "path"',
+    '',
+    'import * as PluginModule from "./publish-plugin/index.ts"',
+    '',
+    '// OpenCode auto-loads plugin files placed directly in ~/.config/opencode/plugins.',
+    '// Proxy into the installed plugin bundle while preserving its expected root.',
+    'const pluginFactory = Object.values(PluginModule).find((value): value is Plugin => typeof value === "function")',
+    '',
+    'if (!pluginFactory) {',
+    '  throw new Error("OpenCode plugin bundle for publish-plugin did not export a plugin function.")',
+    '}',
+    '',
+    'export const PublishPlugin: Plugin = async (context) =>',
+    '  pluginFactory({',
+    '    ...context,',
+    '    directory: join(context.directory, "publish-plugin"),',
+    '  })',
+    '',
+  ].join('\n')
 }
 
 function getGeneratedInstallerPaths(platform: TargetPlatform, rootDir: string): {
@@ -1467,6 +1535,132 @@ with tarfile.open(archive, 'w:gz') as tf:
     expect(readFileSync(resolve(run.rootDir, 'publish-plugin.ts'), 'utf-8')).toBe('// private wrapper\n')
     expect(readFileSync(resolve(run.pluginInstallDir, '.pluxx-user.json'), 'utf-8')).toBe('{}\n')
     expect(existsSync(resolve(run.pluginInstallDir, 'package.json'))).toBe(false)
+  })
+
+
+  it('adopts trusted pre-ownership generated installs across core hosts', () => {
+    const platforms: TargetPlatform[] = ['claude-code', 'cursor', 'codex', 'opencode']
+
+    for (const platform of platforms) {
+      const run = runGeneratedInstaller(platform, {
+        config: { ...makeUserConfigInstallerConfig(platform), targets: [platform] },
+        existingUserConfig: {
+          values: { 'instantly-api-key': 'saved-instantly-key' },
+          env: { SENDLENS_INSTANTLY_API_KEY: 'saved-instantly-key' },
+        },
+        extraFiles: platform === 'opencode'
+          ? { 'skills/client-intel/SKILL.md': '# Client Intel\n' }
+          : {},
+        setupPaths: (paths) => {
+          writeLegacyInstalledManifest(platform, paths.pluginInstallDir, matchingLegacyManifestForPlatform(platform))
+          writeFileSync(resolve(paths.pluginInstallDir, 'legacy-pre-ownership.txt'), 'legacy bundle marker\n')
+
+          if (platform === 'opencode') {
+            const entryPath = paths.env.PLUXX_OPENCODE_ENTRY_PATH
+            mkdirSync(resolve(entryPath, '..'), { recursive: true })
+            writeFileSync(entryPath, legacyOpenCodeWrapper())
+
+            const skillDir = resolve(paths.env.PLUXX_OPENCODE_SKILLS_ROOT, 'publish-plugin-client-intel')
+            mkdirSync(skillDir, { recursive: true })
+            writeFileSync(resolve(skillDir, 'SKILL.md'), '---\nname: publish-plugin/client-intel\n---\n\n# Client Intel\n')
+          }
+        },
+      })
+
+      expect(run.status, `${platform} installer failed:\n${run.stderr}\n${run.stdout}`).toBe(0)
+      expect(run.stderr).toBe('')
+      expect(existsSync(resolve(run.pluginInstallDir, 'legacy-pre-ownership.txt'))).toBe(false)
+      expect(existsSync(generatedInstallerOwnershipPath(platform, run.rootDir, run.pluginInstallDir))).toBe(true)
+      expect(run.stdout).toContain('Found existing publish-plugin config; reusing saved install values.')
+
+      if (platform === 'codex') {
+        expect(run.installedUserConfig?.envRefs?.SENDLENS_INSTANTLY_API_KEY).toBe('SENDLENS_INSTANTLY_API_KEY')
+      } else {
+        expect(run.installedUserConfig?.values?.['instantly-api-key']).toBe('saved-instantly-key')
+        expect(run.installedUserConfig?.env?.SENDLENS_INSTANTLY_API_KEY).toBe('saved-instantly-key')
+      }
+
+      if (platform === 'opencode') {
+        expect(readFileSync(resolve(run.rootDir, 'publish-plugin.ts'), 'utf-8')).toContain('OpenCode auto-loads plugin files')
+        expect(readFileSync(resolve(run.rootDir, 'opencode-skills/publish-plugin-client-intel/SKILL.md'), 'utf-8')).toContain('name: publish-plugin/client-intel')
+      }
+    }
+  })
+
+  it('rejects unowned legacy installs with missing, malformed, or mismatched manifests', () => {
+    const cases: Array<{ name: string; writeManifest?: (installDir: string) => void }> = [
+      { name: 'missing manifest' },
+      {
+        name: 'malformed manifest',
+        writeManifest: (installDir) => writeLegacyInstalledManifest('cursor', installDir, '{not-json\n'),
+      },
+      {
+        name: 'mismatched manifest',
+        writeManifest: (installDir) => writeLegacyInstalledManifest('cursor', installDir, { name: 'other-plugin', version: '9.9.9' }),
+      },
+    ]
+
+    for (const testCase of cases) {
+      const run = runGeneratedInstaller('cursor', {
+        existingUserConfig: { values: { marker: testCase.name } },
+        setupPaths: (paths) => {
+          writeFileSync(resolve(paths.pluginInstallDir, 'untrusted.txt'), 'do not replace\n')
+          testCase.writeManifest?.(paths.pluginInstallDir)
+        },
+      })
+
+      expect(run.status, testCase.name).toBe(1)
+      expect(run.stderr, testCase.name).toContain('Refusing to replace unowned install')
+      expect(readFileSync(resolve(run.pluginInstallDir, 'untrusted.txt'), 'utf-8')).toBe('do not replace\n')
+      expect(run.installedUserConfig?.values?.marker).toBe(testCase.name)
+    }
+  })
+
+  it('rejects mismatched pre-ownership generated install identity across core hosts', () => {
+    const platforms: TargetPlatform[] = ['claude-code', 'cursor', 'codex', 'opencode']
+
+    for (const platform of platforms) {
+      const run = runGeneratedInstaller(platform, {
+        existingUserConfig: { values: { marker: 'legacy' } },
+        setupPaths: (paths) => {
+          const manifest = platform === 'opencode'
+            ? { name: '@orchid/other-plugin-opencode', version: '1.2.2' }
+            : { name: 'other-plugin', version: '1.2.2' }
+          writeLegacyInstalledManifest(platform, paths.pluginInstallDir, manifest)
+          writeFileSync(resolve(paths.pluginInstallDir, 'legacy-pre-ownership.txt'), 'do not replace\n')
+        },
+      })
+
+      expect(run.status, `${platform} should fail closed`).toBe(1)
+      expect(run.stderr).toContain('Refusing to replace unowned install')
+      expect(readFileSync(resolve(run.pluginInstallDir, 'legacy-pre-ownership.txt'), 'utf-8')).toBe('do not replace\n')
+    }
+  })
+
+  it('rejects unrecognized legacy OpenCode skill companion collisions', () => {
+    const cases = [
+      { name: 'no legacy frontmatter', content: '# Private unrelated skill\n' },
+      { name: 'wrong legacy namespace identity', content: '---\nname: publish-plugin/other-skill\n---\n\n# Private unrelated skill\n' },
+    ]
+
+    for (const testCase of cases) {
+      const run = runGeneratedInstaller('opencode', {
+        config: { ...makeConfig(), targets: ['opencode'] },
+        existingUserConfig: { values: { marker: testCase.name } },
+        extraFiles: { 'skills/client-intel/SKILL.md': '# Client Intel\n' },
+        setupPaths: (paths) => {
+          writeLegacyInstalledManifest('opencode', paths.pluginInstallDir, matchingLegacyManifestForPlatform('opencode'))
+          const skillDir = resolve(paths.env.PLUXX_OPENCODE_SKILLS_ROOT, 'publish-plugin-client-intel')
+          mkdirSync(skillDir, { recursive: true })
+          writeFileSync(resolve(skillDir, 'SKILL.md'), testCase.content)
+        },
+      })
+
+      expect(run.status, testCase.name).toBe(1)
+      expect(run.stderr, testCase.name).toContain('Refusing to replace unowned OpenCode companion')
+      expect(readFileSync(resolve(run.rootDir, 'opencode-skills/publish-plugin-client-intel/SKILL.md'), 'utf-8')).toBe(testCase.content)
+      expect(run.installedUserConfig?.values?.marker).toBe(testCase.name)
+    }
   })
 
   it('reuses saved generated-installer user config across core host updates', () => {


### PR DESCRIPTION
## Summary

- allow generated installers to adopt trusted pre-ownership installs when the existing host manifest identity matches the staged candidate bundle for that host
- keep arbitrary/missing/malformed/mismatched legacy installs fail-closed, and preserve ownership-ledger rollback behavior for managed installs
- migrate recognized legacy OpenCode entry wrappers and exact namespaced skill companions without overwriting unrelated companion collisions
- bump Pluxx to 0.1.33 and refresh the narrow release/proof docs for PLUXX-333

Linear: [PLUXX-333](https://linear.app/orchid-automation/issue/PLUXX-333/fix-release-installers-rejecting-trusted-pre-ownership-plugin-installs)

## Validation

- `bun test tests/publish.test.ts --timeout 120000` (48 passed / 478 expectations)
- `bun test tests/install-ownership.test.ts --timeout 120000`
- `npm run typecheck`
- `npm run build`
- `npm test` (61 files / 758 tests)
- `npm run proof:check`
- `npm run release:check` (proof freshness, build, typecheck, full tests, package runtime verification, dry-run npm pack)
- `git diff --check`

## Release notes

After merge, tag `v0.1.33` from main and verify npm/GitHub release publication before SendLens consumes the fix.
