### PR TITLE
chore(release): publish Pluxx 0.1.37 security patch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,6 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org
 
-      - name: Install dependencies
-        run: npm ci
-
       - name: Resolve release version
         id: version
         shell: bash
@@ -65,12 +62,11 @@ jobs:
             exit 1
           fi
 
-          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
-            TRUSTED_MAIN_COMMIT="$(git rev-parse "${GITHUB_SHA}^{commit}")"
-            if ! git merge-base --is-ancestor "${TAG_COMMIT}" "${TRUSTED_MAIN_COMMIT}"; then
-              echo "Release tag ${TAG_NAME} is not contained in trusted main commit ${TRUSTED_MAIN_COMMIT}." >&2
-              exit 1
-            fi
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          TRUSTED_MAIN_COMMIT="$(git rev-parse "refs/remotes/origin/main^{commit}")"
+          if ! git merge-base --is-ancestor "${TAG_COMMIT}" "${TRUSTED_MAIN_COMMIT}"; then
+            echo "Release tag ${TAG_NAME} is not contained in trusted main commit ${TRUSTED_MAIN_COMMIT}." >&2
+            exit 1
           fi
 
           PACKAGE_VERSION="$(node -p "require('./package.json').version")"
@@ -82,6 +78,9 @@ jobs:
 
           echo "package_version=${PACKAGE_VERSION}" >> "$GITHUB_OUTPUT"
           echo "release_tag=${TAG_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Run release checks
         env:

--- a/docs/proof-and-install.md
+++ b/docs/proof-and-install.md
@@ -30,9 +30,9 @@ This is the shortest current repo-native path to:
 
 For the fuller release/distribution boundary, including publish commands and deferred marketplace/trust-layer work, use [docs/release-distribution-proof-map.md](./release-distribution-proof-map.md).
 
-Proof labels and freshness come from [proof-freshness.md](./proof-freshness.md) and [proof-manifest.json](./proof-manifest.json). The May self-hosted run, April Firecrawl connector run, and previous 0.1.35 release evidence are preserved as historical environment evidence; they are not current host receipts for `0.1.36`.
+Proof labels and freshness come from [proof-freshness.md](./proof-freshness.md) and [proof-manifest.json](./proof-manifest.json). The May self-hosted run, April Firecrawl connector run, and released 0.1.36 evidence are preserved as historical environment evidence; they are not current host receipts for `0.1.37`.
 
-The current v0.1.36 release receipts prove the `bundle-contract` and generated-installer `fake-home-install` tiers from the repository state, including installed top-level OpenCode wrapper workspace passthrough and maintained core-four fake-home coverage. No current receipt claims installed-runtime or real-host behavior until public host verification is refreshed.
+The v0.1.37 release-prep lane will record current `bundle-contract` and `fake-home-install` receipts after its versioned commit passes the full release gate. The security focus is fail-closed detection of bundled runtime scripts that source workspace `.env` files through direct or statically evaluable shell forms. No current receipt claims installed-runtime or real-host behavior until public host verification is refreshed.
 
 ## The Story In One Screen
 
@@ -210,7 +210,7 @@ curl -fsSL https://raw.githubusercontent.com/orchidautomation/pluxx/main/example
 
 Current release note:
 
-- the canonical repository version is `@orchid-labs/pluxx@0.1.36` for the OpenCode installed-wrapper workspace patch release; previous `v0.1.35` public release evidence is historical
+- the canonical repository version is `@orchid-labs/pluxx@0.1.37` for the PLUXX-339 runtime env-sourcing security patch; released `v0.1.36` evidence is historical
 - the published CLI runtime is Node `>=18`; see [runtime contract](./runtime-contract.md)
 - the published package includes the Claude plugin-agent manifest fix and packaged Node runtime verification
 - the public `pluxx test --install --trust --behavioral` path now matches the repo-local Exa proof state

--- a/docs/proof-and-install.md
+++ b/docs/proof-and-install.md
@@ -32,7 +32,7 @@ For the fuller release/distribution boundary, including publish commands and def
 
 Proof labels and freshness come from [proof-freshness.md](./proof-freshness.md) and [proof-manifest.json](./proof-manifest.json). The May self-hosted run, April Firecrawl connector run, and released 0.1.36 evidence are preserved as historical environment evidence; they are not current host receipts for `0.1.37`.
 
-The v0.1.37 release-prep lane will record current `bundle-contract` and `fake-home-install` receipts after its versioned commit passes the full release gate. The security focus is fail-closed detection of bundled runtime scripts that source workspace `.env` files through direct or statically evaluable shell forms. No current receipt claims installed-runtime or real-host behavior until public host verification is refreshed.
+The v0.1.37 release-prep receipts prove the `bundle-contract` and maintained core-four `fake-home-install` tiers from exact versioned commit `f7ee0bd5d6cf5f8b75dec7df6dcda85dcf5a7af8`. The security focus is fail-closed detection of bundled runtime scripts that source workspace `.env` files through direct or statically evaluable shell forms. No current receipt claims installed-runtime or real-host behavior until public host verification is refreshed.
 
 ## The Story In One Screen
 

