### PR TITLE
Fix release recovery npm integrity comparison

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,12 +109,17 @@ jobs:
           set -euo pipefail
           EXPECTED_VERSION="${{ steps.version.outputs.package_version }}"
           EXPECTED_INTEGRITY="${{ steps.pack.outputs.package_integrity }}"
+          extract_integrity() {
+            awk '/^sha512-/{ value = $0 } END { if (value != "") print value }'
+          }
+
           set +e
           EXISTING_OUTPUT="$(npm view "@orchid-labs/pluxx@${EXPECTED_VERSION}" dist.integrity 2>&1)"
           EXISTING_STATUS=$?
           set -e
           if [[ "$EXISTING_STATUS" -eq 0 ]]; then
-            EXISTING_INTEGRITY="$EXISTING_OUTPUT"
+            EXISTING_INTEGRITY="$(printf '%s\n' "$EXISTING_OUTPUT" | extract_integrity)"
+            test -n "$EXISTING_INTEGRITY"
             test "$EXISTING_INTEGRITY" = "$EXPECTED_INTEGRITY"
             echo "@orchid-labs/pluxx@${EXPECTED_VERSION} already exists with matching integrity; skipping immutable npm publish."
           elif grep -Eiq 'E404|404 Not Found|is not in this registry' <<<"$EXISTING_OUTPUT"; then
@@ -131,10 +136,15 @@ jobs:
           set -euo pipefail
           EXPECTED_VERSION="${{ steps.version.outputs.package_version }}"
           EXPECTED_INTEGRITY="${{ steps.pack.outputs.package_integrity }}"
+          extract_integrity() {
+            awk '/^sha512-/{ value = $0 } END { if (value != "") print value }'
+          }
+
           for attempt in 1 2 3 4 5 6; do
             if PUBLISHED_VERSION="$(npm view "@orchid-labs/pluxx@${EXPECTED_VERSION}" version)" \
-              && PUBLISHED_INTEGRITY="$(npm view "@orchid-labs/pluxx@${EXPECTED_VERSION}" dist.integrity)"; then
-              break
+              && PUBLISHED_INTEGRITY_RAW="$(npm view "@orchid-labs/pluxx@${EXPECTED_VERSION}" dist.integrity)"; then
+              PUBLISHED_INTEGRITY="$(printf '%s\n' "$PUBLISHED_INTEGRITY_RAW" | extract_integrity)"
+              if [[ -n "$PUBLISHED_INTEGRITY" ]]; then break; fi
             fi
             if [[ "$attempt" -eq 6 ]]; then exit 1; fi
             sleep 5

--- a/docs/proof-and-install.md
+++ b/docs/proof-and-install.md
@@ -32,7 +32,7 @@ For the fuller release/distribution boundary, including publish commands and def
 
 Proof labels and freshness come from [proof-freshness.md](./proof-freshness.md) and [proof-manifest.json](./proof-manifest.json). The May self-hosted run, April Firecrawl connector run, and previous 0.1.32 release evidence are preserved as historical environment evidence; they are not current host receipts for `0.1.33`.
 
-The current v0.1.33 receipts prove the `bundle-contract` and generated-installer `fake-home-install` tiers from release-prep state, including trusted legacy installer adoption across the core four. No current receipt claims installed-runtime or real-host behavior.
+The current v0.1.33 receipts prove the `bundle-contract` and generated-installer `fake-home-install` tiers from tagged release state, including trusted legacy installer adoption across the core four. No current receipt claims installed-runtime or real-host behavior.
 
 ## The Story In One Screen
 
@@ -208,7 +208,7 @@ curl -fsSL https://raw.githubusercontent.com/orchidautomation/pluxx/main/example
 
 Current release note:
 
-- the canonical repository version is `@orchid-labs/pluxx@0.1.33` in release-prep for trusted legacy installer adoption; previous `v0.1.32` public release evidence is historical once this fix ships
+- the canonical repository version is `@orchid-labs/pluxx@0.1.33` for trusted legacy installer adoption; previous `v0.1.32` public release evidence is historical
 - the published CLI runtime is Node `>=18`; see [runtime contract](./runtime-contract.md)
 - the published package includes the Claude plugin-agent manifest fix and packaged Node runtime verification
 - the public `pluxx test --install --trust --behavioral` path now matches the repo-local Exa proof state

