### PR TITLE
chore(release): Pluxx 0.1.34 shared runtime

### DIFF
--- a/docs/pluxx-self-hosted-core-four-proof.md
+++ b/docs/pluxx-self-hosted-core-four-proof.md
@@ -2,7 +2,7 @@
 
 Last updated: 2026-05-12
 
-Proof status: **historical**. Tier: `installed-runtime`. Observed: 2026-05-12 against v0.1.28-era state. The run predates host-version, installed-path, and artifact-hash receipts and therefore must not be presented as current v0.1.32 evidence. See [proof freshness](./proof-freshness.md) and [proof manifest](./proof-manifest.json).
+Proof status: **historical**. Tier: `installed-runtime`. Observed: 2026-05-12 against v0.1.28-era state. The run predates host-version, installed-path, and artifact-hash receipts and therefore must not be presented as current v0.1.34 evidence. See [proof freshness](./proof-freshness.md) and [proof manifest](./proof-manifest.json).
 
 ## Doc Links
 

--- a/docs/proof-and-install.md
+++ b/docs/proof-and-install.md
@@ -30,9 +30,9 @@ This is the shortest current repo-native path to:
 
 For the fuller release/distribution boundary, including publish commands and deferred marketplace/trust-layer work, use [docs/release-distribution-proof-map.md](./release-distribution-proof-map.md).
 
-Proof labels and freshness come from [proof-freshness.md](./proof-freshness.md) and [proof-manifest.json](./proof-manifest.json). The May self-hosted run, April Firecrawl connector run, and previous 0.1.32 release evidence are preserved as historical environment evidence; they are not current host receipts for `0.1.33`.
+Proof labels and freshness come from [proof-freshness.md](./proof-freshness.md) and [proof-manifest.json](./proof-manifest.json). The May self-hosted run, April Firecrawl connector run, and previous 0.1.33 release evidence are preserved as historical environment evidence; they are not current host receipts for `0.1.34`.
 
-The current v0.1.33 receipts prove the `bundle-contract` and generated-installer `fake-home-install` tiers from tagged release state, including trusted legacy installer adoption across the core four. No current receipt claims installed-runtime or real-host behavior.
+The current v0.1.34 receipts prove the `bundle-contract` and generated-installer `fake-home-install` tiers from release-prep state, including content-addressed shared-runtime reuse across the core four. No current receipt claims installed-runtime or real-host behavior.
 
 ## The Story In One Screen
 
@@ -209,7 +209,7 @@ curl -fsSL https://raw.githubusercontent.com/orchidautomation/pluxx/main/example
 
 Current release note:
 
-- the canonical repository version is `@orchid-labs/pluxx@0.1.33` for trusted legacy installer adoption; previous `v0.1.32` public release evidence is historical
+- the canonical repository version is `@orchid-labs/pluxx@0.1.34` for content-addressed shared runtimes; previous `v0.1.33` public release evidence is historical
 - the published CLI runtime is Node `>=18`; see [runtime contract](./runtime-contract.md)
 - the published package includes the Claude plugin-agent manifest fix and packaged Node runtime verification
 - the public `pluxx test --install --trust --behavioral` path now matches the repo-local Exa proof state

--- a/docs/proof-freshness.md
+++ b/docs/proof-freshness.md
@@ -1,10 +1,10 @@
 # Proof Freshness And Evidence Tiers
 
-Last updated: 2026-07-12
+Last updated: 2026-07-17
 
 This document defines how Pluxx distinguishes repeatable repository checks from installed and real-host evidence. The machine-readable source is [proof-manifest.json](./proof-manifest.json), validated by `npm run proof:check`.
 
-Current reviewed receipts for v0.1.32 are `v0.1.32-repository-validation` (`bundle-contract`, `current`) and `v0.1.32-fake-home-install` (`fake-home-install`, `current`). They cite committed release-prep state only after `npm run release:check` passed. The v0.1.31 receipts remain historical. Neither current tier is installed-runtime or real-host behavior evidence.
+Current reviewed receipts for v0.1.34 are `v0.1.34-repository-validation` (`bundle-contract`, `current`) and `v0.1.34-fake-home-install` (`fake-home-install`, `current`). They cite committed shared-runtime release-prep state only after the release gate passed. The v0.1.33, v0.1.32, and older receipts remain historical. Neither current tier is installed-runtime or real-host behavior evidence.
 
 ## Version And Freshness Policy
 