--- a/docs/proof-freshness.md
+++ b/docs/proof-freshness.md
@@ -4,7 +4,7 @@ Last updated: 2026-07-17
 
 This document defines how Pluxx distinguishes repeatable repository checks from installed and real-host evidence. The machine-readable source is [proof-manifest.json](./proof-manifest.json), validated by `npm run proof:check`.
 
-Current reviewed receipts for released v0.1.36 are `v0.1.36-repository-validation` (`bundle-contract`, `current`) and `v0.1.36-fake-home-install` (`fake-home-install`, `current`). They cite the installed OpenCode top-level wrapper workspace passthrough patch state. The v0.1.35, v0.1.34, v0.1.33, v0.1.32, and older receipts remain historical. Neither current tier is installed-runtime or real-host behavior evidence.
+The canonical `v0.1.37` security patch is in release-prep. Fresh repository-validation and fake-home-install receipts will be bound to the versioned release-prep commit after the first full gate. The released v0.1.36 and older receipts remain historical. No current receipt claims installed-runtime or real-host behavior until public host verification is refreshed.
 
 ## Version And Freshness Policy
 

--- a/docs/proof-freshness.md
+++ b/docs/proof-freshness.md
@@ -4,7 +4,7 @@ Last updated: 2026-07-17
 
 This document defines how Pluxx distinguishes repeatable repository checks from installed and real-host evidence. The machine-readable source is [proof-manifest.json](./proof-manifest.json), validated by `npm run proof:check`.
 
-The canonical `v0.1.37` security patch is in release-prep. Fresh repository-validation and fake-home-install receipts will be bound to the versioned release-prep commit after the first full gate. The released v0.1.36 and older receipts remain historical. No current receipt claims installed-runtime or real-host behavior until public host verification is refreshed.
+Current reviewed receipts for the `v0.1.37` security release-prep are `v0.1.37-repository-validation` (`bundle-contract`, `current`) and `v0.1.37-fake-home-install` (`fake-home-install`, `current`). Both are bound to versioned commit `f7ee0bd5d6cf5f8b75dec7df6dcda85dcf5a7af8` after the complete release gate passed. The released v0.1.36 and older receipts remain historical. No current receipt claims installed-runtime or real-host behavior until public host verification is refreshed.
 
 ## Version And Freshness Policy
 

--- a/docs/proof-manifest.json
+++ b/docs/proof-manifest.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
-  "canonicalVersion": "0.1.36",
-  "expectedTag": "v0.1.36",
-  "releaseState": "released",
+  "canonicalVersion": "0.1.37",
+  "expectedTag": "v0.1.37",
+  "releaseState": "release-prep",
   "policy": {
     "environmentReceiptMaxAgeDays": 30
   },
@@ -105,17 +105,17 @@
     },
     {
       "id": "v0.1.36-repository-validation",
-      "summary": "The v0.1.36 released state passes the repository release gate for installed OpenCode wrapper workspace passthrough.",
+      "summary": "The v0.1.36 released state remains historical proof for installed OpenCode wrapper workspace passthrough.",
       "tier": "bundle-contract",
-      "freshness": "current",
+      "freshness": "historical",
       "evidencePath": "tests/proof-freshness.test.ts",
       "receiptId": "v0.1.36-repository-validation"
     },
     {
       "id": "v0.1.36-fake-home-install",
-      "summary": "Generated installer fake-home coverage proves OpenCode top-level wrappers preserve selected workspace context for v0.1.36.",
+      "summary": "Generated installer fake-home coverage for v0.1.36 remains historical proof of OpenCode workspace preservation.",
       "tier": "fake-home-install",
-      "freshness": "current",
+      "freshness": "historical",
       "evidencePath": "tests/publish.test.ts",
       "receiptId": "v0.1.36-fake-home-install"
     }
