### PR TITLE
docs(proof): repair v0.1.36 squash-merge receipts

### DIFF
--- a/docs/proof-manifest.json
+++ b/docs/proof-manifest.json
@@ -415,9 +415,9 @@
       "id": "v0.1.36-repository-validation",
       "tier": "bundle-contract",
       "freshness": "current",
-      "commitSha": "8d76ff3acbde7643184c0fb6d2af1223462d8dfb",
+      "commitSha": "bfbdd5fc80e73ff1014d64ac3d9c59f9e48dfeee",
       "packageVersion": "0.1.36",
-      "timestamp": "2026-07-18T20:22:40.549Z",
+      "timestamp": "2026-07-18T20:54:05.637Z",
       "commands": [
         {
           "command": "npm run release:check",
@@ -453,9 +453,9 @@
           "outcome": "passed"
         }
       ],
-      "commitSha": "8d76ff3acbde7643184c0fb6d2af1223462d8dfb",
+      "commitSha": "bfbdd5fc80e73ff1014d64ac3d9c59f9e48dfeee",
       "packageVersion": "0.1.36",
-      "timestamp": "2026-07-18T20:22:45.326Z"
+      "timestamp": "2026-07-18T20:54:05.805Z"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Follow-up to #453 and PLUXX-337.

- Points both current v0.1.36 proof receipts at squash-merge commit `bfbdd5fc80e73ff1014d64ac3d9c59f9e48dfeee`.
- Fixes the trusted release workflow's reachability gate; the pre-merge implementation checkpoint is intentionally unreachable after squash merge.

## Validation

- `PLUXX_RELEASE_TAG=v0.1.36 npm run proof:check` passed: 14 claims, 14 receipts.
- `bun test tests/publish.test.ts tests/doctor.test.ts tests/install.test.ts tests/verify-install.test.ts` passed: 183 tests, 1060 expectations.
- PR #453 CI and Orchid Merge Gate passed on the same source tree before squash merge.
- The first v0.1.36 release run stopped at proof freshness before packaging or publishing; npm and GitHub Releases remain untouched.

## Release plan

Merge this metadata-only repair, move the unpublished `v0.1.36` tag to the new main commit, and let the trusted workflow rerun the full release gate before publication.