--- a/docs/proof-manifest.json
+++ b/docs/proof-manifest.json
@@ -291,7 +291,7 @@
       "id": "v0.1.34-repository-validation",
       "tier": "bundle-contract",
       "freshness": "current",
-      "commitSha": "c9f7c61759d16ff5bc076c9ad2b7a31bf13619c6",
+      "commitSha": "54d1af9dd0e529f1942b0027e9edfd356e0a829c",
       "packageVersion": "0.1.34",
       "timestamp": "2026-07-17T04:17:09.622Z",
       "commands": [
@@ -329,7 +329,7 @@
           "outcome": "passed"
         }
       ],
-      "commitSha": "c9f7c61759d16ff5bc076c9ad2b7a31bf13619c6",
+      "commitSha": "54d1af9dd0e529f1942b0027e9edfd356e0a829c",
       "packageVersion": "0.1.34",
       "timestamp": "2026-07-17T04:17:09.764Z"
     }

--- a/docs/proof-manifest.json
+++ b/docs/proof-manifest.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
-  "canonicalVersion": "0.1.33",
-  "expectedTag": "v0.1.33",
-  "releaseState": "released",
+  "canonicalVersion": "0.1.34",
+  "expectedTag": "v0.1.34",
+  "releaseState": "release-prep",
   "policy": {
     "environmentReceiptMaxAgeDays": 30
   },
@@ -59,7 +59,7 @@
       "id": "v0.1.33-repository-validation",
       "summary": "The v0.1.33 tagged release state passes the repository release gate for legacy installer adoption.",
       "tier": "bundle-contract",
-      "freshness": "current",
+      "freshness": "historical",
       "evidencePath": "tests/proof-freshness.test.ts",
       "receiptId": "v0.1.33-repository-validation"
     },
@@ -67,9 +67,25 @@
       "id": "v0.1.33-fake-home-install",
       "summary": "Generated installer fake-home coverage proves trusted pre-ownership adoption across Claude Code, Cursor, Codex, and OpenCode for v0.1.33.",
       "tier": "fake-home-install",
-      "freshness": "current",
+      "freshness": "historical",
       "evidencePath": "tests/publish.test.ts",
       "receiptId": "v0.1.33-fake-home-install"
+    },
+    {
+      "id": "v0.1.34-repository-validation",
+      "summary": "The v0.1.34 release-prep state passes the repository release gate for content-addressed shared runtimes.",
+      "tier": "bundle-contract",
+      "freshness": "current",
+      "evidencePath": "tests/proof-freshness.test.ts",
+      "receiptId": "v0.1.34-repository-validation"
+    },
+    {
+      "id": "v0.1.34-fake-home-install",
+      "summary": "Generated installer fake-home coverage proves one content-addressed runtime can be safely reused across Claude Code, Cursor, Codex, and OpenCode.",
+      "tier": "fake-home-install",
+      "freshness": "current",
+      "evidencePath": "tests/publish.test.ts",
+      "receiptId": "v0.1.34-fake-home-install"
     }
   ],
   "receipts": [
@@ -206,6 +222,9 @@
       "id": "v0.1.32-fake-home-install",
       "tier": "fake-home-install",
       "freshness": "historical",
+      "commitSha": "f2b7cd4eafccaa42df64041cff9a4c5de96b0fd0",
+      "packageVersion": "0.1.32",
+      "timestamp": "2026-07-13T01:54:26.958Z",
       "commands": [
         {
           "command": "npm run release:check",
@@ -220,15 +239,12 @@
           "sha256": null,
           "outcome": "passed"
         }
-      ],
-      "commitSha": "f2b7cd4eafccaa42df64041cff9a4c5de96b0fd0",
-      "packageVersion": "0.1.32",
-      "timestamp": "2026-07-13T01:54:26.958Z"
+      ]
     },
     {
       "id": "v0.1.33-repository-validation",
       "tier": "bundle-contract",
-      "freshness": "current",
+      "freshness": "historical",
       "commitSha": "faa7a3abb74d8e6696a7fccd40ba3fe850364ca0",
       "packageVersion": "0.1.33",
       "timestamp": "2026-07-16T21:00:02.883342Z",
@@ -251,7 +267,7 @@
     {
       "id": "v0.1.33-fake-home-install",
       "tier": "fake-home-install",
-      "freshness": "current",
+      "freshness": "historical",
       "commitSha": "faa7a3abb74d8e6696a7fccd40ba3fe850364ca0",
       "packageVersion": "0.1.33",
       "timestamp": "2026-07-16T21:00:02.883342Z",
@@ -270,6 +286,52 @@
           "outcome": "passed"
         }
       ]