@@ -414,7 +414,7 @@
     {
       "id": "v0.1.36-repository-validation",
       "tier": "bundle-contract",
-      "freshness": "current",
+      "freshness": "historical",
       "commitSha": "bfbdd5fc80e73ff1014d64ac3d9c59f9e48dfeee",
       "packageVersion": "0.1.36",
       "timestamp": "2026-07-18T20:54:05.637Z",
@@ -437,7 +437,7 @@
     {
       "id": "v0.1.36-fake-home-install",
       "tier": "fake-home-install",
-      "freshness": "current",
+      "freshness": "historical",
       "commands": [
         {
           "command": "bun test tests/publish.test.ts tests/doctor.test.ts tests/install.test.ts tests/verify-install.test.ts",

--- a/docs/proof-manifest.json
+++ b/docs/proof-manifest.json
@@ -118,6 +118,22 @@
       "freshness": "historical",
       "evidencePath": "tests/publish.test.ts",
       "receiptId": "v0.1.36-fake-home-install"
+    },
+    {
+      "id": "v0.1.37-repository-validation",
+      "summary": "The v0.1.37 release-prep state passes the complete repository release gate for the PLUXX-339 runtime env-sourcing security patch.",
+      "tier": "bundle-contract",
+      "freshness": "current",
+      "evidencePath": "tests/proof-freshness.test.ts",
+      "receiptId": "v0.1.37-repository-validation"
+    },
+    {
+      "id": "v0.1.37-fake-home-install",
+      "summary": "The v0.1.37 release gate passes maintained core-four isolated install and packaged-runtime verification with the runtime env-sourcing guard enabled.",
+      "tier": "fake-home-install",
+      "freshness": "current",
+      "evidencePath": "tests/release-smoke.test.ts",
+      "receiptId": "v0.1.37-fake-home-install"
     }
   ],
   "receipts": [
@@ -438,6 +454,9 @@
       "id": "v0.1.36-fake-home-install",
       "tier": "fake-home-install",
       "freshness": "historical",
+      "commitSha": "bfbdd5fc80e73ff1014d64ac3d9c59f9e48dfeee",
+      "packageVersion": "0.1.36",
+      "timestamp": "2026-07-18T20:54:05.805Z",
       "commands": [
         {
           "command": "bun test tests/publish.test.ts tests/doctor.test.ts tests/install.test.ts tests/verify-install.test.ts",
@@ -452,10 +471,53 @@
           "sha256": null,
           "outcome": "passed"
         }
+      ]
+    },
+    {
+      "id": "v0.1.37-repository-validation",
+      "tier": "bundle-contract",
+      "freshness": "current",
+      "commitSha": "f7ee0bd5d6cf5f8b75dec7df6dcda85dcf5a7af8",
+      "packageVersion": "0.1.37",
+      "timestamp": "2026-07-25T01:02:45.000Z",
+      "commands": [
+        {
+          "command": "npm run release:check",
+          "outcome": "passed"
+        }
       ],
-      "commitSha": "bfbdd5fc80e73ff1014d64ac3d9c59f9e48dfeee",
-      "packageVersion": "0.1.36",
-      "timestamp": "2026-07-18T20:54:05.805Z"
+      "targets": [
+        {
+          "target": "repository",
+          "hostVersion": null,
+          "installedPath": null,
+          "sha256": null,
+          "outcome": "passed"
+        }
+      ]
+    },
+    {
+      "id": "v0.1.37-fake-home-install",
+      "tier": "fake-home-install",
+      "freshness": "current",
+      "commitSha": "f7ee0bd5d6cf5f8b75dec7df6dcda85dcf5a7af8",
+      "packageVersion": "0.1.37",
+      "timestamp": "2026-07-25T01:02:45.000Z",
+      "commands": [
+        {
+          "command": "npm run release:check",
+          "outcome": "passed"
+        }
+      ],
+      "targets": [
+        {
+          "target": "claude-code,cursor,codex,opencode",
+          "hostVersion": null,
+          "installedPath": null,
+          "sha256": null,
+          "outcome": "passed"
+        }
+      ]
     }
   ]
 }

--- a/docs/proof-receipts/v0.1.37-fake-home-install.json
+++ b/docs/proof-receipts/v0.1.37-fake-home-install.json
@@ -1,0 +1,23 @@
+{
+  "id": "v0.1.37-fake-home-install",
+  "tier": "fake-home-install",
+  "freshness": "current",
+  "commitSha": "f7ee0bd5d6cf5f8b75dec7df6dcda85dcf5a7af8",
+  "packageVersion": "0.1.37",
+  "timestamp": "2026-07-25T01:02:45.000Z",
+  "commands": [
+    {
+      "command": "npm run release:check",
+      "outcome": "passed"
+    }
+  ],
+  "targets": [
+    {
+      "target": "claude-code,cursor,codex,opencode",
+      "hostVersion": null,
+      "installedPath": null,
+      "sha256": null,
+      "outcome": "passed"
+    }
+  ]
+}

--- a/docs/proof-receipts/v0.1.37-repository-validation.json
+++ b/docs/proof-receipts/v0.1.37-repository-validation.json
@@ -1,0 +1,23 @@
+{
+  "id": "v0.1.37-repository-validation",
+  "tier": "bundle-contract",
+  "freshness": "current",
+  "commitSha": "f7ee0bd5d6cf5f8b75dec7df6dcda85dcf5a7af8",
+  "packageVersion": "0.1.37",
+  "timestamp": "2026-07-25T01:02:45.000Z",
+  "commands": [
+    {
+      "command": "npm run release:check",
+      "outcome": "passed"
+    }
+  ],
+  "targets": [
+    {
+      "target": "repository",
+      "hostVersion": null,
+      "installedPath": null,
+      "sha256": null,
+      "outcome": "passed"
+    }
+  ]
+}