--- a/docs/proof-manifest.json
+++ b/docs/proof-manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "canonicalVersion": "0.1.33",
   "expectedTag": "v0.1.33",
-  "releaseState": "release-prep",
+  "releaseState": "released",
   "policy": {
     "environmentReceiptMaxAgeDays": 30
   },
@@ -57,7 +57,7 @@
     },
     {
       "id": "v0.1.33-repository-validation",
-      "summary": "The v0.1.33 release-prep state passes the repository release gate for legacy installer adoption.",
+      "summary": "The v0.1.33 tagged release state passes the repository release gate for legacy installer adoption.",
       "tier": "bundle-contract",
       "freshness": "current",
       "evidencePath": "tests/proof-freshness.test.ts",

--- a/docs/release-distribution-proof-map.md
+++ b/docs/release-distribution-proof-map.md
@@ -26,7 +26,7 @@ Last updated: 2026-07-16
 
 This is the short release/distribution map for what Pluxx can ship today, what is locally proven, and what still belongs to later marketplace or trust-layer work.
 
-Proof state is governed by [proof-freshness.md](./proof-freshness.md) and the machine-readable [proof manifest](./proof-manifest.json). The canonical repository version is `0.1.33` in release-prep. The previous published `v0.1.32` release is historical once this fix ships; older host runs linked below are historical unless a current receipt says otherwise.
+Proof state is governed by [proof-freshness.md](./proof-freshness.md) and the machine-readable [proof manifest](./proof-manifest.json). The canonical repository version is `0.1.33`, tagged as `v0.1.33`. The previous published `v0.1.32` release is historical; older host runs linked below are historical unless a current receipt says otherwise.
 
 ## Current Primary Fronts
 
@@ -49,7 +49,7 @@ Pluxx can ship the OSS authoring substrate today:
 - `pluxx install` can install built bundles locally for the primary fronts
 - `pluxx verify-install` checks the host-visible installed bundle, not only generated files in `dist/`
 - `pluxx test --install` runs source checks, build smoke, local install, and installed verification together
-- `pluxx publish --github-release` packages built bundles and generates primary-front installers that pin the tagged release, use bounded download retries/timeouts, verify release checksums, reject unsafe archives, enforce install-scoped locking and ownership before replacement, stage setup, and restore the prior bundle plus owned companion state when post-swap work fails or is interrupted. Starting in the `0.1.33` release-prep lane, generated installers can also perform a one-time adoption of pre-ownership installs only when the existing host manifest identity matches the trusted candidate bundle for that exact host; post-publish verification downloads remote assets and compares their bytes with the generated local files
+- `pluxx publish --github-release` packages built bundles and generates primary-front installers that pin the tagged release, use bounded download retries/timeouts, verify release checksums, reject unsafe archives, enforce install-scoped locking and ownership before replacement, stage setup, and restore the prior bundle plus owned companion state when post-swap work fails or is interrupted. Starting in the `0.1.33` tagged release lane, generated installers can also perform a one-time adoption of pre-ownership installs only when the existing host manifest identity matches the trusted candidate bundle for that exact host; post-publish verification downloads remote assets and compares their bytes with the generated local files
 - `pluxx publish --npm` covers the npm-backed OpenCode wrapper package path; publish validates source/built/package version identity, compares exact packed-tarball SRI before reconciling immutable npm versions, and reconciles existing GitHub releases to the exact asset set
 - `pluxx upgrade` reports invocation source and version direction, verifies the active PATH binary/version, and prints an exact rollback command
 - `pluxx discover-mcp` and `pluxx init --from-installed-mcp` can import already configured MCP servers from Claude Code, Cursor, Codex, and OpenCode without copying literal secret values

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -82,7 +82,7 @@ The full v0.1.31 audit-remediation tranche is merged. Main now includes safer in
 
 Proof governance now distinguishes unit, bundle-contract, fake-home install, installed-runtime, and real-host behavior evidence. Canonical version/freshness checks run in CI through [proof-freshness.md](./proof-freshness.md) and [proof-manifest.json](./proof-manifest.json); historical April/May proof stays available without being treated as current.
 
-The active release-blocking slice is PLUXX-333 legacy installer adoption. The 0.1.33 release-prep branch fixes generated installers that rejected trusted pre-ownership installs, while keeping arbitrary or mismatched directories fail-closed.
+The active release-blocking slice is PLUXX-333 legacy installer adoption release recovery. The 0.1.33 tagged release fixes generated installers that rejected trusted pre-ownership installs, while keeping arbitrary or mismatched directories fail-closed.
 
 ### 1. Product clarity and source-of-truth coherence
 
@@ -228,7 +228,7 @@ The closure plan is now narrower than it was before:
 - historical release-gate evidence from 2026-05-19 remains available but is not current proof:
   - `npm test` passed
   - `npm run release:check` passed
-- the canonical repository version is `@orchid-labs/pluxx@0.1.33` in release-prep; previous `v0.1.32` release evidence is historical once this fix ships
+- the canonical repository version is `@orchid-labs/pluxx@0.1.33`; previous `v0.1.32` release evidence is historical
 - the release/distribution/proof boundary is now explicit:
   - [docs/release-distribution-proof-map.md](./release-distribution-proof-map.md)
   - [docs/core-four-primitive-proof-ledger.md](./core-four-primitive-proof-ledger.md)
@@ -388,7 +388,7 @@ This is for learning and proof, not for prematurely building the full trust laye
 
 ### 6. Next release
 
-The canonical repository version is `0.1.33` in release-prep. Current repository-validation and fake-home-install receipts are tied to the PLUXX-333 legacy installer adoption fix; previous 0.1.32 proof is historical for the prior release baseline.
+The canonical repository version is `0.1.33`, tagged as `v0.1.33`. Current repository-validation and fake-home-install receipts are tied to the PLUXX-333 legacy installer adoption fix; previous 0.1.32 proof is historical for the prior release baseline.
 
 The next npm cut should stay primarily an operations step rather than a code-confidence rescue step.
 

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -39,7 +39,7 @@ If you want the shortest public proof and install path after this file, use [doc
 
 If you want the current release, distribution, and proof boundary, use [docs/release-distribution-proof-map.md](./release-distribution-proof-map.md).
 
-If you need to know whether a proof claim is current, historical, repository-only, installed, or real-host evidence, use [docs/proof-freshness.md](./proof-freshness.md) and [docs/proof-manifest.json](./proof-manifest.json). Canonical repository version truth is `package.json` (`0.1.33`) and the proof manifest marks this branch as release-prep until tag `v0.1.33` is published. The previous `v0.1.32` tag and package are historical release evidence for the prior baseline.
+If you need to know whether a proof claim is current, historical, repository-only, installed, or real-host evidence, use [docs/proof-freshness.md](./proof-freshness.md) and [docs/proof-manifest.json](./proof-manifest.json). Canonical repository version truth is `package.json` (`0.1.33`) and the proof manifest marks `v0.1.33` as tagged. The previous `v0.1.32` tag and package are historical release evidence for the prior baseline.
 
 If you want the primitive-by-host proof ledger behind the core-four native shipping claim, use [docs/core-four-primitive-proof-ledger.md](./core-four-primitive-proof-ledger.md).
 
@@ -135,7 +135,7 @@ Generated Codex companion artifacts should become operational rather than only a
 
 The decision note is [docs/orchid/decisions/2026-06-26-pluxx-next-ship-review.md](./orchid/decisions/2026-06-26-pluxx-next-ship-review.md).
 
-Core-four local installs now use a shared transactional ownership layer. Copied bundles are staged and validated before an atomic sibling swap, the previous bundle stays recoverable until post-install work succeeds, ownership records hash installed files, reinstall refuses modified or unowned content, uninstall removes only unchanged owned files, and `verify-install` reports same-version content drift. Generated GitHub Release installers pin their tagged release and add install-scoped locking, bounded downloads, signal-safe recovery, and the same stage/backup/rollback and ownership contract. The 0.1.33 release-prep lane also allows a one-time trusted legacy adoption when a pre-ownership installed host manifest matches the candidate bundle identity; arbitrary or mismatched directories still fail closed.
+Core-four local installs now use a shared transactional ownership layer. Copied bundles are staged and validated before an atomic sibling swap, the previous bundle stays recoverable until post-install work succeeds, ownership records hash installed files, reinstall refuses modified or unowned content, uninstall removes only unchanged owned files, and `verify-install` reports same-version content drift. Generated GitHub Release installers pin their tagged release and add install-scoped locking, bounded downloads, signal-safe recovery, and the same stage/backup/rollback and ownership contract. The 0.1.33 tagged release lane also allows a one-time trusted legacy adoption when a pre-ownership installed host manifest matches the candidate bundle identity; arbitrary or mismatched directories still fail closed.
 
 Codex companion config now has a conservative inverse too: `pluxx codex apply` records the exact before/after config state it owns, and `pluxx codex unapply` restores the prior state only while the applied config remains unchanged. If the user edits active config after apply, unapply preserves it and asks for manual reconciliation instead of overwriting unrelated changes.
 
@@ -369,7 +369,7 @@ The repo already proves a lot.
 - historical release-gate evidence from 2026-05-19 remains available but is not current proof:
   - `npm test` passed
   - `npm run release:check` passed
-- the canonical repository version is `@orchid-labs/pluxx@0.1.33` in release-prep for PLUXX-333; previous `v0.1.32` release evidence is historical once this fix ships
+- the canonical repository version is `@orchid-labs/pluxx@0.1.33`; previous `v0.1.32` release evidence is historical
 - marketplace submission APIs, a managed trust/distribution control plane, automatic rollback/unpublish orchestration, and real authenticated publish plus rollback proof remain explicit release gaps, not hidden shipped capabilities:
   - `docs/release-distribution-proof-map.md`
   - “automatic rollback” here means remote release rollback/unpublish; generated local installers now restore the prior bundle when staged setup fails
@@ -539,9 +539,9 @@ Run two lanes in parallel:
 
 ### 6. Release State
 
-The canonical repository version is `0.1.33` in release-prep. The previous `v0.1.32` tag and package are historical release evidence for the prior baseline. `package.json` is the source of truth for repository docs, while [proof-manifest.json](./proof-manifest.json) records tag state and proof freshness.
+The canonical repository version is `0.1.33`, tagged as `v0.1.33`. The previous `v0.1.32` tag and package are historical release evidence for the prior baseline. `package.json` is the source of truth for repository docs, while [proof-manifest.json](./proof-manifest.json) records tag state and proof freshness.
 
-For v0.1.33, finish PLUXX-333 review, merge the focused fix, create the immutable `v0.1.33` tag from main, then verify npm, GitHub, the published tarball, and CLI behavior. Future releases should repeat the version bump and release-prep proof work on a focused PR before tagging.
+For v0.1.33, the focused fix is merged and the immutable tag has been pushed; finish GitHub release recovery, then verify npm, GitHub, the published tarball, and CLI behavior. Future releases should repeat the version bump and proof-prep work on a focused PR before tagging.
 
 ## Working Rules
 

--- a/docs/todo/master-backlog.md
+++ b/docs/todo/master-backlog.md
@@ -86,10 +86,10 @@ Proof governance is now explicit: [proof-freshness.md](../proof-freshness.md) de
 
 - [x] Merge all nine PLUXX-313 through PLUXX-321 audit-remediation PRs into main at `f92e3cc`
 - [x] Prepare 0.1.33 in PLUXX-333 with synchronized package, proof, planning, and release truth
-- [x] Generate fresh repository-validation and fake-home-install receipts for 0.1.33 release-prep state
+- [x] Generate fresh repository-validation and fake-home-install receipts for 0.1.33 tagged state
 - [x] Pass the official serial suite and complete release gate
-- [ ] Merge the release PR and push immutable tag `v0.1.33` from main
-- [ ] Merge the focused legacy-installer-adoption PR after substantive checks and review are green
+- [x] Merge the release PR and push immutable tag `v0.1.33` from main
+- [x] Merge the focused legacy-installer-adoption PR after substantive checks and review are green
 - [ ] Coordinator: dispatch the trusted tag workflow, verify npm/GitHub/tarball/CLI, then archive the completed batch
 
 ### 1. Product clarity and front-door coherence
@@ -453,10 +453,10 @@ Open work:
 - [x] Prepare and merge the historical focused v0.1.32 release PR under PLUXX-322
 - [ ] Prepare and merge the focused v0.1.33 legacy installer adoption PR under PLUXX-333
 - [x] Preserve historical repository/fake-home receipts from committed 0.1.32 state
-- [x] Refresh current repository/fake-home receipts from 0.1.33 release-prep state
+- [x] Refresh current repository/fake-home receipts from 0.1.33 tagged state
 - [x] Pass targeted checks, official serial 758/758 `npm test`, and `npm run release:check`
 - [x] Merge the release-prep PR and push `v0.1.32` at `188527e`
-- [ ] Merge the PLUXX-333 release-prep PR and push `v0.1.33` from main
+- [x] Merge the PLUXX-333 release PR and push `v0.1.33` from main
 - [ ] Merge the legacy-installer-adoption PR, then dispatch the trusted tag workflow
 - [x] Verify `@orchid-labs/pluxx@0.1.32`, GitHub release assets, tarball contents, and CLI behavior
 - [ ] Verify `@orchid-labs/pluxx@0.1.33`, GitHub release assets, tarball contents, and CLI behavior

--- a/docs/todo/queue.md
+++ b/docs/todo/queue.md
@@ -188,7 +188,7 @@ The initial author-once hardening tranche is also materially done.
 The public baseline is also real.
 
 - npm package is live as `@orchid-labs/pluxx`
-- the canonical repository version is `@orchid-labs/pluxx@0.1.33` in release-prep for PLUXX-333; previous `v0.1.32` evidence is historical after this fix ships
+- the canonical repository version is `@orchid-labs/pluxx@0.1.33`; previous `v0.1.32` evidence is historical after this fix ships
 - proof claims now use [docs/proof-freshness.md](../proof-freshness.md) and [docs/proof-manifest.json](../proof-manifest.json) so historical host runs cannot masquerade as current evidence
 - published CLI runtime is Node `>=18`
 - published CLI lifecycle ergonomics are now stronger for global installs:
@@ -503,10 +503,10 @@ Current work:
 - [x] PLUXX-322 prepared and merged the focused release PR at `188527e`
 - [x] bump `package.json` and `package-lock.json` to 0.1.33
 - [x] refresh canonical release, planning, and proof truth without carrying old evidence forward as current
-- [x] generate fresh repository-validation and fake-home-install receipts for 0.1.33 release-prep state
+- [x] generate fresh repository-validation and fake-home-install receipts for 0.1.33 tagged state
 - [x] pass the official serial suite and `npm run release:check`
-- [ ] push immutable tag `v0.1.33` from main after merge
-- [ ] merge the focused legacy-installer-adoption PR after substantive checks and review are green
+- [x] push immutable tag `v0.1.33` from main after merge
+- [x] merge the focused legacy-installer-adoption PR after substantive checks and review are green
 
 Coordinator-owned after this task:
 


### PR DESCRIPTION
## Summary

- normalize `npm view ... dist.integrity` output in the release workflow before comparing integrity
- apply the same extraction in the npm publication verification step
- needed because the `v0.1.33` recovery run packaged the same tarball integrity already published on npm, but raw npm CLI output in Actions can include extra notice text, causing the exact-string comparison to fail before GitHub release creation

Linear: [PLUXX-333](https://linear.app/orchid-automation/issue/PLUXX-333/fix-release-installers-rejecting-trusted-pre-ownership-plugin-installs)

## Validation

- `git diff --check`
- local bash extraction smoke: notice-prefixed output resolves to the `sha512-...` integrity line

## Release recovery

After merge, dispatch `Release` from `main` with `release_tag=v0.1.33`. NPM already has `@orchid-labs/pluxx@0.1.33` with matching integrity; the recovery should skip immutable npm publish, verify npm, create the GitHub release, and verify the release asset.