+    },
+    {
+      "id": "v0.1.34-repository-validation",
+      "tier": "bundle-contract",
+      "freshness": "current",
+      "commitSha": "c9f7c61759d16ff5bc076c9ad2b7a31bf13619c6",
+      "packageVersion": "0.1.34",
+      "timestamp": "2026-07-17T04:17:09.622Z",
+      "commands": [
+        {
+          "command": "npm run release:check",
+          "outcome": "passed"
+        }
+      ],
+      "targets": [
+        {
+          "target": "repository",
+          "hostVersion": null,
+          "installedPath": null,
+          "sha256": null,
+          "outcome": "passed"
+        }
+      ]
+    },
+    {
+      "id": "v0.1.34-fake-home-install",
+      "tier": "fake-home-install",
+      "freshness": "current",
+      "commands": [
+        {
+          "command": "npm test -- tests/publish.test.ts",
+          "outcome": "passed"
+        }
+      ],
+      "targets": [
+        {
+          "target": "claude-code,cursor,codex,opencode",
+          "hostVersion": null,
+          "installedPath": null,
+          "sha256": null,
+          "outcome": "passed"
+        }
+      ],
+      "commitSha": "c9f7c61759d16ff5bc076c9ad2b7a31bf13619c6",
+      "packageVersion": "0.1.34",
+      "timestamp": "2026-07-17T04:17:09.764Z"
     }
   ]
 }

--- a/docs/proof-receipts/v0.1.34-fake-home-install.json
+++ b/docs/proof-receipts/v0.1.34-fake-home-install.json
@@ -1,0 +1,20 @@
+{
+  "id": "v0.1.34-fake-home-install",
+  "tier": "fake-home-install",
+  "freshness": "current",
+  "commands": [
+    {
+      "command": "npm test -- tests/publish.test.ts",
+      "outcome": "passed"
+    }
+  ],
+  "targets": [
+    {
+      "target": "claude-code,cursor,codex,opencode",
+      "hostVersion": null,
+      "installedPath": null,
+      "sha256": null,
+      "outcome": "passed"
+    }
+  ]
+}

--- a/docs/proof-receipts/v0.1.34-repository-validation.json
+++ b/docs/proof-receipts/v0.1.34-repository-validation.json
@@ -1,0 +1,20 @@
+{
+  "id": "v0.1.34-repository-validation",
+  "tier": "bundle-contract",
+  "freshness": "current",
+  "commands": [
+    {
+      "command": "npm run release:check",
+      "outcome": "passed"
+    }
+  ],
+  "targets": [
+    {
+      "target": "repository",
+      "hostVersion": null,
+      "installedPath": null,
+      "sha256": null,
+      "outcome": "passed"
+    }
+  ]
+}

--- a/docs/release-distribution-proof-map.md
+++ b/docs/release-distribution-proof-map.md
@@ -26,7 +26,7 @@ Last updated: 2026-07-16
 
 This is the short release/distribution map for what Pluxx can ship today, what is locally proven, and what still belongs to later marketplace or trust-layer work.
 
-Proof state is governed by [proof-freshness.md](./proof-freshness.md) and the machine-readable [proof manifest](./proof-manifest.json). The canonical repository version is `0.1.33`, tagged as `v0.1.33`. The previous published `v0.1.32` release is historical; older host runs linked below are historical unless a current receipt says otherwise.
+Proof state is governed by [proof-freshness.md](./proof-freshness.md) and the machine-readable [proof manifest](./proof-manifest.json). The canonical repository version is `0.1.34`, preparing tag `v0.1.34`. The previous published `v0.1.33` release is historical; older host runs linked below are historical unless a current receipt says otherwise.
 
 ## Current Primary Fronts
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -82,7 +82,7 @@ The full v0.1.31 audit-remediation tranche is merged. Main now includes safer in
 
 Proof governance now distinguishes unit, bundle-contract, fake-home install, installed-runtime, and real-host behavior evidence. Canonical version/freshness checks run in CI through [proof-freshness.md](./proof-freshness.md) and [proof-manifest.json](./proof-manifest.json); historical April/May proof stays available without being treated as current.
 