--- a/docs/release-distribution-proof-map.md
+++ b/docs/release-distribution-proof-map.md
@@ -26,7 +26,7 @@ Last updated: 2026-07-16
 
 This is the short release/distribution map for what Pluxx can ship today, what is locally proven, and what still belongs to later marketplace or trust-layer work.
 
-Proof state is governed by [proof-freshness.md](./proof-freshness.md) and the machine-readable [proof manifest](./proof-manifest.json). The canonical repository version is `0.1.36`, tagged as `v0.1.36`. The previous published `v0.1.35` release is historical; older host runs linked below are historical unless a current receipt says otherwise. PLUXX-337 is the released slice for installed OpenCode top-level wrappers preserving the selected workspace context.
+Proof state is governed by [proof-freshness.md](./proof-freshness.md) and the machine-readable [proof manifest](./proof-manifest.json). The canonical repository version is `0.1.37`, preparing tag `v0.1.37`. The published `v0.1.36` release is historical; older host runs linked below are historical unless a current receipt says otherwise. PLUXX-339 is the release-prep security slice that blocks bundled runtime scripts from sourcing workspace `.env` files through direct and statically evaluable shell forms.
 
 ## Current Primary Fronts
 

--- a/docs/releasing-pluxx.md
+++ b/docs/releasing-pluxx.md
@@ -11,10 +11,11 @@ This repo now has a tag-based GitHub Actions workflow at [`.github/workflows/rel
 When you push a tag like `v0.1.1`, GitHub Actions will:
 
 1. install Node dependencies
-2. run `npm run release:check`
-3. verify the tag matches `package.json` version
-4. run `npm publish --provenance --access public`
-5. create a GitHub release and attach the packed npm tarball
+2. verify the tag commit belongs to the current trusted `origin/main` history
+3. run `npm run release:check`
+4. verify the tag matches `package.json` version
+5. run `npm publish --provenance --access public`
+6. create a GitHub release and attach the packed npm tarball
 
 That means GitHub pushes do **not** update npm by themselves. Only a versioned tag release does.
 
@@ -23,6 +24,8 @@ The workflow also has a maintainer-only recovery dispatch for an existing releas
 Do not publish this package from a local shell. The package lifecycle now refuses local `npm publish` and only allows the trusted GitHub release workflow on a matching `vX.Y.Z` tag. This keeps npm provenance intact and avoids depending on local npm auth.
 
 That package-release rule is separate from `pluxx publish`, which packages a user's built plugin bundles and generated installers for distribution.
+
+The workflow rejects normal tag pushes and recovery dispatches when the tag commit is outside current `origin/main` history. Repository administrators should also restrict `v*` tag creation and preserve any configured GitHub release approvals: workflow code is loaded from the tagged commit, so GitHub-side tag governance remains part of the trust boundary.
 
 ## One-Time Setup
 
@@ -97,6 +100,7 @@ Check:
 
 The workflow intentionally fails if:
 
+- the tag commit is not contained in current trusted `origin/main` history
 - the tag does not match `package.json` version
 - a recovery dispatch does not run from `main`
 - the requested recovery tag is missing, malformed, not checked out, or not contained in trusted `main` history

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -388,7 +388,7 @@ This is for learning and proof, not for prematurely building the full trust laye
 
 ### 6. Next release
 
-The canonical repository version is `0.1.37`, preparing tag `v0.1.37`. Fresh repository-validation and fake-home-install receipts will be tied to the versioned PLUXX-339 runtime env-sourcing security patch state; released 0.1.36 proof is historical.
+The canonical repository version is `0.1.37`, preparing tag `v0.1.37`. Current repository-validation and fake-home-install receipts are tied to versioned commit `f7ee0bd5d6cf5f8b75dec7df6dcda85dcf5a7af8` for the PLUXX-339 runtime env-sourcing security patch; released 0.1.36 proof is historical.
 
 The next npm cut should stay primarily an operations step rather than a code-confidence rescue step.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -82,7 +82,7 @@ The full v0.1.31 audit-remediation tranche is merged. Main now includes safer in
 
 Proof governance now distinguishes unit, bundle-contract, fake-home install, installed-runtime, and real-host behavior evidence. Canonical version/freshness checks run in CI through [proof-freshness.md](./proof-freshness.md) and [proof-manifest.json](./proof-manifest.json); historical April/May proof stays available without being treated as current.
 
-The active release-blocking slice is the PLUXX-337 follow-up to the 0.1.35 OpenCode plugin-root patch release. The published 0.1.35 release fixed the inner bundle split between installed plugin root and active workspace directory, but installed top-level OpenCode wrappers still need to preserve the host-provided `context.directory` unchanged.
+The active release-blocking slice is PLUXX-339 after the historical released 0.1.36 OpenCode workspace patch. The security patch blocks bundled runtime scripts from sourcing workspace `.env` files through direct and statically evaluable shell forms while preserving valid safe shell syntax.
 
 ### 1. Product clarity and source-of-truth coherence
 
@@ -228,7 +228,7 @@ The closure plan is now narrower than it was before:
 - historical release-gate evidence from 2026-05-19 remains available but is not current proof:
   - `npm test` passed
   - `npm run release:check` passed
-- the canonical repository version is `@orchid-labs/pluxx@0.1.36`; previous `v0.1.35` release evidence is historical
+- the canonical repository version is `@orchid-labs/pluxx@0.1.37`; released `v0.1.36` evidence is historical
 - the release/distribution/proof boundary is now explicit:
   - [docs/release-distribution-proof-map.md](./release-distribution-proof-map.md)
   - [docs/core-four-primitive-proof-ledger.md](./core-four-primitive-proof-ledger.md)
@@ -388,11 +388,11 @@ This is for learning and proof, not for prematurely building the full trust laye
 
 ### 6. Next release
 
-The canonical repository version is `0.1.36`, prepared for tag `v0.1.36`. Current repository-validation and fake-home-install receipts are tied to PLUXX-337 installed top-level OpenCode wrapper workspace passthrough; previous 0.1.35 proof is historical for the prior OpenCode inner-bundle fix.
+The canonical repository version is `0.1.37`, preparing tag `v0.1.37`. Fresh repository-validation and fake-home-install receipts will be tied to the versioned PLUXX-339 runtime env-sourcing security patch state; released 0.1.36 proof is historical.
 
 The next npm cut should stay primarily an operations step rather than a code-confidence rescue step.
 
-- complete PLUXX-337, then prepare the next patch package, proof, and source-of-truth release for installed OpenCode wrapper workspace passthrough
+- complete the focused 0.1.37 release PR for PLUXX-339, then push the immutable tag from merged main
 - preserve the release proof as current repository-validation and fake-home-install evidence
 - use future focused release PRs and trusted tag workflows for the next package cut
 

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -39,7 +39,7 @@ If you want the shortest public proof and install path after this file, use [doc
 
 If you want the current release, distribution, and proof boundary, use [docs/release-distribution-proof-map.md](./release-distribution-proof-map.md).
 
-If you need to know whether a proof claim is current, historical, repository-only, installed, or real-host evidence, use [docs/proof-freshness.md](./proof-freshness.md) and [docs/proof-manifest.json](./proof-manifest.json). Canonical repository version truth is `package.json` (`0.1.36`) and the proof manifest marks `v0.1.36` as released. The previous `v0.1.35` tag and package are historical release evidence for the prior OpenCode inner-bundle fix.
+If you need to know whether a proof claim is current, historical, repository-only, installed, or real-host evidence, use [docs/proof-freshness.md](./proof-freshness.md) and [docs/proof-manifest.json](./proof-manifest.json). Canonical repository version truth is `package.json` (`0.1.37`) and the proof manifest marks `v0.1.37` as release-prep. The released `v0.1.36` tag and package are historical evidence for the OpenCode installed-wrapper workspace fix.
 
 If you want the primitive-by-host proof ledger behind the core-four native shipping claim, use [docs/core-four-primitive-proof-ledger.md](./core-four-primitive-proof-ledger.md).
 
@@ -369,7 +369,7 @@ The repo already proves a lot.
 - historical release-gate evidence from 2026-05-19 remains available but is not current proof:
   - `npm test` passed
   - `npm run release:check` passed
-- the canonical repository version is `@orchid-labs/pluxx@0.1.36`; previous `v0.1.35` release evidence is historical
+- the canonical repository version is `@orchid-labs/pluxx@0.1.37`; released `v0.1.36` evidence is historical
 - marketplace submission APIs, a managed trust/distribution control plane, automatic rollback/unpublish orchestration, and real authenticated publish plus rollback proof remain explicit release gaps, not hidden shipped capabilities:
   - `docs/release-distribution-proof-map.md`
   - “automatic rollback” here means remote release rollback/unpublish; generated local installers now restore the prior bundle when staged setup fails
@@ -539,9 +539,9 @@ Run two lanes in parallel:
 
 ### 6. Release State
 
-The canonical repository version is `0.1.36`, tagged as `v0.1.36`. The previous `v0.1.35` tag and package are historical release evidence for the prior OpenCode inner-bundle fix. `package.json` is the source of truth for repository docs, while [proof-manifest.json](./proof-manifest.json) records tag state and proof freshness.
+The canonical repository version is `0.1.37`, preparing tag `v0.1.37`. The released `v0.1.36` tag and package are historical evidence for the OpenCode installed-wrapper workspace fix. `package.json` is the source of truth for repository docs, while [proof-manifest.json](./proof-manifest.json) records tag state and proof freshness.
 
-For v0.1.36, PLUXX-337 is the released focus: installed top-level OpenCode wrappers pass the host-provided workspace context through unchanged. Future releases should repeat the version bump and proof-prep work on a focused PR before tagging.
+For v0.1.37, PLUXX-339 is the release-prep focus: lint, doctor, install, and packaged-runtime verification fail closed when bundled runtime scripts source workspace `.env` files through direct or statically evaluable shell forms. The patch preserves valid safe shell forms and uses a bounded explicit scanner rather than an expanding regex.
 
 ## Working Rules
 

--- a/docs/todo/master-backlog.md
+++ b/docs/todo/master-backlog.md
@@ -99,15 +99,24 @@ Proof governance is now explicit: [proof-freshness.md](../proof-freshness.md) de
 - [x] Pass `npm run release:check`
 - [x] Push immutable tag `v0.1.35` from main
 - [x] Verify `@orchid-labs/pluxx@0.1.35`, GitHub release assets, tarball contents, and CLI behavior
-- [~] Complete PLUXX-337 before the next patch release: generated local and release OpenCode top-level wrappers must preserve `context.directory` exactly while the inner bundle continues to derive plugin root from its installed module URL.
-- [ ] Cut and verify the next patch release after PLUXX-337 merges.
+- [x] Complete PLUXX-337: generated local and release OpenCode top-level wrappers preserve `context.directory` exactly while the inner bundle continues to derive plugin root from its installed module URL.
+- [x] Cut and verify v0.1.36 after PLUXX-337 merged.
 
-### 0. v0.1.36 OpenCode installed-wrapper workspace patch release
+### 0. Historical v0.1.36 OpenCode installed-wrapper workspace patch release
 
-- [~] Prepare 0.1.36 through PLUXX-337 with synchronized package, proof, planning, generated release, local install, doctor, verify-install, legacy-adoption, and example fixture truth.
+- [x] Historical: prepare 0.1.36 through PLUXX-337 with synchronized package, proof, planning, generated release, local install, doctor, verify-install, legacy-adoption, and example fixture truth.
+- [x] Pass `npm run release:check`
+- [x] Push immutable tag `v0.1.36` from main
+- [x] Verify `@orchid-labs/pluxx@0.1.36`, GitHub release assets, tarball contents, and CLI behavior
+
+### 0. v0.1.37 runtime env-sourcing security patch release
+
+- [x] Merge PLUXX-339 through PR #456 at exact reviewed head `b888c62dc7905fd66c9fdf50c4e752984fee5b48`
+- [x] Prepare synchronized 0.1.37 package, proof, planning, and release truth
+- [ ] Bind fresh current receipts to the versioned release-prep commit
 - [ ] Pass `npm run release:check`
-- [ ] Push immutable tag `v0.1.36` from main
-- [ ] Verify `@orchid-labs/pluxx@0.1.36`, GitHub release assets, tarball contents, and CLI behavior
+- [ ] Merge the focused release PR and push immutable tag `v0.1.37`
+- [ ] Verify `@orchid-labs/pluxx@0.1.37`, GitHub release assets, tarball contents, and CLI behavior
 
 ### 1. Product clarity and front-door coherence
 

--- a/docs/todo/master-backlog.md
+++ b/docs/todo/master-backlog.md
@@ -113,8 +113,8 @@ Proof governance is now explicit: [proof-freshness.md](../proof-freshness.md) de
 
 - [x] Merge PLUXX-339 through PR #456 at exact reviewed head `b888c62dc7905fd66c9fdf50c4e752984fee5b48`
 - [x] Prepare synchronized 0.1.37 package, proof, planning, and release truth
-- [ ] Bind fresh current receipts to the versioned release-prep commit
-- [ ] Pass `npm run release:check`
+- [x] Bind fresh current receipts to versioned release-prep commit `f7ee0bd5d6cf5f8b75dec7df6dcda85dcf5a7af8`
+- [x] Pass `npm run release:check`
 - [ ] Merge the focused release PR and push immutable tag `v0.1.37`
 - [ ] Verify `@orchid-labs/pluxx@0.1.37`, GitHub release assets, tarball contents, and CLI behavior
 

--- a/docs/todo/queue.md
+++ b/docs/todo/queue.md
@@ -541,8 +541,8 @@ Current work:
 
 - [x] merge PLUXX-339 through exact reviewed PR #456 head `b888c62dc7905fd66c9fdf50c4e752984fee5b48`
 - [x] bump package and canonical release truth to 0.1.37
-- [ ] bind fresh repository-validation and fake-home-install receipts to the versioned release-prep commit
-- [ ] pass `npm run release:check`
+- [x] bind fresh repository-validation and fake-home-install receipts to versioned release-prep commit `f7ee0bd5d6cf5f8b75dec7df6dcda85dcf5a7af8`
+- [x] pass `npm run release:check`
 - [ ] merge the focused release PR and push immutable tag `v0.1.37` from main
 - [ ] verify npm, GitHub release assets, tarball contents, and CLI behavior
 

--- a/docs/todo/queue.md
+++ b/docs/todo/queue.md
@@ -188,7 +188,7 @@ The initial author-once hardening tranche is also materially done.
 The public baseline is also real.
 
 - npm package is live as `@orchid-labs/pluxx`
-- the canonical repository version is `@orchid-labs/pluxx@0.1.36`; previous `v0.1.35` evidence is historical
+- the canonical repository version is `@orchid-labs/pluxx@0.1.37`; released `v0.1.36` evidence is historical
 - proof claims now use [docs/proof-freshness.md](../proof-freshness.md) and [docs/proof-manifest.json](../proof-manifest.json) so historical host runs cannot masquerade as current evidence
 - published CLI runtime is Node `>=18`
 - published CLI lifecycle ergonomics are now stronger for global installs:
@@ -525,16 +525,25 @@ Current work:
 - [x] pass `npm run release:check`
 - [x] push immutable tag `v0.1.35` from main
 - [x] verify npm, GitHub release assets, tarball contents, and CLI behavior
-- [~] PLUXX-337 is the active follow-up: installed local and generated-release OpenCode top-level wrappers must call `pluginFactory(context)` so the selected workspace root is not rewritten to `<workspace>/<plugin>`.
-- [ ] after PLUXX-337 merges, cut the next patch release with refreshed repository-validation and fake-home-install receipts, then verify npm, GitHub release assets, tarball contents, and CLI behavior.
+- [x] PLUXX-337 shipped in v0.1.36: installed local and generated-release OpenCode top-level wrappers call `pluginFactory(context)` so the selected workspace root is not rewritten to `<workspace>/<plugin>`.
+- [x] cut and verify v0.1.36 with refreshed repository-validation and fake-home-install receipts.
 
-### 8. v0.1.36 OpenCode installed-wrapper workspace patch release
+### 8. Historical v0.1.36 OpenCode installed-wrapper workspace patch release
 
 Current work:
 
-- [~] PLUXX-337 prepares 0.1.36 with package, proof, planning, local-install, generated-release, doctor, verify-install, legacy-adoption, and example-release fixture alignment.
+- [x] Historical: PLUXX-337 prepared 0.1.36 with package, proof, planning, local-install, generated-release, doctor, verify-install, legacy-adoption, and example-release fixture alignment.
+- [x] passed `npm run release:check`
+- [x] pushed immutable tag `v0.1.36` from main
+- [x] verified npm, GitHub release assets, tarball contents, and CLI behavior
+
+### 9. v0.1.37 runtime env-sourcing security patch release
+
+- [x] merge PLUXX-339 through exact reviewed PR #456 head `b888c62dc7905fd66c9fdf50c4e752984fee5b48`
+- [x] bump package and canonical release truth to 0.1.37
+- [ ] bind fresh repository-validation and fake-home-install receipts to the versioned release-prep commit
 - [ ] pass `npm run release:check`
-- [ ] push immutable tag `v0.1.36` from main after merge
+- [ ] merge the focused release PR and push immutable tag `v0.1.37` from main
 - [ ] verify npm, GitHub release assets, tarball contents, and CLI behavior
 
 ### 7. Historical v0.1.28 release checklist

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orchid-labs/pluxx",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchid-labs/pluxx",
-      "version": "0.1.36",
+      "version": "0.1.37",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orchid-labs/pluxx",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "description": "Build AI agent plugins once. Prime-time on Claude Code, Cursor, Codex, and OpenCode, with beta generators for additional hosts.",
   "type": "module",
   "main": "dist/index.js",

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test'
-import { readFileSync } from 'fs'
-import { resolve } from 'path'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join, resolve } from 'path'
 import { parse } from 'yaml'
 import { spawnSync } from 'child_process'
 
@@ -45,10 +46,69 @@ describe('release workflow', () => {
     expect(version?.env?.REQUESTED_RELEASE_TAG).toBe("${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}")
     expect(version?.run).toContain('Release recovery must be dispatched from main')
     expect(version?.run).toContain('git show-ref --verify --quiet "refs/tags/${TAG_NAME}"')
+    expect(version?.run).toContain('git fetch --no-tags origin main:refs/remotes/origin/main')
+    expect(version?.run).toContain('git rev-parse "refs/remotes/origin/main^{commit}"')
     expect(version?.run).toContain('git merge-base --is-ancestor "${TAG_COMMIT}" "${TRUSTED_MAIN_COMMIT}"')
+    expect(version?.run).not.toContain('if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then')
     expect(version?.run).toContain('Checked-out commit ${HEAD_COMMIT} does not match ${TAG_NAME} commit ${TAG_COMMIT}.')
     expect(version?.run).toContain('echo "release_tag=${TAG_NAME}" >> "$GITHUB_OUTPUT"')
     expect(release?.with?.tag_name).toBe('${{ steps.version.outputs.release_tag }}')
+  })
+
+  it('rejects a normal release tag whose commit is outside trusted main history', () => {
+    const workflow = parse(releaseWorkflow) as {
+      jobs: { publish: { steps: Array<{ name?: string; run?: string }> } }
+    }
+    const versionScript = workflow.jobs.publish.steps.find((step) => step.name === 'Resolve release version')?.run
+    expect(versionScript).toBeTruthy()
+
+    const fixtureRoot = mkdtempSync(join(tmpdir(), 'pluxx-release-tag-'))
+    const remote = join(fixtureRoot, 'remote.git')
+    const checkout = join(fixtureRoot, 'checkout')
+    const output = join(fixtureRoot, 'github-output')
+    const git = (args: string[], cwd = checkout) => {
+      const result = spawnSync('git', args, { cwd, encoding: 'utf-8' })
+      expect(result.status, result.stderr).toBe(0)
+      return result.stdout.trim()
+    }
+
+    try {
+      git(['init', '--bare', remote], fixtureRoot)
+      git(['init', checkout], fixtureRoot)
+      git(['config', 'user.email', 'release-test@example.com'])
+      git(['config', 'user.name', 'Release Test'])
+      writeFileSync(join(checkout, 'package.json'), '{"version":"0.1.37"}\n')
+      git(['add', 'package.json'])
+      git(['commit', '-m', 'main release version'])
+      git(['branch', '-M', 'main'])
+      git(['remote', 'add', 'origin', remote])
+      git(['push', '-u', 'origin', 'main'])
+
+      git(['switch', '-c', 'side-release'])
+      writeFileSync(join(checkout, 'side-only.txt'), 'not reviewed on main\n')
+      git(['add', 'side-only.txt'])
+      git(['commit', '-m', 'side release'])
+      git(['tag', 'v0.1.37'])
+      const tagCommit = git(['rev-parse', 'HEAD'])
+
+      const result = spawnSync('bash', ['-c', versionScript!], {
+        cwd: checkout,
+        encoding: 'utf-8',
+        env: {
+          ...process.env,
+          GITHUB_EVENT_NAME: 'push',
+          GITHUB_REF: 'refs/tags/v0.1.37',
+          GITHUB_SHA: tagCommit,
+          GITHUB_OUTPUT: output,
+          REQUESTED_RELEASE_TAG: 'v0.1.37',
+        },
+      })
+
+      expect(result.status).toBe(1)
+      expect(result.stderr).toContain('Release tag v0.1.37 is not contained in trusted main commit')
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true })
+    }
   })
 
   it('uses GitHub Actions runtime versions that avoid the Node 20 deprecation path', () => {
@@ -80,6 +140,8 @@ describe('release workflow', () => {
     const names = workflow.jobs.publish.steps.map((step) => step.name)
     const releaseCheck = workflow.jobs.publish.steps.find((step) => step.name === 'Run release checks')
     expect(releaseCheck?.env?.PLUXX_RELEASE_TAG).toBe('${{ steps.version.outputs.release_tag }}')
+    expect(names.indexOf('Resolve release version')).toBeLessThan(names.indexOf('Install dependencies'))
+    expect(names.indexOf('Install dependencies')).toBeLessThan(names.indexOf('Run release checks'))
     expect(names.indexOf('Pack release tarball')).toBeLessThan(names.indexOf('Verify packaged Node runtime'))
     expect(names.indexOf('Verify packaged Node runtime')).toBeLessThan(names.indexOf('Publish to npm'))
     expect(names.indexOf('Publish to npm')).toBeLessThan(names.indexOf('Verify npm publication'))


### PR DESCRIPTION
## Summary

- bumps `@orchid-labs/pluxx` from 0.1.36 to 0.1.37 after exact PLUXX-339 merge commit `25471264642c368813999c2b888352c449bb493d`
- records current repository and fake-home proof receipts against versioned commit `f7ee0bd5d6cf5f8b75dec7df6dcda85dcf5a7af8`
- aligns canonical release, roadmap, queue, and proof documentation for the runtime env-sourcing security patch

## Validation

- `npm run release:check` on `f7ee0bd5d6cf5f8b75dec7df6dcda85dcf5a7af8`
- `npm run release:check` on exact PR head `8e293291bfa3a5c79aa4de3c5e5d2f34241dc5a7`
- 61 test files / 802 tests passed
- isolated package install and `npm exec` doctor/validate/build passed
- dry-run npm pack produced `@orchid-labs/pluxx@0.1.37`

## Release

After this PR merges with fresh checks green, tag the exact merged main commit as `v0.1.37` and let the trusted tag workflow publish with provenance. No local publish and no autofix enrollment.