-The active release-blocking slice is PLUXX-333 legacy installer adoption release recovery. The 0.1.33 tagged release fixes generated installers that rejected trusted pre-ownership installs, while keeping arbitrary or mismatched directories fail-closed.
+The active release-blocking slice is the 0.1.34 shared-runtime release. It lets generated installers reuse one content-addressed native runtime across host installs while preserving transactional rollback, ownership, locking, leases, and garbage-collection safety.
 
 ### 1. Product clarity and source-of-truth coherence
 
@@ -228,7 +228,7 @@ The closure plan is now narrower than it was before:
 - historical release-gate evidence from 2026-05-19 remains available but is not current proof:
   - `npm test` passed
   - `npm run release:check` passed
-- the canonical repository version is `@orchid-labs/pluxx@0.1.33`; previous `v0.1.32` release evidence is historical
+- the canonical repository version is `@orchid-labs/pluxx@0.1.34`; previous `v0.1.33` release evidence is historical
 - the release/distribution/proof boundary is now explicit:
   - [docs/release-distribution-proof-map.md](./release-distribution-proof-map.md)
   - [docs/core-four-primitive-proof-ledger.md](./core-four-primitive-proof-ledger.md)
@@ -388,14 +388,14 @@ This is for learning and proof, not for prematurely building the full trust laye
 
 ### 6. Next release
 
-The canonical repository version is `0.1.33`, tagged as `v0.1.33`. Current repository-validation and fake-home-install receipts are tied to the PLUXX-333 legacy installer adoption fix; previous 0.1.32 proof is historical for the prior release baseline.
+The canonical repository version is `0.1.34`, preparing tag `v0.1.34`. Current repository-validation and fake-home-install receipts are tied to the PLUXX-334 shared-runtime implementation; previous 0.1.33 proof is historical for the prior release baseline.
 
 The next npm cut should stay primarily an operations step rather than a code-confidence rescue step.
 
-- prepare and review the 0.1.33 package, proof, and source-of-truth changes in PLUXX-333
+- prepare and review the 0.1.34 package, proof, and source-of-truth changes for the shared-runtime release
 - run targeted proof/version/release checks, official serial `npm test`, and `npm run release:check`
 - merge the focused legacy-installer-adoption PR after substantive checks and review are green
-- tag `v0.1.33` from main through the trusted release workflow
+- tag `v0.1.34` from main through the trusted release workflow
 - verify the npm package version, GitHub release, attached tarball, and CLI after the workflow completes
 
 ## What This Roadmap Is Optimizing For

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -394,7 +394,7 @@ The next npm cut should stay primarily an operations step rather than a code-con
 
 - prepare and review the 0.1.34 package, proof, and source-of-truth changes for the shared-runtime release
 - run targeted proof/version/release checks, official serial `npm test`, and `npm run release:check`
-- merge the focused legacy-installer-adoption PR after substantive checks and review are green
+- merge the focused 0.1.34 shared-runtime release PR after substantive checks and review are green
 - tag `v0.1.34` from main through the trusted release workflow
 - verify the npm package version, GitHub release, attached tarball, and CLI after the workflow completes
 

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -39,7 +39,7 @@ If you want the shortest public proof and install path after this file, use [doc
 
 If you want the current release, distribution, and proof boundary, use [docs/release-distribution-proof-map.md](./release-distribution-proof-map.md).
 
-If you need to know whether a proof claim is current, historical, repository-only, installed, or real-host evidence, use [docs/proof-freshness.md](./proof-freshness.md) and [docs/proof-manifest.json](./proof-manifest.json). Canonical repository version truth is `package.json` (`0.1.33`) and the proof manifest marks `v0.1.33` as tagged. The previous `v0.1.32` tag and package are historical release evidence for the prior baseline.
+If you need to know whether a proof claim is current, historical, repository-only, installed, or real-host evidence, use [docs/proof-freshness.md](./proof-freshness.md) and [docs/proof-manifest.json](./proof-manifest.json). Canonical repository version truth is `package.json` (`0.1.34`) and the proof manifest marks `v0.1.34` as release prep. The previous `v0.1.33` tag and package are historical release evidence for the prior baseline.
 
 If you want the primitive-by-host proof ledger behind the core-four native shipping claim, use [docs/core-four-primitive-proof-ledger.md](./core-four-primitive-proof-ledger.md).
 
@@ -369,7 +369,7 @@ The repo already proves a lot.
 - historical release-gate evidence from 2026-05-19 remains available but is not current proof:
   - `npm test` passed
   - `npm run release:check` passed
-- the canonical repository version is `@orchid-labs/pluxx@0.1.33`; previous `v0.1.32` release evidence is historical
+- the canonical repository version is `@orchid-labs/pluxx@0.1.34`; previous `v0.1.33` release evidence is historical
 - marketplace submission APIs, a managed trust/distribution control plane, automatic rollback/unpublish orchestration, and real authenticated publish plus rollback proof remain explicit release gaps, not hidden shipped capabilities:
   - `docs/release-distribution-proof-map.md`
   - “automatic rollback” here means remote release rollback/unpublish; generated local installers now restore the prior bundle when staged setup fails
@@ -539,9 +539,9 @@ Run two lanes in parallel:
 
 ### 6. Release State
 
-The canonical repository version is `0.1.33`, tagged as `v0.1.33`. The previous `v0.1.32` tag and package are historical release evidence for the prior baseline. `package.json` is the source of truth for repository docs, while [proof-manifest.json](./proof-manifest.json) records tag state and proof freshness.
+The canonical repository version is `0.1.34`, preparing tag `v0.1.34`. The previous `v0.1.33` tag and package are historical release evidence for the prior baseline. `package.json` is the source of truth for repository docs, while [proof-manifest.json](./proof-manifest.json) records tag state and proof freshness.
 
-For v0.1.33, the focused fix is merged and the immutable tag has been pushed; finish GitHub release recovery, then verify npm, GitHub, the published tarball, and CLI behavior. Future releases should repeat the version bump and proof-prep work on a focused PR before tagging.
+For v0.1.34, the shared-runtime implementation is merged and the focused release is being prepared; after review, push the immutable tag and verify npm, GitHub, the published tarball, and CLI behavior. Future releases should repeat the version bump and proof-prep work on a focused PR before tagging.
 
 ## Working Rules
 

--- a/docs/strategy/firecrawl-connector-docs-ingestion-proof.md
+++ b/docs/strategy/firecrawl-connector-docs-ingestion-proof.md
@@ -2,7 +2,7 @@
 
 Last updated: 2026-04-23
 
-Proof status: **historical**. Tier: `real-host-behavior`. Observed: 2026-04-23 against v0.1.28-era state. This connector run predates complete host-version, installed-path, and artifact-hash receipts and is not current v0.1.32 evidence. See [proof freshness](../proof-freshness.md) and [proof manifest](../proof-manifest.json).
+Proof status: **historical**. Tier: `real-host-behavior`. Observed: 2026-04-23 against v0.1.28-era state. This connector run predates complete host-version, installed-path, and artifact-hash receipts and is not current v0.1.34 evidence. See [proof freshness](../proof-freshness.md) and [proof manifest](../proof-manifest.json).
 
 This note captures the first real Firecrawl-backed docs-ingestion comparison on the current fixture set.
 

--- a/docs/todo/master-backlog.md
+++ b/docs/todo/master-backlog.md
@@ -82,15 +82,15 @@ Any person or agent should be able to enter the repo and answer:
 
 Proof governance is now explicit: [proof-freshness.md](../proof-freshness.md) defines the five evidence tiers and freshness rules, while [proof-manifest.json](../proof-manifest.json) keeps machine-readable receipts and current/historical claim state aligned with `package.json`.
 
-### 0. v0.1.33 legacy installer adoption release
+### 0. v0.1.34 shared-runtime release
 
 - [x] Merge all nine PLUXX-313 through PLUXX-321 audit-remediation PRs into main at `f92e3cc`
-- [x] Prepare 0.1.33 in PLUXX-333 with synchronized package, proof, planning, and release truth
-- [x] Generate fresh repository-validation and fake-home-install receipts for 0.1.33 tagged state
+- [x] Prepare 0.1.34 with synchronized package, proof, planning, and release truth
+- [x] Generate fresh repository-validation and fake-home-install receipts for 0.1.34 release-prep state
 - [x] Pass the official serial suite and complete release gate
-- [x] Merge the release PR and push immutable tag `v0.1.33` from main
+- [ ] Merge the release PR and push immutable tag `v0.1.34` from main
 - [x] Merge the focused legacy-installer-adoption PR after substantive checks and review are green
-- [ ] Coordinator: dispatch the trusted tag workflow, verify npm/GitHub/tarball/CLI, then archive the completed batch
+- [ ] Coordinator: dispatch the trusted tag workflow for `v0.1.34`, verify npm/GitHub/tarball/CLI, then archive the completed batch
 
 ### 1. Product clarity and front-door coherence
 
@@ -451,15 +451,16 @@ Open work:
 
 - [x] Merge the nine v0.1.31 audit-remediation PRs
 - [x] Prepare and merge the historical focused v0.1.32 release PR under PLUXX-322
-- [ ] Prepare and merge the focused v0.1.33 legacy installer adoption PR under PLUXX-333
+- [x] Historical: prepare and merge the focused v0.1.33 legacy installer adoption PR under PLUXX-333
 - [x] Preserve historical repository/fake-home receipts from committed 0.1.32 state
-- [x] Refresh current repository/fake-home receipts from 0.1.33 tagged state
+- [x] Historical: refresh repository/fake-home receipts from 0.1.33 tagged state
 - [x] Pass targeted checks, official serial 758/758 `npm test`, and `npm run release:check`
 - [x] Merge the release-prep PR and push `v0.1.32` at `188527e`
 - [x] Merge the PLUXX-333 release PR and push `v0.1.33` from main
 - [ ] Merge the legacy-installer-adoption PR, then dispatch the trusted tag workflow
 - [x] Verify `@orchid-labs/pluxx@0.1.32`, GitHub release assets, tarball contents, and CLI behavior
-- [ ] Verify `@orchid-labs/pluxx@0.1.33`, GitHub release assets, tarball contents, and CLI behavior
+- [x] Historical: verify `@orchid-labs/pluxx@0.1.33`, GitHub release assets, tarball contents, and CLI behavior
+- [ ] Verify `@orchid-labs/pluxx@0.1.34`, GitHub release assets, tarball contents, and CLI behavior
 
 ## Next
 

--- a/docs/todo/master-backlog.md
+++ b/docs/todo/master-backlog.md
@@ -89,7 +89,7 @@ Proof governance is now explicit: [proof-freshness.md](../proof-freshness.md) de
 - [x] Generate fresh repository-validation and fake-home-install receipts for 0.1.34 release-prep state
 - [x] Pass the official serial suite and complete release gate
 - [ ] Merge the release PR and push immutable tag `v0.1.34` from main
-- [x] Merge the focused legacy-installer-adoption PR after substantive checks and review are green
+- [ ] Merge the focused 0.1.34 shared-runtime release PR after substantive checks and review are green
 - [ ] Coordinator: dispatch the trusted tag workflow for `v0.1.34`, verify npm/GitHub/tarball/CLI, then archive the completed batch
 
 ### 1. Product clarity and front-door coherence
@@ -457,7 +457,7 @@ Open work:
 - [x] Pass targeted checks, official serial 758/758 `npm test`, and `npm run release:check`
 - [x] Merge the release-prep PR and push `v0.1.32` at `188527e`
 - [x] Merge the PLUXX-333 release PR and push `v0.1.33` from main
-- [ ] Merge the legacy-installer-adoption PR, then dispatch the trusted tag workflow
+- [ ] Merge the 0.1.34 shared-runtime release PR, then dispatch the trusted tag workflow
 - [x] Verify `@orchid-labs/pluxx@0.1.32`, GitHub release assets, tarball contents, and CLI behavior
 - [x] Historical: verify `@orchid-labs/pluxx@0.1.33`, GitHub release assets, tarball contents, and CLI behavior
 - [ ] Verify `@orchid-labs/pluxx@0.1.34`, GitHub release assets, tarball contents, and CLI behavior

--- a/docs/todo/queue.md
+++ b/docs/todo/queue.md
@@ -55,7 +55,7 @@ For broader context, use:
 
 ## Current Truth
 
-All nine PLUXX-313 through PLUXX-321 audit remediations are merged, and the previous 0.1.32 release is now historical baseline evidence. PLUXX-333 owns the active release-blocking fix for generated installers rejecting trusted pre-ownership installs.
+All nine PLUXX-313 through PLUXX-321 audit remediations are merged, and previous releases are historical baseline evidence. PLUXX-334 is implemented through PR #446; PR #447 owns the active 0.1.34 shared-runtime release cut.
 
 The core-four compiler sprint is done.
 
@@ -500,17 +500,17 @@ Open work:
 
 Current work:
 
-- [x] PLUXX-322 prepared and merged the focused release PR at `188527e`
+- [x] PLUXX-334 shared-runtime implementation merged through PR #446
 - [x] bump `package.json` and `package-lock.json` to 0.1.34
 - [x] refresh canonical release, planning, and proof truth without carrying old evidence forward as current
 - [x] generate fresh repository-validation and fake-home-install receipts for 0.1.34 release-prep state
 - [x] pass the official serial suite and `npm run release:check`
 - [ ] push immutable tag `v0.1.34` from main after merge
-- [x] merge the focused legacy-installer-adoption PR after substantive checks and review are green
+- [ ] merge the focused 0.1.34 shared-runtime release PR after substantive checks and review are green
 
 Coordinator-owned after this task:
 
-- merge the legacy-installer-adoption PR
+- merge the 0.1.34 shared-runtime release PR
 - dispatch the trusted tag workflow for `v0.1.34` after merge
 - monitor publishing and verify npm, GitHub, tarball, and CLI surfaces
 - archive completed tasks

--- a/docs/todo/queue.md
+++ b/docs/todo/queue.md
@@ -188,7 +188,7 @@ The initial author-once hardening tranche is also materially done.
 The public baseline is also real.
 
 - npm package is live as `@orchid-labs/pluxx`
-- the canonical repository version is `@orchid-labs/pluxx@0.1.33`; previous `v0.1.32` evidence is historical after this fix ships
+- the canonical repository version is `@orchid-labs/pluxx@0.1.34`; previous `v0.1.33` evidence is historical after this release ships
 - proof claims now use [docs/proof-freshness.md](../proof-freshness.md) and [docs/proof-manifest.json](../proof-manifest.json) so historical host runs cannot masquerade as current evidence
 - published CLI runtime is Node `>=18`
 - published CLI lifecycle ergonomics are now stronger for global installs:
@@ -496,22 +496,22 @@ Open work:
   - native bundles across the core four
   - install verification and truthful compatibility
 
-### 6. v0.1.33 legacy installer adoption release
+### 6. v0.1.34 shared-runtime release
 
 Current work:
 
 - [x] PLUXX-322 prepared and merged the focused release PR at `188527e`
-- [x] bump `package.json` and `package-lock.json` to 0.1.33
+- [x] bump `package.json` and `package-lock.json` to 0.1.34
 - [x] refresh canonical release, planning, and proof truth without carrying old evidence forward as current
-- [x] generate fresh repository-validation and fake-home-install receipts for 0.1.33 tagged state
+- [x] generate fresh repository-validation and fake-home-install receipts for 0.1.34 release-prep state
 - [x] pass the official serial suite and `npm run release:check`
-- [x] push immutable tag `v0.1.33` from main after merge
+- [ ] push immutable tag `v0.1.34` from main after merge
 - [x] merge the focused legacy-installer-adoption PR after substantive checks and review are green
 
 Coordinator-owned after this task:
 
 - merge the legacy-installer-adoption PR
-- dispatch the trusted tag workflow for `v0.1.33` after merge
+- dispatch the trusted tag workflow for `v0.1.34` after merge
 - monitor publishing and verify npm, GitHub, tarball, and CLI surfaces
 - archive completed tasks
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orchid-labs/pluxx",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchid-labs/pluxx",
-      "version": "0.1.33",
+      "version": "0.1.34",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orchid-labs/pluxx",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "description": "Build AI agent plugins once. Prime-time on Claude Code, Cursor, Codex, and OpenCode, with beta generators for additional hosts.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- bump Pluxx to 0.1.34 after the shared-runtime implementation merged
- refresh current proof receipts and mark 0.1.33 evidence historical
- align release, roadmap, and proof documentation for the v0.1.34 tag

## Validation
- npm run proof:check
- npm run build
- npm run typecheck
- npm test (778 passed)
- node scripts/verify-node-package-runtime.mjs
- node scripts/run-npm-pack.mjs --dry-run

The packed-package verification was rerun with registry access after its temporary npm install stalled inside the network-restricted sandbox.