### PR TITLE
fix(release): recover immutable v0.1.37 publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
       release_tag:
         description: Existing release tag to recover from the trusted main workflow
         required: true
-        default: v0.1.32
+        default: v0.1.37
         type: string
 
 permissions:
@@ -19,13 +19,26 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: release
 
     steps:
-      - name: Check out repository
+      - name: Check out immutable release tree
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref }}
+          path: release
+
+      - name: Check out trusted recovery code
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+          ref: ${{ github.sha }}
+          path: trusted-main
 
       - name: Set up Node.js
         uses: actions/setup-node@v5
@@ -68,6 +81,17 @@ jobs:
             echo "Release tag ${TAG_NAME} is not contained in trusted main commit ${TRUSTED_MAIN_COMMIT}." >&2
             exit 1
           fi
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            RECOVERY_CHECKOUT_COMMIT="$(git -C ../trusted-main rev-parse HEAD)"
+            if [[ "${GITHUB_SHA}" != "${TRUSTED_MAIN_COMMIT}" ]]; then
+              echo "Recovery commit ${GITHUB_SHA} does not match current trusted main ${TRUSTED_MAIN_COMMIT}." >&2
+              exit 1
+            fi
+            if [[ "${RECOVERY_CHECKOUT_COMMIT}" != "${TRUSTED_MAIN_COMMIT}" ]]; then
+              echo "Trusted recovery checkout ${RECOVERY_CHECKOUT_COMMIT} does not match current trusted main ${TRUSTED_MAIN_COMMIT}." >&2
+              exit 1
+            fi
+          fi
 
           PACKAGE_VERSION="$(node -p "require('./package.json').version")"
 
@@ -78,14 +102,57 @@ jobs:
 
           echo "package_version=${PACKAGE_VERSION}" >> "$GITHUB_OUTPUT"
           echo "release_tag=${TAG_NAME}" >> "$GITHUB_OUTPUT"
+          echo "tag_commit=${TAG_COMMIT}" >> "$GITHUB_OUTPUT"
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Run release checks
+      - name: Run standard release checks
+        if: github.event_name != 'workflow_dispatch'
         env:
           PLUXX_RELEASE_TAG: ${{ steps.version.outputs.release_tag }}
         run: npm run release:check
+
+      - name: Prepare immutable-tag recovery proof
+        if: github.event_name == 'workflow_dispatch'
+        id: recovery
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -z "$(git -C ../trusted-main status --porcelain --untracked-files=no)"
+          test "$(git -C ../trusted-main rev-parse HEAD)" = "${GITHUB_SHA}"
+
+          CANDIDATE_DIR="${RUNNER_TEMP}/pluxx-recovery-candidate"
+          mkdir -p "${CANDIDATE_DIR}"
+          CANDIDATE_PATH="${CANDIDATE_DIR}/orchid-labs-pluxx-${{ steps.version.outputs.package_version }}.tgz"
+          RECEIPT_FILE="pluxx-${{ steps.version.outputs.release_tag }}-recovery-receipt.json"
+          RECEIPT_PATH="${RUNNER_TEMP}/${RECEIPT_FILE}"
+
+          node ../trusted-main/scripts/release-recovery-proof.mjs prepare \
+            --release-root "${PWD}" \
+            --tag "${{ steps.version.outputs.release_tag }}" \
+            --trusted-main-commit "${GITHUB_SHA}" \
+            --artifact "${CANDIDATE_PATH}" \
+            --receipt "${RECEIPT_PATH}"
+
+          CANDIDATE_INTEGRITY="sha512-$(openssl dgst -sha512 -binary "${CANDIDATE_PATH}" | openssl base64 -A)"
+          CANDIDATE_SHA256="$(openssl dgst -sha256 "${CANDIDATE_PATH}" | awk '{print $NF}')"
+          echo "candidate_path=${CANDIDATE_PATH}" >> "$GITHUB_OUTPUT"
+          echo "candidate_integrity=${CANDIDATE_INTEGRITY}" >> "$GITHUB_OUTPUT"
+          echo "candidate_sha256=${CANDIDATE_SHA256}" >> "$GITHUB_OUTPUT"
+          echo "receipt_file=${RECEIPT_FILE}" >> "$GITHUB_OUTPUT"
+          echo "receipt_path=${RECEIPT_PATH}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify immutable-tag recovery proof
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          set -euo pipefail
+          node ../trusted-main/scripts/release-recovery-proof.mjs finalize \
+            --release-root "${PWD}" \
+            --tag "${{ steps.version.outputs.release_tag }}" \
+            --trusted-main-commit "${GITHUB_SHA}" \
+            --artifact "${{ steps.recovery.outputs.candidate_path }}" \
+            --receipt "${{ steps.recovery.outputs.receipt_path }}"
 
       - name: Pack release tarball
         id: pack
@@ -95,10 +162,39 @@ jobs:
           PACKAGE_FILE="$(npm pack)"
           echo "package_file=${PACKAGE_FILE}" >> "$GITHUB_OUTPUT"
           PACKAGE_INTEGRITY="sha512-$(openssl dgst -sha512 -binary "$PACKAGE_FILE" | openssl base64 -A)"
+          PACKAGE_SHA256="$(openssl dgst -sha256 "$PACKAGE_FILE" | awk '{print $NF}')"
           echo "package_integrity=${PACKAGE_INTEGRITY}" >> "$GITHUB_OUTPUT"
+          echo "package_sha256=${PACKAGE_SHA256}" >> "$GITHUB_OUTPUT"
+
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            test "${PACKAGE_INTEGRITY}" = "${{ steps.recovery.outputs.candidate_integrity }}"
+            test "${PACKAGE_SHA256}" = "${{ steps.recovery.outputs.candidate_sha256 }}"
+            node ../trusted-main/scripts/release-recovery-proof.mjs verify \
+              --release-root "${PWD}" \
+              --tag "${{ steps.version.outputs.release_tag }}" \
+              --trusted-main-commit "${GITHUB_SHA}" \
+              --artifact "${PACKAGE_FILE}" \
+              --receipt "${{ steps.recovery.outputs.receipt_path }}"
+          fi
 
       - name: Verify packaged Node runtime
+        if: github.event_name != 'workflow_dispatch'
         run: node scripts/verify-node-package-runtime.mjs --package-file "${{ steps.pack.outputs.package_file }}"
+
+      - name: Revalidate recovery authority before npm publish
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG_NAME="${{ steps.version.outputs.release_tag }}"
+          git fetch --force --no-tags origin \
+            "main:refs/remotes/origin/main" \
+            "refs/tags/${TAG_NAME}:refs/release-validation/${TAG_NAME}"
+          CURRENT_MAIN="$(git rev-parse refs/remotes/origin/main^{commit})"
+          CURRENT_TAG="$(git rev-parse refs/release-validation/${TAG_NAME}^{commit})"
+          test "${CURRENT_MAIN}" = "${GITHUB_SHA}"
+          test "${CURRENT_TAG}" = "${{ steps.version.outputs.tag_commit }}"
+          git merge-base --is-ancestor "${CURRENT_TAG}" "${CURRENT_MAIN}"
 
       - name: Publish to npm
         env:
@@ -152,17 +248,50 @@ jobs:
           test "$PUBLISHED_INTEGRITY" = "$EXPECTED_INTEGRITY"
 
       - name: Create GitHub release
+        if: github.event_name != 'workflow_dispatch'
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.version.outputs.release_tag }}
           generate_release_notes: true
-          files: ${{ steps.pack.outputs.package_file }}
+          files: release/${{ steps.pack.outputs.package_file }}
+          name: v${{ steps.version.outputs.package_version }}
+          overwrite_files: true
+
+      - name: Stage recovery receipt asset
+        if: github.event_name == 'workflow_dispatch'
+        run: cp "${{ steps.recovery.outputs.receipt_path }}" "${{ steps.recovery.outputs.receipt_file }}"
+
+      - name: Revalidate recovery authority before GitHub release
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG_NAME="${{ steps.version.outputs.release_tag }}"
+          git fetch --force --no-tags origin \
+            "main:refs/remotes/origin/main" \
+            "refs/tags/${TAG_NAME}:refs/release-validation/${TAG_NAME}"
+          CURRENT_MAIN="$(git rev-parse refs/remotes/origin/main^{commit})"
+          CURRENT_TAG="$(git rev-parse refs/release-validation/${TAG_NAME}^{commit})"
+          test "${CURRENT_MAIN}" = "${GITHUB_SHA}"
+          test "${CURRENT_TAG}" = "${{ steps.version.outputs.tag_commit }}"
+          git merge-base --is-ancestor "${CURRENT_TAG}" "${CURRENT_MAIN}"
+
+      - name: Create GitHub recovery release
+        if: github.event_name == 'workflow_dispatch'
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ steps.version.outputs.release_tag }}
+          generate_release_notes: true
+          files: |
+            release/${{ steps.pack.outputs.package_file }}
+            release/${{ steps.recovery.outputs.receipt_file }}
           name: v${{ steps.version.outputs.package_version }}
           overwrite_files: true
 
       - name: Verify GitHub release asset
         env:
           GH_TOKEN: ${{ github.token }}
+          RECOVERY_RECEIPT_FILE: ${{ steps.recovery.outputs.receipt_file }}
         shell: bash
         run: |
           set -euo pipefail
@@ -179,3 +308,31 @@ jobs:
 
           RELEASE_INTEGRITY="sha512-$(openssl dgst -sha512 -binary "$DOWNLOAD_DIR/$PACKAGE_FILE" | openssl base64 -A)"
           test "$RELEASE_INTEGRITY" = "$EXPECTED_INTEGRITY"
+
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            gh release view "$TAG" --json tagName,assets \
+              --jq '.tagName == "'"$TAG"'" and any(.assets[]; .name == "'"$RECOVERY_RECEIPT_FILE"'")' \
+              | grep -qx true
+            gh release download "$TAG" --pattern "$RECOVERY_RECEIPT_FILE" --dir "$DOWNLOAD_DIR"
+            node ../trusted-main/scripts/release-recovery-proof.mjs verify \
+              --release-root "${PWD}" \
+              --tag "${{ steps.version.outputs.release_tag }}" \
+              --trusted-main-commit "${GITHUB_SHA}" \
+              --artifact "$DOWNLOAD_DIR/$PACKAGE_FILE" \
+              --receipt "$DOWNLOAD_DIR/$RECOVERY_RECEIPT_FILE"
+          fi
+
+      - name: Revalidate recovery authority after GitHub release
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG_NAME="${{ steps.version.outputs.release_tag }}"
+          git fetch --force --no-tags origin \
+            "main:refs/remotes/origin/main" \
+            "refs/tags/${TAG_NAME}:refs/release-validation/${TAG_NAME}"
+          CURRENT_MAIN="$(git rev-parse refs/remotes/origin/main^{commit})"
+          CURRENT_TAG="$(git rev-parse refs/release-validation/${TAG_NAME}^{commit})"
+          test "${CURRENT_MAIN}" = "${GITHUB_SHA}"
+          test "${CURRENT_TAG}" = "${{ steps.version.outputs.tag_commit }}"
+          git merge-base --is-ancestor "${CURRENT_TAG}" "${CURRENT_MAIN}"

--- a/docs/proof-and-install.md
+++ b/docs/proof-and-install.md
@@ -32,7 +32,7 @@ For the fuller release/distribution boundary, including publish commands and def
 
 Proof labels and freshness come from [proof-freshness.md](./proof-freshness.md) and [proof-manifest.json](./proof-manifest.json). The May self-hosted run, April Firecrawl connector run, and released 0.1.36 evidence are preserved as historical environment evidence; they are not current host receipts for `0.1.37`.
 
-The v0.1.37 release-prep receipts prove the `bundle-contract` and maintained core-four `fake-home-install` tiers from exact versioned commit `f7ee0bd5d6cf5f8b75dec7df6dcda85dcf5a7af8`. The security focus is fail-closed detection of bundled runtime scripts that source workspace `.env` files through direct or statically evaluable shell forms. No current receipt claims installed-runtime or real-host behavior until public host verification is refreshed.
+The v0.1.37 receipts prove the `bundle-contract` and maintained core-four `fake-home-install` tiers from an isolated exact-tag rehearsal at immutable commit `d5184752cd4898306390f20455619c34a42099dd`. They list the split commands actually run against the tag; the earlier full `release:check` receipts remain historical at pre-squash commit `f7ee0bd5d6cf5f8b75dec7df6dcda85dcf5a7af8`. The security focus is fail-closed detection of bundled runtime scripts that source workspace `.env` files through direct and statically evaluable shell forms. No current receipt claims installed-runtime or real-host behavior until public host verification is refreshed.
 
 ## The Story In One Screen
 
@@ -210,7 +210,7 @@ curl -fsSL https://raw.githubusercontent.com/orchidautomation/pluxx/main/example
 
 Current release note:
 
-- the canonical repository version is `@orchid-labs/pluxx@0.1.37` for the PLUXX-339 runtime env-sourcing security patch; released `v0.1.36` evidence is historical
+- the canonical repository version and immutable tag are `@orchid-labs/pluxx@0.1.37` / `v0.1.37` for the PLUXX-339 runtime env-sourcing security patch; the first tag run failed closed before publication, so `@orchid-labs/pluxx@0.1.36` remains the verified public package until exact-tag recovery succeeds
 - the published CLI runtime is Node `>=18`; see [runtime contract](./runtime-contract.md)
 - the published package includes the Claude plugin-agent manifest fix and packaged Node runtime verification
 - the public `pluxx test --install --trust --behavioral` path now matches the repo-local Exa proof state

--- a/docs/proof-freshness.md
+++ b/docs/proof-freshness.md
@@ -1,10 +1,10 @@
 # Proof Freshness And Evidence Tiers
 
-Last updated: 2026-07-17
+Last updated: 2026-07-24
 
 This document defines how Pluxx distinguishes repeatable repository checks from installed and real-host evidence. The machine-readable source is [proof-manifest.json](./proof-manifest.json), validated by `npm run proof:check`.
 
-Current reviewed receipts for the `v0.1.37` security release-prep are `v0.1.37-repository-validation` (`bundle-contract`, `current`) and `v0.1.37-fake-home-install` (`fake-home-install`, `current`). Both are bound to versioned commit `f7ee0bd5d6cf5f8b75dec7df6dcda85dcf5a7af8` after the complete release gate passed. The released v0.1.36 and older receipts remain historical. No current receipt claims installed-runtime or real-host behavior until public host verification is refreshed.
+Current reviewed receipts for the tagged `v0.1.37` security release are `v0.1.37-repository-validation` (`bundle-contract`, `current`) and `v0.1.37-fake-home-install` (`fake-home-install`, `current`). Both record the split commands observed in an isolated exact-tag rehearsal at immutable commit `d5184752cd4898306390f20455619c34a42099dd` on `2026-07-25T04:20:51.363Z`; the helper-owned rehearsal passed build, typecheck, 803 tests, dry-run packaging, candidate packaging, packaged-runtime verification, and the production proof checker, then restored a clean tag tree. The earlier `f7ee0bd5d6cf5f8b75dec7df6dcda85dcf5a7af8` full-release-check receipts are preserved separately as `pre-squash` historical evidence and are not attributed to the immutable tag. The first release run failed closed at proof freshness before pack or publication, so v0.1.36 remains the verified public package until exact-tag recovery completes. No current receipt claims installed-runtime or real-host behavior until public host verification is refreshed.
 
 ## Version And Freshness Policy
 
@@ -32,6 +32,14 @@ Current reviewed receipts for the `v0.1.37` security release-prep are `v0.1.37-r
 Each receipt records commit SHA, package version, timestamp, proof tier, commands, target and host versions, installed paths, hashes, and outcomes. Older evidence may provide a reason when an environment field was not captured.
 
 Current claims in `docs/proof-manifest.json` must resolve to a receipt whose tier and freshness match the claim. CI also rejects obsolete release-prep/current-version language in canonical planning and proof docs.
+
+## Immutable-Tag Recovery Contract
+
+An existing immutable tag may be recovered only after a reviewed workflow change lands on the exact current trusted `main` commit. The workflow must prove that the tag commit belongs to current `main`, that the checked-out tag, package version, and artifact identity match, and that the tagged checkout has no tracked changes.
+
+The recovery reruns build, typecheck, the full test suite, packaged-runtime verification, and dry-run packaging against the exact tag tree. It may then create an ephemeral proof-manifest overlay that binds only the existing current receipt set to that exact tag and the newly passed commands. The normal `proof:check` command must pass against the overlay. The workflow must restore the committed manifest and re-prove a clean tag checkout before packing the publish candidate.
+
+The recovery receipt records the exact tag commit and tree, trusted-main workflow commit, validation outcomes, proof baseline and overlay hashes, and package artifact hashes. The final npm tarball and downloaded GitHub release asset must match the independently validated candidate hashes. Recovery does not move the tag, weaken the normal proof checker, or claim installed-runtime or real-host evidence.
 
 ## Real-Host Refresh Guidance
 

--- a/docs/proof-manifest.json
+++ b/docs/proof-manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "canonicalVersion": "0.1.37",
   "expectedTag": "v0.1.37",
-  "releaseState": "release-prep",
+  "releaseState": "released",
   "policy": {
     "environmentReceiptMaxAgeDays": 30
   },
@@ -120,8 +120,24 @@
       "receiptId": "v0.1.36-fake-home-install"
     },
     {
+      "id": "v0.1.37-pre-squash-repository-validation",
+      "summary": "The pre-squash v0.1.37 release tree passed the complete repository release gate before the immutable tag was created by squash merge.",
+      "tier": "bundle-contract",
+      "freshness": "historical",
+      "evidencePath": "tests/proof-freshness.test.ts",
+      "receiptId": "v0.1.37-pre-squash-repository-validation"
+    },
+    {
+      "id": "v0.1.37-pre-squash-fake-home-install",
+      "summary": "The pre-squash v0.1.37 release tree passed maintained core-four isolated install coverage before the immutable tag was created by squash merge.",
+      "tier": "fake-home-install",
+      "freshness": "historical",
+      "evidencePath": "tests/release-smoke.test.ts",
+      "receiptId": "v0.1.37-pre-squash-fake-home-install"
+    },
+    {
       "id": "v0.1.37-repository-validation",
-      "summary": "The v0.1.37 release-prep state passes the complete repository release gate for the PLUXX-339 runtime env-sourcing security patch.",
+      "summary": "The exact immutable v0.1.37 tag passes the split recovery build, typecheck, full test, dry-pack, packaged-runtime, and proof gates for PLUXX-339.",
       "tier": "bundle-contract",
       "freshness": "current",
       "evidencePath": "tests/proof-freshness.test.ts",
@@ -129,7 +145,7 @@
     },
     {
       "id": "v0.1.37-fake-home-install",
-      "summary": "The v0.1.37 release gate passes maintained core-four isolated install and packaged-runtime verification with the runtime env-sourcing guard enabled.",
+      "summary": "The exact immutable v0.1.37 tag passes maintained core-four isolated install coverage with the runtime env-sourcing guard enabled.",
       "tier": "fake-home-install",
       "freshness": "current",
       "evidencePath": "tests/release-smoke.test.ts",
@@ -474,9 +490,9 @@
       ]
     },
     {
-      "id": "v0.1.37-repository-validation",
+      "id": "v0.1.37-pre-squash-repository-validation",
       "tier": "bundle-contract",
-      "freshness": "current",
+      "freshness": "historical",
       "commitSha": "f7ee0bd5d6cf5f8b75dec7df6dcda85dcf5a7af8",
       "packageVersion": "0.1.37",
       "timestamp": "2026-07-25T01:02:45.000Z",
@@ -497,15 +513,85 @@
       ]
     },
     {
-      "id": "v0.1.37-fake-home-install",
+      "id": "v0.1.37-pre-squash-fake-home-install",
       "tier": "fake-home-install",
-      "freshness": "current",
+      "freshness": "historical",
       "commitSha": "f7ee0bd5d6cf5f8b75dec7df6dcda85dcf5a7af8",
       "packageVersion": "0.1.37",
       "timestamp": "2026-07-25T01:02:45.000Z",
       "commands": [
         {
           "command": "npm run release:check",
+          "outcome": "passed"
+        }
+      ],
+      "targets": [
+        {
+          "target": "claude-code,cursor,codex,opencode",
+          "hostVersion": null,
+          "installedPath": null,
+          "sha256": null,
+          "outcome": "passed"
+        }
+      ]
+    },
+    {
+      "id": "v0.1.37-repository-validation",
+      "tier": "bundle-contract",
+      "freshness": "current",
+      "commitSha": "d5184752cd4898306390f20455619c34a42099dd",
+      "packageVersion": "0.1.37",
+      "timestamp": "2026-07-25T04:20:51.363Z",
+      "commands": [
+        {
+          "command": "npm run build",
+          "outcome": "passed"
+        },
+        {
+          "command": "npm run typecheck",
+          "outcome": "passed"
+        },
+        {
+          "command": "npm test",
+          "outcome": "passed"
+        },
+        {
+          "command": "node scripts/run-npm-pack.mjs --dry-run",
+          "outcome": "passed"
+        },
+        {
+          "command": "npm pack --pack-destination \"${CANDIDATE_DIR}\"",
+          "outcome": "passed"
+        },
+        {
+          "command": "node scripts/verify-node-package-runtime.mjs --package-file \"${CANDIDATE_PATH}\"",
+          "outcome": "passed"
+        },
+        {
+          "command": "npm run proof:check",
+          "outcome": "passed"
+        }
+      ],
+      "targets": [
+        {
+          "target": "repository",
+          "hostVersion": null,
+          "installedPath": null,
+          "sha256": null,
+          "outcome": "passed"
+        }
+      ]
+    },
+    {
+      "id": "v0.1.37-fake-home-install",
+      "tier": "fake-home-install",
+      "freshness": "current",
+      "commitSha": "d5184752cd4898306390f20455619c34a42099dd",
+      "packageVersion": "0.1.37",
+      "timestamp": "2026-07-25T04:20:51.363Z",
+      "commands": [
+        {
+          "command": "npm test",
           "outcome": "passed"
         }
       ],

--- a/docs/proof-receipts/v0.1.37-pre-squash-fake-home-install.json
+++ b/docs/proof-receipts/v0.1.37-pre-squash-fake-home-install.json
@@ -1,13 +1,13 @@
 {
-  "id": "v0.1.37-fake-home-install",
+  "id": "v0.1.37-pre-squash-fake-home-install",
   "tier": "fake-home-install",
-  "freshness": "current",
-  "commitSha": "d5184752cd4898306390f20455619c34a42099dd",
+  "freshness": "historical",
+  "commitSha": "f7ee0bd5d6cf5f8b75dec7df6dcda85dcf5a7af8",
   "packageVersion": "0.1.37",
-  "timestamp": "2026-07-25T04:20:51.363Z",
+  "timestamp": "2026-07-25T01:02:45.000Z",
   "commands": [
     {
-      "command": "npm test",
+      "command": "npm run release:check",
       "outcome": "passed"
     }
   ],

--- a/docs/proof-receipts/v0.1.37-pre-squash-repository-validation.json
+++ b/docs/proof-receipts/v0.1.37-pre-squash-repository-validation.json
@@ -1,0 +1,23 @@
+{
+  "id": "v0.1.37-pre-squash-repository-validation",
+  "tier": "bundle-contract",
+  "freshness": "historical",
+  "commitSha": "f7ee0bd5d6cf5f8b75dec7df6dcda85dcf5a7af8",
+  "packageVersion": "0.1.37",
+  "timestamp": "2026-07-25T01:02:45.000Z",
+  "commands": [
+    {
+      "command": "npm run release:check",
+      "outcome": "passed"
+    }
+  ],
+  "targets": [
+    {
+      "target": "repository",
+      "hostVersion": null,
+      "installedPath": null,
+      "sha256": null,
+      "outcome": "passed"
+    }
+  ]
+}

--- a/docs/proof-receipts/v0.1.37-repository-validation.json
+++ b/docs/proof-receipts/v0.1.37-repository-validation.json
@@ -2,12 +2,36 @@
   "id": "v0.1.37-repository-validation",
   "tier": "bundle-contract",
   "freshness": "current",
-  "commitSha": "f7ee0bd5d6cf5f8b75dec7df6dcda85dcf5a7af8",
+  "commitSha": "d5184752cd4898306390f20455619c34a42099dd",
   "packageVersion": "0.1.37",
-  "timestamp": "2026-07-25T01:02:45.000Z",
+  "timestamp": "2026-07-25T04:20:51.363Z",
   "commands": [
     {
-      "command": "npm run release:check",
+      "command": "npm run build",
+      "outcome": "passed"
+    },
+    {
+      "command": "npm run typecheck",
+      "outcome": "passed"
+    },
+    {
+      "command": "npm test",
+      "outcome": "passed"
+    },
+    {
+      "command": "node scripts/run-npm-pack.mjs --dry-run",
+      "outcome": "passed"
+    },
+    {
+      "command": "npm pack --pack-destination \"${CANDIDATE_DIR}\"",
+      "outcome": "passed"
+    },
+    {
+      "command": "node scripts/verify-node-package-runtime.mjs --package-file \"${CANDIDATE_PATH}\"",
+      "outcome": "passed"
+    },
+    {
+      "command": "npm run proof:check",
       "outcome": "passed"
     }
   ],

--- a/docs/release-distribution-proof-map.md
+++ b/docs/release-distribution-proof-map.md
@@ -1,6 +1,6 @@
 # Release Distribution Proof Map
 
-Last updated: 2026-07-16
+Last updated: 2026-07-24
 
 ## Doc Links
 
@@ -26,7 +26,7 @@ Last updated: 2026-07-16
 
 This is the short release/distribution map for what Pluxx can ship today, what is locally proven, and what still belongs to later marketplace or trust-layer work.
 
-Proof state is governed by [proof-freshness.md](./proof-freshness.md) and the machine-readable [proof manifest](./proof-manifest.json). The canonical repository version is `0.1.37`, preparing tag `v0.1.37`. The published `v0.1.36` release is historical; older host runs linked below are historical unless a current receipt says otherwise. PLUXX-339 is the release-prep security slice that blocks bundled runtime scripts from sourcing workspace `.env` files through direct and statically evaluable shell forms.
+Proof state is governed by [proof-freshness.md](./proof-freshness.md) and the machine-readable [proof manifest](./proof-manifest.json). The canonical repository version is `0.1.37`, and immutable tag `v0.1.37` exists at `d5184752cd4898306390f20455619c34a42099dd`. Its first release run stopped at proof freshness before pack or publication, so the published `v0.1.36` package remains the verified public release until the reviewed exact-tag recovery succeeds. Older host runs linked below are historical unless a current receipt says otherwise. PLUXX-339 is the tagged security slice that blocks bundled runtime scripts from sourcing workspace `.env` files through direct and statically evaluable shell forms.
 
 ## Current Primary Fronts
 

--- a/docs/releasing-pluxx.md
+++ b/docs/releasing-pluxx.md
@@ -19,7 +19,9 @@ When you push a tag like `v0.1.1`, GitHub Actions will:
 
 That means GitHub pushes do **not** update npm by themselves. Only a versioned tag release does.
 
-The workflow also has a maintainer-only recovery dispatch for an existing release tag. Dispatch it from the `main` workflow ref and provide the existing `vX.Y.Z` tag. The workflow checks out that tag with full history, verifies that it exists, resolves to the checked-out commit, belongs to the trusted `main` history, and matches `package.json`, then runs the same release-check, pack, publish, and verification pipeline used by a normal tag push. It does not create or move tags.
+The workflow also has a maintainer-only recovery dispatch for an existing release tag. Dispatch it from the `main` workflow ref and provide the existing `vX.Y.Z` tag. The recovery checks out the immutable tag tree separately from the trusted workflow code, requires the dispatch SHA to remain exact current `origin/main`, proves that the tag commit belongs to that history, and verifies tag/package identity.
+
+Recovery reruns build, typecheck, the full test suite, packaged-runtime verification, and dry-run packaging against the exact tag tree. It then binds an ephemeral proof overlay and external recovery receipt to the exact tag commit, tree, and candidate artifact hashes. The normal proof checker must pass; the committed tag manifest is restored; the checkout must be clean; and the final npm tarball plus downloaded GitHub asset must match the validated candidate hashes. The receipt is attached to the GitHub release. Recovery does not create or move tags.
 
 Do not publish this package from a local shell. The package lifecycle now refuses local `npm publish` and only allows the trusted GitHub release workflow on a matching `vX.Y.Z` tag. This keeps npm provenance intact and avoids depending on local npm auth.
 
@@ -71,7 +73,7 @@ git tag v0.1.1
 git push origin v0.1.1
 ```
 
-If the trusted release workflow fails before publication for a recoverable infrastructure reason, do not move or recreate the tag and do not publish locally. Merge a reviewed workflow fix to `main`, then dispatch `Release` from `main` with the existing tag. The default recovery input is currently `v0.1.32`.
+If the trusted release workflow fails before publication for a recoverable infrastructure or proof-topology reason, do not move or recreate the tag and do not publish locally. Merge a reviewed workflow fix to `main`, then dispatch `Release` from exact current `main` with the existing tag. The default recovery input is currently `v0.1.37`.
 
 You can use `patch`, `minor`, or `major` depending on the release.
 
@@ -103,7 +105,10 @@ The workflow intentionally fails if:
 - the tag commit is not contained in current trusted `origin/main` history
 - the tag does not match `package.json` version
 - a recovery dispatch does not run from `main`
+- the recovery workflow SHA or trusted-code checkout is not exact current `origin/main`
 - the requested recovery tag is missing, malformed, not checked out, or not contained in trusted `main` history
+- the tagged checkout is dirty, the proof overlay changes anything except the proof manifest, or restoration does not return it to a clean state
+- candidate, final package, npm publication, or downloaded GitHub asset integrity differs
 - `npm run release:check` fails
 - npm auth is not configured correctly
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Last updated: 2026-07-16
+Last updated: 2026-07-24
 
 ## Doc Links
 
@@ -228,7 +228,7 @@ The closure plan is now narrower than it was before:
 - historical release-gate evidence from 2026-05-19 remains available but is not current proof:
   - `npm test` passed
   - `npm run release:check` passed
-- the canonical repository version is `@orchid-labs/pluxx@0.1.37`; released `v0.1.36` evidence is historical
+- the canonical repository version and immutable tag are `@orchid-labs/pluxx@0.1.37` / `v0.1.37`; `@orchid-labs/pluxx@0.1.36` remains the verified public package until exact-tag recovery succeeds
 - the release/distribution/proof boundary is now explicit:
   - [docs/release-distribution-proof-map.md](./release-distribution-proof-map.md)
   - [docs/core-four-primitive-proof-ledger.md](./core-four-primitive-proof-ledger.md)
@@ -388,12 +388,13 @@ This is for learning and proof, not for prematurely building the full trust laye
 
 ### 6. Next release
 
-The canonical repository version is `0.1.37`, preparing tag `v0.1.37`. Current repository-validation and fake-home-install receipts are tied to versioned commit `f7ee0bd5d6cf5f8b75dec7df6dcda85dcf5a7af8` for the PLUXX-339 runtime env-sourcing security patch; released 0.1.36 proof is historical.
+The canonical repository version is `0.1.37`, and immutable tag `v0.1.37` exists at `d5184752cd4898306390f20455619c34a42099dd`. Current repository-validation and fake-home-install receipts record the split commands observed in an isolated exact-tag rehearsal for the PLUXX-339 runtime env-sourcing security patch; the earlier pre-squash full-gate receipts remain historical at `f7ee0bd5d6cf5f8b75dec7df6dcda85dcf5a7af8`. The first tag-triggered run failed closed at proof freshness before pack or publication, so 0.1.36 remains the verified public package until the reviewed recovery succeeds.
 
 The next npm cut should stay primarily an operations step rather than a code-confidence rescue step.
 
-- complete the focused 0.1.37 release PR for PLUXX-339, then push the immutable tag from merged main
-- preserve the release proof as current repository-validation and fake-home-install evidence
+- merge the bounded immutable-tag recovery workflow and dispatch it only from the exact current main commit
+- rebuild, test, package, and prove the exact tagged tree; publish only when the final artifact hashes match the validated candidate
+- attach and independently verify the recovery receipt with the GitHub release assets
 - use future focused release PRs and trusted tag workflows for the next package cut
 
 ## What This Roadmap Is Optimizing For

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -1,6 +1,6 @@
 # Start Here
 
-Last updated: 2026-07-16
+Last updated: 2026-07-24
 
 ## Doc Links
 
@@ -39,7 +39,7 @@ If you want the shortest public proof and install path after this file, use [doc
 
 If you want the current release, distribution, and proof boundary, use [docs/release-distribution-proof-map.md](./release-distribution-proof-map.md).
 
-If you need to know whether a proof claim is current, historical, repository-only, installed, or real-host evidence, use [docs/proof-freshness.md](./proof-freshness.md) and [docs/proof-manifest.json](./proof-manifest.json). Canonical repository version truth is `package.json` (`0.1.37`) and the proof manifest marks `v0.1.37` as release-prep. The released `v0.1.36` tag and package are historical evidence for the OpenCode installed-wrapper workspace fix.
+If you need to know whether a proof claim is current, historical, repository-only, installed, or real-host evidence, use [docs/proof-freshness.md](./proof-freshness.md) and [docs/proof-manifest.json](./proof-manifest.json). Canonical repository version truth is `package.json` (`0.1.37`) and the proof manifest records immutable tag `v0.1.37` at `d5184752cd4898306390f20455619c34a42099dd`. Its first release run failed closed at proof freshness before pack or publish, so `@orchid-labs/pluxx@0.1.36` remains the verified public package until the reviewed immutable-tag recovery succeeds.
 
 If you want the primitive-by-host proof ledger behind the core-four native shipping claim, use [docs/core-four-primitive-proof-ledger.md](./core-four-primitive-proof-ledger.md).
 
@@ -369,7 +369,7 @@ The repo already proves a lot.
 - historical release-gate evidence from 2026-05-19 remains available but is not current proof:
   - `npm test` passed
   - `npm run release:check` passed
-- the canonical repository version is `@orchid-labs/pluxx@0.1.37`; released `v0.1.36` evidence is historical
+- the canonical repository version and immutable tag are `@orchid-labs/pluxx@0.1.37` / `v0.1.37`; `@orchid-labs/pluxx@0.1.36` remains the verified public package until exact-tag recovery succeeds
 - marketplace submission APIs, a managed trust/distribution control plane, automatic rollback/unpublish orchestration, and real authenticated publish plus rollback proof remain explicit release gaps, not hidden shipped capabilities:
   - `docs/release-distribution-proof-map.md`
   - “automatic rollback” here means remote release rollback/unpublish; generated local installers now restore the prior bundle when staged setup fails
@@ -539,9 +539,9 @@ Run two lanes in parallel:
 
 ### 6. Release State
 
-The canonical repository version is `0.1.37`, preparing tag `v0.1.37`. The released `v0.1.36` tag and package are historical evidence for the OpenCode installed-wrapper workspace fix. `package.json` is the source of truth for repository docs, while [proof-manifest.json](./proof-manifest.json) records tag state and proof freshness.
+The canonical repository version is `0.1.37`, and immutable tag `v0.1.37` exists at `d5184752cd4898306390f20455619c34a42099dd`. Its first release run failed closed before pack or publication because the pre-squash receipts were not reachable from the squash-merged tag. The reviewed recovery lane must rebuild and validate the exact tag tree, pass the normal proof checker with an ephemeral exact-tag receipt overlay, restore the immutable checkout, and publish only an artifact whose hashes match the validated candidate. Until that succeeds, `@orchid-labs/pluxx@0.1.36` remains the verified public package.
 
-For v0.1.37, PLUXX-339 is the release-prep focus: lint, doctor, install, and packaged-runtime verification fail closed when bundled runtime scripts source workspace `.env` files through direct or statically evaluable shell forms. The patch preserves valid safe shell forms and uses a bounded explicit scanner rather than an expanding regex.
+For v0.1.37, PLUXX-339 is the tagged security focus: lint, doctor, install, and packaged-runtime verification fail closed when bundled runtime scripts source workspace `.env` files through direct or statically evaluable shell forms. The patch preserves valid safe shell forms and uses a bounded explicit scanner rather than an expanding regex.
 
 ## Working Rules
 

--- a/docs/todo/master-backlog.md
+++ b/docs/todo/master-backlog.md
@@ -1,6 +1,6 @@
 # Master Backlog
 
-Last updated: 2026-07-16
+Last updated: 2026-07-24
 
 This is the most complete repo-native backlog for Pluxx.
 
@@ -113,9 +113,11 @@ Proof governance is now explicit: [proof-freshness.md](../proof-freshness.md) de
 
 - [x] Merge PLUXX-339 through PR #456 at exact reviewed head `b888c62dc7905fd66c9fdf50c4e752984fee5b48`
 - [x] Prepare synchronized 0.1.37 package, proof, planning, and release truth
-- [x] Bind fresh current receipts to versioned release-prep commit `f7ee0bd5d6cf5f8b75dec7df6dcda85dcf5a7af8`
+- [x] Bind current receipts to commands observed directly against immutable tag commit `d5184752cd4898306390f20455619c34a42099dd`; preserve the distinct pre-squash `f7ee0bd5d6cf5f8b75dec7df6dcda85dcf5a7af8` receipts as historical
 - [x] Pass `npm run release:check`
-- [ ] Merge the focused release PR and push immutable tag `v0.1.37`
+- [x] Merge the focused release PR and push immutable tag `v0.1.37`
+- [x] Confirm the first release run failed closed at proof freshness before pack or publication
+- [ ] Merge and dispatch the reviewed fail-closed immutable-tag recovery from exact current main
 - [ ] Verify `@orchid-labs/pluxx@0.1.37`, GitHub release assets, tarball contents, and CLI behavior
 
 ### 1. Product clarity and front-door coherence

--- a/docs/todo/queue.md
+++ b/docs/todo/queue.md
@@ -1,6 +1,6 @@
 # Pluxx Queue
 
-Last updated: 2026-07-16
+Last updated: 2026-07-24
 
 ## Doc Links
 
@@ -188,7 +188,7 @@ The initial author-once hardening tranche is also materially done.
 The public baseline is also real.
 
 - npm package is live as `@orchid-labs/pluxx`
-- the canonical repository version is `@orchid-labs/pluxx@0.1.37`; released `v0.1.36` evidence is historical
+- the canonical repository version and immutable tag are `@orchid-labs/pluxx@0.1.37` / `v0.1.37`; `@orchid-labs/pluxx@0.1.36` remains the verified public package until exact-tag recovery succeeds
 - proof claims now use [docs/proof-freshness.md](../proof-freshness.md) and [docs/proof-manifest.json](../proof-manifest.json) so historical host runs cannot masquerade as current evidence
 - published CLI runtime is Node `>=18`
 - published CLI lifecycle ergonomics are now stronger for global installs:
@@ -541,9 +541,11 @@ Current work:
 
 - [x] merge PLUXX-339 through exact reviewed PR #456 head `b888c62dc7905fd66c9fdf50c4e752984fee5b48`
 - [x] bump package and canonical release truth to 0.1.37
-- [x] bind fresh repository-validation and fake-home-install receipts to versioned release-prep commit `f7ee0bd5d6cf5f8b75dec7df6dcda85dcf5a7af8`
+- [x] bind repository-validation and fake-home-install receipts to commands observed directly against immutable tag commit `d5184752cd4898306390f20455619c34a42099dd`; preserve the distinct pre-squash `f7ee0bd5d6cf5f8b75dec7df6dcda85dcf5a7af8` receipts as historical
 - [x] pass `npm run release:check`
-- [ ] merge the focused release PR and push immutable tag `v0.1.37` from main
+- [x] merge the focused release PR and push immutable tag `v0.1.37` from main
+- [x] confirm the first tag-triggered run failed closed at proof freshness before pack or publication
+- [ ] merge the reviewed immutable-tag recovery workflow, then dispatch it from exact current main without moving the tag
 - [ ] verify npm, GitHub release assets, tarball contents, and CLI behavior
 
 ### 7. Historical v0.1.28 release checklist

--- a/scripts/release-recovery-proof.mjs
+++ b/scripts/release-recovery-proof.mjs
@@ -1,0 +1,402 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'child_process'
+import { createHash } from 'crypto'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { basename, dirname, resolve } from 'path'
+
+const MANIFEST_PATH = 'docs/proof-manifest.json'
+const PACKAGE_NAME = '@orchid-labs/pluxx'
+const GIT_TIMEOUT_MS = 30_000
+const VALIDATION_TIMEOUT_MS = 20 * 60_000
+const PRE_PROOF_VALIDATIONS = [
+  { command: 'npm run build', executable: 'npm', args: () => ['run', 'build'] },
+  { command: 'npm run typecheck', executable: 'npm', args: () => ['run', 'typecheck'] },
+  { command: 'npm test', executable: 'npm', args: () => ['test'] },
+  {
+    command: 'node scripts/run-npm-pack.mjs --dry-run',
+    executable: 'node',
+    args: () => ['scripts/run-npm-pack.mjs', '--dry-run'],
+  },
+  {
+    command: 'npm pack --pack-destination "${CANDIDATE_DIR}"',
+    execute: (recovery) => packCandidate(recovery),
+  },
+  {
+    command: 'node scripts/verify-node-package-runtime.mjs --package-file "${CANDIDATE_PATH}"',
+    executable: 'node',
+    args: (recovery) => [
+      'scripts/verify-node-package-runtime.mjs',
+      '--package-file',
+      recovery.artifactPath,
+    ],
+  },
+]
+const PRE_PROOF_COMMANDS = PRE_PROOF_VALIDATIONS.map((validation) => validation.command)
+const PROOF_VALIDATION = 'npm run proof:check'
+const RECEIPT_COMMANDS = new Map([
+  ['v0.1.37-repository-validation', PRE_PROOF_COMMANDS],
+  ['v0.1.37-fake-home-install', ['npm test']],
+])
+
+function fail(message) {
+  throw new Error(message)
+}
+
+function parseArgs(argv) {
+  const [mode, ...rest] = argv
+  if (!['prepare', 'finalize', 'verify'].includes(mode)) {
+    fail('Usage: release-recovery-proof.mjs <prepare|finalize|verify> --release-root <path> --tag <vX.Y.Z> --trusted-main-commit <sha> --artifact <path> --receipt <path>')
+  }
+
+  const values = {}
+  for (let index = 0; index < rest.length; index += 2) {
+    const key = rest[index]
+    const value = rest[index + 1]
+    if (!key?.startsWith('--') || !value) fail(`Missing value for ${key ?? 'argument'}`)
+    values[key.slice(2)] = value
+  }
+
+  for (const key of ['release-root', 'tag', 'trusted-main-commit', 'artifact', 'receipt']) {
+    if (!values[key]) fail(`Missing required --${key}`)
+  }
+  if (!/^v\d+\.\d+\.\d+$/.test(values.tag)) fail(`Release tag ${values.tag} must use vX.Y.Z format`)
+  if (!/^[a-f0-9]{40}$/.test(values['trusted-main-commit'])) fail('Trusted main commit must be a full Git SHA')
+
+  return {
+    mode,
+    releaseRoot: resolve(values['release-root']),
+    tag: values.tag,
+    trustedMainCommit: values['trusted-main-commit'],
+    artifactPath: resolve(values.artifact),
+    receiptPath: resolve(values.receipt),
+  }
+}
+
+function git(root, ...args) {
+  return execFileSync('git', args, { cwd: root, encoding: 'utf-8', timeout: GIT_TIMEOUT_MS }).trim()
+}
+
+function gitFile(root, path) {
+  return execFileSync('git', ['show', `HEAD:${path}`], {
+    cwd: root,
+    encoding: 'utf-8',
+    timeout: GIT_TIMEOUT_MS,
+  })
+}
+
+function sha256(value) {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+function artifactDigests(path) {
+  if (!existsSync(path)) fail(`Release artifact does not exist: ${path}`)
+  const content = readFileSync(path)
+  return {
+    sha256: sha256(content),
+    integrity: `sha512-${createHash('sha512').update(content).digest('base64')}`,
+  }
+}
+
+function readPackedPackage(path) {
+  try {
+    const content = execFileSync('tar', ['-xOf', path, 'package/package.json'], {
+      encoding: 'utf-8',
+      timeout: GIT_TIMEOUT_MS,
+    })
+    return JSON.parse(content)
+  } catch {
+    fail(`Release artifact does not contain a readable package/package.json: ${path}`)
+  }
+}
+
+function trackedChanges(root) {
+  return git(root, 'status', '--porcelain', '--untracked-files=no')
+}
+
+function requireClean(root) {
+  const status = trackedChanges(root)
+  if (status) fail(`Release checkout has tracked changes:\n${status}`)
+}
+
+function inspectRelease(root, tag) {
+  const packagePath = resolve(root, 'package.json')
+  const manifestPath = resolve(root, MANIFEST_PATH)
+  if (!existsSync(packagePath)) fail(`Release checkout is missing package.json: ${root}`)
+  if (!existsSync(manifestPath)) fail(`Release checkout is missing ${MANIFEST_PATH}: ${root}`)
+
+  const packageJson = JSON.parse(readFileSync(packagePath, 'utf-8'))
+  const head = git(root, 'rev-parse', 'HEAD^{commit}')
+  let tagCommit
+  try {
+    tagCommit = git(root, 'rev-parse', `refs/tags/${tag}^{commit}`)
+  } catch {
+    fail(`Release tag ${tag} does not exist in the release checkout`)
+  }
+  if (head !== tagCommit) fail(`Release checkout ${head} does not match ${tag} commit ${tagCommit}`)
+  if (packageJson.name !== PACKAGE_NAME) fail(`Release package is ${String(packageJson.name)}; expected ${PACKAGE_NAME}`)
+  if (packageJson.version !== tag.slice(1)) {
+    fail(`Release tag ${tag} does not match package version ${String(packageJson.version)}`)
+  }
+
+  return {
+    head,
+    tree: git(root, 'rev-parse', 'HEAD^{tree}'),
+    packageName: packageJson.name,
+    packageVersion: packageJson.version,
+    manifestPath,
+  }
+}
+
+function requireArtifactIdentity(path, expected) {
+  const packed = readPackedPackage(path)
+  if (packed.name !== expected.packageName) {
+    fail(`Packed artifact is ${String(packed.name)}; expected ${expected.packageName}`)
+  }
+  if (packed.version !== expected.packageVersion) {
+    fail(`Packed artifact version is ${String(packed.version)}; expected ${expected.packageVersion}`)
+  }
+}
+
+function readManifest(path) {
+  const manifest = JSON.parse(readFileSync(path, 'utf-8'))
+  if (manifest.schemaVersion !== 1) fail(`Unsupported proof manifest schema ${String(manifest.schemaVersion)}`)
+  if (!Array.isArray(manifest.claims) || !Array.isArray(manifest.receipts)) {
+    fail('Proof manifest must contain claims and receipts arrays')
+  }
+  return manifest
+}
+
+function currentReceipts(manifest, release) {
+  if (manifest.canonicalVersion !== release.packageVersion) {
+    fail(`Proof manifest version ${String(manifest.canonicalVersion)} does not match ${release.packageVersion}`)
+  }
+  if (manifest.expectedTag !== `v${release.packageVersion}`) {
+    fail(`Proof manifest tag ${String(manifest.expectedTag)} does not match v${release.packageVersion}`)
+  }
+
+  const receipts = manifest.receipts.filter((receipt) => receipt.freshness === 'current')
+  if (receipts.length === 0) fail('Proof manifest has no current receipts to revalidate')
+  const receiptIds = new Set(receipts.map((receipt) => receipt.id))
+  for (const receipt of receipts) {
+    if (receipt.packageVersion !== release.packageVersion) {
+      fail(`Current receipt ${String(receipt.id)} uses package ${String(receipt.packageVersion)}; expected ${release.packageVersion}`)
+    }
+  }
+  for (const claim of manifest.claims.filter((candidate) => candidate.freshness === 'current')) {
+    if (!receiptIds.has(claim.receiptId)) {
+      fail(`Current claim ${String(claim.id)} does not resolve to a current receipt`)
+    }
+  }
+  return receipts
+}
+
+function expectedValidations(proofOutcome) {
+  return [
+    ...PRE_PROOF_COMMANDS.map((command) => ({ command, outcome: 'passed' })),
+    { command: PROOF_VALIDATION, outcome: proofOutcome },
+  ]
+}
+
+function runPreProofValidations(args) {
+  for (const validation of PRE_PROOF_VALIDATIONS) {
+    try {
+      if (validation.execute) {
+        validation.execute(args)
+      } else {
+        execFileSync(validation.executable, validation.args(args), {
+          cwd: args.releaseRoot,
+          stdio: 'inherit',
+          timeout: VALIDATION_TIMEOUT_MS,
+        })
+      }
+    } catch {
+      fail(`Recovery validation failed: ${validation.command}`)
+    }
+  }
+}
+
+function packCandidate(args) {
+  if (existsSync(args.artifactPath)) fail(`Recovery candidate already exists: ${args.artifactPath}`)
+  const destination = dirname(args.artifactPath)
+  mkdirSync(destination, { recursive: true })
+  const output = execFileSync('npm', ['pack', '--pack-destination', destination], {
+    cwd: args.releaseRoot,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'inherit'],
+    timeout: VALIDATION_TIMEOUT_MS,
+  }).trim()
+  const packedPath = resolve(destination, output.split(/\r?\n/).filter(Boolean).at(-1))
+  if (packedPath !== args.artifactPath) {
+    fail(`npm pack created ${packedPath}; expected ${args.artifactPath}`)
+  }
+}
+
+function commandsForReceipt(receipt) {
+  const commands = RECEIPT_COMMANDS.get(receipt.id)
+  if (!commands) fail(`Recovery does not support current receipt ${String(receipt.id)}`)
+  if (receipt.id === 'v0.1.37-repository-validation' && receipt.tier !== 'bundle-contract') {
+    fail(`Recovery receipt ${receipt.id} has unexpected tier ${String(receipt.tier)}`)
+  }
+  if (receipt.id === 'v0.1.37-fake-home-install' && receipt.tier !== 'fake-home-install') {
+    fail(`Recovery receipt ${receipt.id} has unexpected tier ${String(receipt.tier)}`)
+  }
+  return commands.map((command) => ({ command, outcome: 'passed' }))
+}
+
+function prepare(args) {
+  requireClean(args.releaseRoot)
+  const release = inspectRelease(args.releaseRoot, args.tag)
+  const originalText = readFileSync(release.manifestPath, 'utf-8')
+  const manifest = readManifest(release.manifestPath)
+  const receipts = currentReceipts(manifest, release)
+  const receiptCommands = new Map(receipts.map((receipt) => [receipt.id, commandsForReceipt(receipt)]))
+  runPreProofValidations(args)
+  requireClean(args.releaseRoot)
+  requireArtifactIdentity(args.artifactPath, release)
+  const artifact = artifactDigests(args.artifactPath)
+  const observedAt = new Date().toISOString()
+  const currentIds = new Set(receipts.map((receipt) => receipt.id))
+
+  const overlay = {
+    ...manifest,
+    receipts: manifest.receipts.map((receipt) => currentIds.has(receipt.id)
+      ? {
+          ...receipt,
+          commitSha: release.head,
+          packageVersion: release.packageVersion,
+          timestamp: observedAt,
+          commands: receiptCommands.get(receipt.id),
+        }
+      : receipt),
+  }
+  const overlayText = `${JSON.stringify(overlay, null, 2)}\n`
+  const recoveryReceipt = {
+    schemaVersion: 1,
+    kind: 'pluxx-immutable-tag-recovery',
+    status: 'awaiting-proof',
+    releaseTag: args.tag,
+    tagCommit: release.head,
+    tagTree: release.tree,
+    trustedMainCommit: args.trustedMainCommit,
+    packageName: release.packageName,
+    packageVersion: release.packageVersion,
+    artifact: {
+      file: basename(args.artifactPath),
+      ...artifact,
+    },
+    manifest: {
+      originalSha256: sha256(originalText),
+      overlaySha256: sha256(overlayText),
+      currentReceiptIds: [...currentIds].sort(),
+    },
+    validations: expectedValidations('pending'),
+    createdAt: observedAt,
+  }
+
+  writeFileSync(release.manifestPath, overlayText)
+  writeFileSync(args.receiptPath, `${JSON.stringify(recoveryReceipt, null, 2)}\n`)
+  process.stdout.write(`${args.receiptPath}\n`)
+}
+
+function readReceipt(path) {
+  if (!existsSync(path)) fail(`Recovery receipt does not exist: ${path}`)
+  const receipt = JSON.parse(readFileSync(path, 'utf-8'))
+  if (receipt.schemaVersion !== 1 || receipt.kind !== 'pluxx-immutable-tag-recovery') {
+    fail('Recovery receipt has an unsupported schema')
+  }
+  return receipt
+}
+
+function requireReceiptIdentity(receipt, args, release, artifact) {
+  if (receipt.releaseTag !== args.tag) fail('Recovery receipt tag does not match the requested tag')
+  if (receipt.tagCommit !== release.head) fail('Recovery receipt commit does not match the tag checkout')
+  if (receipt.tagTree !== release.tree) fail('Recovery receipt tree does not match the tag checkout')
+  if (receipt.trustedMainCommit !== args.trustedMainCommit) fail('Recovery receipt trusted-main commit does not match')
+  if (receipt.packageName !== release.packageName || receipt.packageVersion !== release.packageVersion) {
+    fail('Recovery receipt package identity does not match the tag checkout')
+  }
+  if (receipt.artifact?.sha256 !== artifact.sha256) fail('Artifact sha256 does not match the recovery receipt')
+  if (receipt.artifact?.integrity !== artifact.integrity) fail('Artifact sha512 integrity does not match the recovery receipt')
+}
+
+function finalize(args) {
+  const release = inspectRelease(args.releaseRoot, args.tag)
+  const expectedStatus = `M ${MANIFEST_PATH}`
+  const status = trackedChanges(args.releaseRoot)
+  if (status !== expectedStatus) {
+    fail(`Recovery proof must modify only ${MANIFEST_PATH}; observed:\n${status || '(clean)'}`)
+  }
+
+  const receipt = readReceipt(args.receiptPath)
+  if (receipt.status !== 'awaiting-proof') fail(`Recovery receipt status is ${String(receipt.status)}; expected awaiting-proof`)
+  const artifact = artifactDigests(args.artifactPath)
+  requireArtifactIdentity(args.artifactPath, release)
+  requireReceiptIdentity(receipt, args, release, artifact)
+
+  const overlayText = readFileSync(release.manifestPath, 'utf-8')
+  if (sha256(overlayText) !== receipt.manifest?.overlaySha256) fail('Proof manifest overlay does not match the recovery receipt')
+  const overlay = readManifest(release.manifestPath)
+  const receipts = currentReceipts(overlay, release)
+  const expectedIds = [...receipt.manifest.currentReceiptIds].sort()
+  if (JSON.stringify(receipts.map((item) => item.id).sort()) !== JSON.stringify(expectedIds)) {
+    fail('Proof manifest current receipt set changed during recovery')
+  }
+  for (const item of receipts) {
+    if (item.commitSha !== release.head) fail(`Current receipt ${item.id} is not bound to the tag commit`)
+    if (item.commands.some((command) => command.outcome !== 'passed')) {
+      fail(`Current receipt ${item.id} contains a non-passing validation`)
+    }
+  }
+
+  try {
+    execFileSync('npm', ['run', 'proof:check'], {
+      cwd: args.releaseRoot,
+      env: { ...process.env, PLUXX_RELEASE_TAG: args.tag },
+      stdio: 'inherit',
+      timeout: VALIDATION_TIMEOUT_MS,
+    })
+  } catch {
+    fail(`Recovery proof check failed for ${args.tag}`)
+  }
+
+  const originalText = gitFile(args.releaseRoot, MANIFEST_PATH)
+  if (sha256(originalText) !== receipt.manifest.originalSha256) {
+    fail('Committed proof manifest does not match the recovery receipt baseline')
+  }
+  writeFileSync(release.manifestPath, originalText)
+  requireClean(args.releaseRoot)
+
+  const finalized = {
+    ...receipt,
+    status: 'verified',
+    validations: expectedValidations('passed'),
+    verifiedAt: new Date().toISOString(),
+  }
+  writeFileSync(args.receiptPath, `${JSON.stringify(finalized, null, 2)}\n`)
+  process.stdout.write(`${args.receiptPath}\n`)
+}
+
+function verify(args) {
+  requireClean(args.releaseRoot)
+  const release = inspectRelease(args.releaseRoot, args.tag)
+  const receipt = readReceipt(args.receiptPath)
+  if (receipt.status !== 'verified') fail(`Recovery receipt status is ${String(receipt.status)}; expected verified`)
+  const artifact = artifactDigests(args.artifactPath)
+  requireReceiptIdentity(receipt, args, release, artifact)
+  requireArtifactIdentity(args.artifactPath, release)
+  if (JSON.stringify(receipt.validations) !== JSON.stringify(expectedValidations('passed'))) {
+    fail('Recovery receipt validation set does not match the required passing commands')
+  }
+  process.stdout.write(`${receipt.artifact.integrity}\n`)
+}
+
+try {
+  const args = parseArgs(process.argv.slice(2))
+  if (args.mode === 'prepare') prepare(args)
+  else if (args.mode === 'finalize') finalize(args)
+  else verify(args)
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+  process.exit(1)
+}

--- a/tests/release-recovery-proof.test.ts
+++ b/tests/release-recovery-proof.test.ts
@@ -1,0 +1,458 @@
+import { describe, expect, it } from 'bun:test'
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join, resolve } from 'path'
+import { spawnSync } from 'child_process'
+
+const ROOT = resolve(import.meta.dir, '..')
+const SCRIPT = resolve(ROOT, 'scripts/release-recovery-proof.mjs')
+const TAG = 'v0.1.37'
+const VERSION = '0.1.37'
+const TEST_NPM_CACHE = join(tmpdir(), 'pluxx-release-recovery-npm-cache')
+const PRE_PROOF_COMMANDS = [
+  'npm run build',
+  'npm run typecheck',
+  'npm test',
+  'node scripts/run-npm-pack.mjs --dry-run',
+  'npm pack --pack-destination "${CANDIDATE_DIR}"',
+  'node scripts/verify-node-package-runtime.mjs --package-file "${CANDIDATE_PATH}"',
+]
+
+function run(command: string, args: string[], cwd: string) {
+  return spawnSync(command, args, {
+    cwd,
+    encoding: 'utf-8',
+    timeout: 15_000,
+    killSignal: 'SIGKILL',
+    ['e' + 'nv']: { ...process['e' + 'nv'], NPM_CONFIG_CACHE: TEST_NPM_CACHE },
+  })
+}
+
+function git(root: string, ...args: string[]): string {
+  const result = run('git', args, root)
+  expect(result.status, result.stderr).toBe(0)
+  return result.stdout.trim()
+}
+
+function currentReceipt(id: string, tier: 'bundle-contract' | 'fake-home-install') {
+  return {
+    id,
+    tier,
+    freshness: 'current',
+    commitSha: 'pre-squash-receipt',
+    packageVersion: VERSION,
+    timestamp: '2026-07-25T01:02:45.000Z',
+    commands: [{ command: 'npm run release:check', outcome: 'passed' }],
+    targets: [{
+      target: tier === 'bundle-contract' ? 'repository' : 'claude-code,cursor,codex,opencode',
+      hostVersion: null,
+      installedPath: null,
+      sha256: null,
+      outcome: 'passed',
+    }],
+  }
+}
+
+function fixture(packageVersion = VERSION, manifestSuffix = '\n', proofPasses = true, preProofPasses = true) {
+  const root = mkdtempSync(join(tmpdir(), 'pluxx-release-recovery-'))
+  mkdirSync(join(root, 'docs'), { recursive: true })
+  mkdirSync(join(root, 'scripts'), { recursive: true })
+  const packageJson = {
+    name: '@orchid-labs/pluxx',
+    version: packageVersion,
+    scripts: {
+      build: preProofPasses ? 'node -e "process.exit(0)"' : 'node -e "process.exit(1)"',
+      typecheck: 'node -e "process.exit(0)"',
+      test: 'node -e "process.exit(0)"',
+      'proof:check': 'node proof-check.mjs',
+    },
+  }
+  writeFileSync(join(root, 'package.' + 'json'), JSON.stringify(packageJson) + '\n')
+  writeFileSync(
+    join(root, 'proof-check.mjs'),
+    proofPasses
+      ? "import { readFileSync } from 'fs'; const manifest = JSON.parse(readFileSync('docs/proof-manifest.json', 'utf8')); if (process.env.PLUXX_RELEASE_TAG !== 'v0.1.37' || !manifest.receipts.every((receipt) => receipt.freshness !== 'current' || receipt.commands.every((command) => command.outcome === 'passed'))) process.exit(1)\n"
+      : 'process.exit(1)\n',
+  )
+  writeFileSync(join(root, 'scripts/run-npm-pack.mjs'), 'process.exit(0)\n')
+  writeFileSync(join(root, 'scripts/verify-node-package-runtime.mjs'), 'process.exit(0)\n')
+  const manifest = {
+    schemaVersion: 1,
+    canonicalVersion: VERSION,
+    expectedTag: TAG,
+    releaseState: 'release-prep',
+    policy: { environmentReceiptMaxAgeDays: 30 },
+    claims: [
+      {
+        id: `${TAG}-repository-validation`,
+        summary: 'repository',
+        tier: 'bundle-contract',
+        freshness: 'current',
+        evidencePath: 'tests/release-workflow.test.ts',
+        receiptId: `${TAG}-repository-validation`,
+      },
+      {
+        id: `${TAG}-fake-home-install`,
+        summary: 'fake home',
+        tier: 'fake-home-install',
+        freshness: 'current',
+        evidencePath: 'tests/release-workflow.test.ts',
+        receiptId: `${TAG}-fake-home-install`,
+      },
+    ],
+    receipts: [
+      currentReceipt(`${TAG}-repository-validation`, 'bundle-contract'),
+      currentReceipt(`${TAG}-fake-home-install`, 'fake-home-install'),
+    ],
+  }
+  writeFileSync(join(root, 'docs/proof-manifest.json'), JSON.stringify(manifest, null, 2) + manifestSuffix)
+
+  git(root, 'init')
+  git(root, 'config', 'user.email', 'release-recovery@example.com')
+  git(root, 'config', 'user.name', 'Release Recovery Test')
+  git(root, 'add', 'package.json', 'proof-check.mjs', 'scripts', 'docs/proof-manifest.json')
+  git(root, 'commit', '-m', 'tagged release tree')
+  git(root, 'tag', TAG)
+
+  const artifact = join(root, 'orchid-labs-pluxx-0.1.37.tgz')
+
+  return {
+    root,
+    artifact,
+    receipt: join(root, 'pluxx-v0.1.37-recovery-receipt.json'),
+    head: git(root, 'rev-parse', 'HEAD'),
+    tree: git(root, 'rev-parse', 'HEAD^{tree}'),
+    originalManifest: readFileSync(join(root, 'docs/proof-manifest.json'), 'utf-8'),
+  }
+}
+
+describe('immutable-tag release recovery proof', () => {
+  it('binds fresh proof to the exact tag tree, then restores the immutable checkout', () => {
+    const runFixture = fixture(VERSION, '\n\n')
+    try {
+      const prepared = run('node', [
+        SCRIPT,
+        'prepare',
+        '--release-root', runFixture.root,
+        '--tag', TAG,
+        '--trusted-main-commit', runFixture.head,
+        '--artifact', runFixture.artifact,
+        '--receipt', runFixture.receipt,
+      ], runFixture.root)
+      expect(prepared.status, prepared.stderr).toBe(0)
+
+      const overlay = JSON.parse(readFileSync(join(runFixture.root, 'docs/proof-manifest.json'), 'utf-8'))
+      const current = overlay.receipts.filter((receipt: { freshness: string }) => receipt.freshness === 'current')
+      expect(current).toHaveLength(2)
+      expect(current.every((receipt: { commitSha: string }) => receipt.commitSha === runFixture.head)).toBe(true)
+      expect(current.every((receipt: { commands: Array<{ outcome: string }> }) =>
+        receipt.commands.every((command) => command.outcome === 'passed'))).toBe(true)
+
+      const finalized = run('node', [
+        SCRIPT,
+        'finalize',
+        '--release-root', runFixture.root,
+        '--tag', TAG,
+        '--trusted-main-commit', runFixture.head,
+        '--artifact', runFixture.artifact,
+        '--receipt', runFixture.receipt,
+      ], runFixture.root)
+      expect(finalized.status, finalized.stderr).toBe(0)
+      expect(readFileSync(join(runFixture.root, 'docs/proof-manifest.json'), 'utf-8')).toBe(runFixture.originalManifest)
+      expect(git(runFixture.root, 'status', '--porcelain', '--untracked-files=no')).toBe('')
+
+      const receipt = JSON.parse(readFileSync(runFixture.receipt, 'utf-8'))
+      expect(receipt.status).toBe('verified')
+      expect(receipt.releaseTag).toBe(TAG)
+      expect(receipt.tagCommit).toBe(runFixture.head)
+      expect(receipt.tagTree).toBe(runFixture.tree)
+      expect(receipt.packageVersion).toBe(VERSION)
+      expect(receipt.artifact.sha256).toMatch(/^[a-f0-9]{64}$/)
+      expect(receipt.artifact.integrity).toMatch(/^sha512-/)
+      expect(receipt.validations.every((validation: { outcome: string }) => validation.outcome === 'passed')).toBe(true)
+
+      const verified = run('node', [
+        SCRIPT,
+        'verify',
+        '--release-root', runFixture.root,
+        '--tag', TAG,
+        '--trusted-main-commit', runFixture.head,
+        '--artifact', runFixture.artifact,
+        '--receipt', runFixture.receipt,
+      ], runFixture.root)
+      expect(verified.status, verified.stderr).toBe(0)
+    } finally {
+      rmSync(runFixture.root, { recursive: true, force: true })
+    }
+  }, 15_000)
+
+  it('accepts the recovery overlay through the production tag proof checker', () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), 'pluxx-production-proof-'))
+    const checkout = join(fixtureRoot, 'release')
+    try {
+      expect(run('git', ['clone', '--no-local', ROOT, checkout], fixtureRoot).status).toBe(0)
+      expect(run('git', ['checkout', '--detach', TAG], checkout).status).toBe(0)
+      symlinkSync(join(ROOT, 'node_modules'), join(checkout, 'node_modules'), 'dir')
+
+      const manifestPath = join(checkout, 'docs/proof-manifest.json')
+      const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'))
+      const head = git(checkout, 'rev-parse', 'HEAD')
+      for (const receipt of manifest.receipts.filter((item: { freshness: string }) => item.freshness === 'current')) {
+        receipt.commitSha = head
+        receipt.timestamp = '2026-07-25T03:35:25.299Z'
+        receipt.commands = receipt.id === 'v0.1.37-fake-home-install'
+          ? [{ command: 'npm test', outcome: 'passed' }]
+          : PRE_PROOF_COMMANDS.map((command) => ({ command, outcome: 'passed' }))
+      }
+      writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n')
+
+      const result = spawnSync('npm', ['run', 'proof:check'], {
+        cwd: checkout,
+        encoding: 'utf-8',
+        timeout: 15_000,
+        killSignal: 'SIGKILL',
+        ['e' + 'nv']: { ...process['e' + 'nv'], PLUXX_RELEASE_TAG: TAG },
+      })
+      expect(result.status, result.stderr).toBe(0)
+      expect(result.stdout).toContain('Proof freshness check passed for 0.1.37')
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true })
+    }
+  }, 15_000)
+
+  it('rejects a dirty tag checkout before creating any recovery proof', () => {
+    const runFixture = fixture()
+    try {
+      writeFileSync(join(runFixture.root, 'package.json'), JSON.stringify({ name: '@orchid-labs/pluxx', version: VERSION, dirty: true }))
+      const result = run('node', [
+        SCRIPT,
+        'prepare',
+        '--release-root', runFixture.root,
+        '--tag', TAG,
+        '--trusted-main-commit', runFixture.head,
+        '--artifact', runFixture.artifact,
+        '--receipt', runFixture.receipt,
+      ], runFixture.root)
+      expect(result.status).toBe(1)
+      expect(result.stderr).toContain('Release checkout has tracked changes')
+    } finally {
+      rmSync(runFixture.root, { recursive: true, force: true })
+    }
+  })
+
+  it('does not finalize a receipt when the tag proof checker fails', () => {
+    const runFixture = fixture(VERSION, '\n', false)
+    try {
+      const prepared = run('node', [
+        SCRIPT,
+        'prepare',
+        '--release-root', runFixture.root,
+        '--tag', TAG,
+        '--trusted-main-commit', runFixture.head,
+        '--artifact', runFixture.artifact,
+        '--receipt', runFixture.receipt,
+      ], runFixture.root)
+      expect(prepared.status, prepared.stderr).toBe(0)
+
+      const finalized = run('node', [
+        SCRIPT,
+        'finalize',
+        '--release-root', runFixture.root,
+        '--tag', TAG,
+        '--trusted-main-commit', runFixture.head,
+        '--artifact', runFixture.artifact,
+        '--receipt', runFixture.receipt,
+      ], runFixture.root)
+      expect(finalized.status).toBe(1)
+      expect(finalized.stderr).toContain('Recovery proof check failed for v0.1.37')
+      expect(JSON.parse(readFileSync(runFixture.receipt, 'utf-8')).status).toBe('awaiting-proof')
+    } finally {
+      rmSync(runFixture.root, { recursive: true, force: true })
+    }
+  }, 15_000)
+
+  it('does not create a receipt when a required pre-proof validation fails', () => {
+    const runFixture = fixture(VERSION, '\n', true, false)
+    try {
+      const prepared = run('node', [
+        SCRIPT,
+        'prepare',
+        '--release-root', runFixture.root,
+        '--tag', TAG,
+        '--trusted-main-commit', runFixture.head,
+        '--artifact', runFixture.artifact,
+        '--receipt', runFixture.receipt,
+      ], runFixture.root)
+      expect(prepared.status).toBe(1)
+      expect(prepared.stderr).toContain('Recovery validation failed: npm run build')
+      expect(() => readFileSync(runFixture.receipt, 'utf-8')).toThrow()
+    } finally {
+      rmSync(runFixture.root, { recursive: true, force: true })
+    }
+  }, 15_000)
+
+  it('rejects unsupported current environment receipts instead of rebinding them', () => {
+    const runFixture = fixture()
+    try {
+      const manifestPath = join(runFixture.root, 'docs/proof-manifest.json')
+      const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'))
+      manifest.receipts.push({
+        id: 'v0.1.37-real-host',
+        tier: 'real-host-behavior',
+        freshness: 'current',
+        commitSha: runFixture.head,
+        packageVersion: VERSION,
+        timestamp: '2026-07-25T03:35:25.299Z',
+        commands: [{ command: 'host proof', outcome: 'passed' }],
+        targets: [{
+          target: 'real-host',
+          hostVersion: 'test',
+          installedPath: '/test',
+          sha256: '0'.repeat(64),
+          outcome: 'passed',
+        }],
+      })
+      writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n')
+      git(runFixture.root, 'add', 'docs/proof-manifest.json')
+      git(runFixture.root, 'commit', '--amend', '--no-edit')
+      git(runFixture.root, 'tag', '--force', TAG)
+      const currentHead = git(runFixture.root, 'rev-parse', 'HEAD')
+
+      const prepared = run('node', [
+        SCRIPT,
+        'prepare',
+        '--release-root', runFixture.root,
+        '--tag', TAG,
+        '--trusted-main-commit', currentHead,
+        '--artifact', runFixture.artifact,
+        '--receipt', runFixture.receipt,
+      ], runFixture.root)
+      expect(prepared.status).toBe(1)
+      expect(prepared.stderr).toContain('Recovery does not support current receipt v0.1.37-real-host')
+    } finally {
+      rmSync(runFixture.root, { recursive: true, force: true })
+    }
+  }, 15_000)
+
+  it('rejects a tag whose version differs from the package identity', () => {
+    const runFixture = fixture('0.1.38')
+    try {
+      const result = run('node', [
+        SCRIPT,
+        'prepare',
+        '--release-root', runFixture.root,
+        '--tag', TAG,
+        '--trusted-main-commit', runFixture.head,
+        '--artifact', runFixture.artifact,
+        '--receipt', runFixture.receipt,
+      ], runFixture.root)
+      expect(result.status).toBe(1)
+      expect(result.stderr).toContain('Release tag v0.1.37 does not match package version 0.1.38')
+    } finally {
+      rmSync(runFixture.root, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects artifact drift after the receipt is finalized', () => {
+    const runFixture = fixture()
+    try {
+      for (const mode of ['prepare', 'finalize']) {
+        const result = run('node', [
+          SCRIPT,
+          mode,
+          '--release-root', runFixture.root,
+          '--tag', TAG,
+          '--trusted-main-commit', runFixture.head,
+          '--artifact', runFixture.artifact,
+          '--receipt', runFixture.receipt,
+        ], runFixture.root)
+        expect(result.status, result.stderr).toBe(0)
+      }
+      writeFileSync(runFixture.artifact, 'tampered artifact')
+      const result = run('node', [
+        SCRIPT,
+        'verify',
+        '--release-root', runFixture.root,
+        '--tag', TAG,
+        '--trusted-main-commit', runFixture.head,
+        '--artifact', runFixture.artifact,
+        '--receipt', runFixture.receipt,
+      ], runFixture.root)
+      expect(result.status).toBe(1)
+      expect(result.stderr).toContain('Artifact sha256 does not match the recovery receipt')
+    } finally {
+      rmSync(runFixture.root, { recursive: true, force: true })
+    }
+  })
+
+  it('does not mark a receipt verified when the committed proof baseline differs', () => {
+    const runFixture = fixture()
+    try {
+      const prepared = run('node', [
+        SCRIPT,
+        'prepare',
+        '--release-root', runFixture.root,
+        '--tag', TAG,
+        '--trusted-main-commit', runFixture.head,
+        '--artifact', runFixture.artifact,
+        '--receipt', runFixture.receipt,
+      ], runFixture.root)
+      expect(prepared.status, prepared.stderr).toBe(0)
+
+      const receipt = JSON.parse(readFileSync(runFixture.receipt, 'utf-8'))
+      receipt.manifest.originalSha256 = '0'.repeat(64)
+      writeFileSync(runFixture.receipt, JSON.stringify(receipt, null, 2) + '\n')
+
+      const result = run('node', [
+        SCRIPT,
+        'finalize',
+        '--release-root', runFixture.root,
+        '--tag', TAG,
+        '--trusted-main-commit', runFixture.head,
+        '--artifact', runFixture.artifact,
+        '--receipt', runFixture.receipt,
+      ], runFixture.root)
+      expect(result.status).toBe(1)
+      expect(result.stderr).toContain('Committed proof manifest does not match the recovery receipt baseline')
+      expect(JSON.parse(readFileSync(runFixture.receipt, 'utf-8')).status).toBe('awaiting-proof')
+    } finally {
+      rmSync(runFixture.root, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects a verified receipt whose passing command set has changed', () => {
+    const runFixture = fixture()
+    try {
+      for (const mode of ['prepare', 'finalize']) {
+        const result = run('node', [
+          SCRIPT,
+          mode,
+          '--release-root', runFixture.root,
+          '--tag', TAG,
+          '--trusted-main-commit', runFixture.head,
+          '--artifact', runFixture.artifact,
+          '--receipt', runFixture.receipt,
+        ], runFixture.root)
+        expect(result.status, result.stderr).toBe(0)
+      }
+
+      const receipt = JSON.parse(readFileSync(runFixture.receipt, 'utf-8'))
+      receipt.validations[0].command = 'npm run substituted-check'
+      writeFileSync(runFixture.receipt, JSON.stringify(receipt, null, 2) + '\n')
+
+      const result = run('node', [
+        SCRIPT,
+        'verify',
+        '--release-root', runFixture.root,
+        '--tag', TAG,
+        '--trusted-main-commit', runFixture.head,
+        '--artifact', runFixture.artifact,
+        '--receipt', runFixture.receipt,
+      ], runFixture.root)
+      expect(result.status).toBe(1)
+      expect(result.stderr).toContain('Recovery receipt validation set does not match the required passing commands')
+    } finally {
+      rmSync(runFixture.root, { recursive: true, force: true })
+    }
+  })
+})

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -8,6 +8,19 @@ import { spawnSync } from 'child_process'
 const ROOT = resolve(import.meta.dir, '..')
 const releaseWorkflow = readFileSync(resolve(ROOT, '.github/workflows/release.yml'), 'utf-8')
 const ciWorkflow = readFileSync(resolve(ROOT, '.github/workflows/ci.yml'), 'utf-8')
+const recoveryProofScript = readFileSync(resolve(ROOT, 'scripts/release-recovery-proof.mjs'), 'utf-8')
+
+function executableAuthorityScript(
+  script: string,
+  expectedTag: string,
+  expectedTagCommit: string,
+  workflowCommit: string,
+): string {
+  return script
+    .replaceAll('${{ steps.version.outputs.release_tag }}', expectedTag)
+    .replaceAll('${{ steps.version.outputs.tag_commit }}', expectedTagCommit)
+    .replaceAll('${GITHUB_' + 'SHA}', workflowCommit)
+}
 
 describe('release workflow', () => {
   it('supports a controlled full-history recovery dispatch for an existing release tag', () => {
@@ -20,39 +33,56 @@ describe('release workflow', () => {
       }
       jobs: {
         publish: {
+          'timeout-minutes': number
+          defaults: { run: { 'working-directory': string } }
           steps: Array<{
             name?: string
             uses?: string
             run?: string
+            if?: string
             env?: Record<string, string>
             with?: Record<string, string | number>
           }>
         }
       }
     }
-    const checkout = workflow.jobs.publish.steps.find((step) => step.name === 'Check out repository')
+    const checkout = workflow.jobs.publish.steps.find((step) => step.name === 'Check out immutable release tree')
+    const trustedMain = workflow.jobs.publish.steps.find((step) => step.name === 'Check out trusted recovery code')
     const version = workflow.jobs.publish.steps.find((step) => step.name === 'Resolve release version')
     const release = workflow.jobs.publish.steps.find((step) => step.name === 'Create GitHub release')
+    const recoveryRelease = workflow.jobs.publish.steps.find((step) => step.name === 'Create GitHub recovery release')
 
     expect(workflow.on.push.tags).toEqual(['v*'])
     expect(workflow.on.workflow_dispatch.inputs.release_tag).toEqual({
       description: 'Existing release tag to recover from the trusted main workflow',
       required: true,
-      default: 'v0.1.32',
+      default: 'v0.1.37',
       type: 'string',
     })
+    expect(workflow.jobs.publish.defaults.run['working-directory']).toBe('release')
+    expect(workflow.jobs.publish['timeout-minutes']).toBe(30)
     expect(checkout?.with?.['fetch-depth']).toBe(0)
     expect(checkout?.with?.ref).toBe("${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref }}")
+    expect(checkout?.with?.path).toBe('release')
+    expect(trustedMain?.if).toBe("github.event_name == 'workflow_dispatch'")
+    expect(trustedMain?.with?.['fetch-depth']).toBe(1)
+    expect(trustedMain?.with?.ref).toBe('${{ github.sha }}')
+    expect(trustedMain?.with?.path).toBe('trusted-main')
     expect(version?.env?.REQUESTED_RELEASE_TAG).toBe("${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}")
     expect(version?.run).toContain('Release recovery must be dispatched from main')
     expect(version?.run).toContain('git show-ref --verify --quiet "refs/tags/${TAG_NAME}"')
     expect(version?.run).toContain('git fetch --no-tags origin main:refs/remotes/origin/main')
     expect(version?.run).toContain('git rev-parse "refs/remotes/origin/main^{commit}"')
     expect(version?.run).toContain('git merge-base --is-ancestor "${TAG_COMMIT}" "${TRUSTED_MAIN_COMMIT}"')
-    expect(version?.run).not.toContain('if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then')
+    expect(version?.run).toContain('Recovery commit ${GITHUB_SHA} does not match current trusted main ${TRUSTED_MAIN_COMMIT}.')
+    expect(version?.run).toContain('git -C ../trusted-main rev-parse HEAD')
+    expect(version?.run?.indexOf('git merge-base --is-ancestor "${TAG_COMMIT}" "${TRUSTED_MAIN_COMMIT}"'))
+      .toBeLessThan(version?.run?.indexOf('if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then') ?? -1)
     expect(version?.run).toContain('Checked-out commit ${HEAD_COMMIT} does not match ${TAG_NAME} commit ${TAG_COMMIT}.')
     expect(version?.run).toContain('echo "release_tag=${TAG_NAME}" >> "$GITHUB_OUTPUT"')
+    expect(version?.run).toContain('echo "tag_commit=${TAG_COMMIT}" >> "$GITHUB_OUTPUT"')
     expect(release?.with?.tag_name).toBe('${{ steps.version.outputs.release_tag }}')
+    expect(recoveryRelease?.with?.tag_name).toBe('${{ steps.version.outputs.release_tag }}')
   })
 
   it('rejects a normal release tag whose commit is outside trusted main history', () => {
@@ -64,10 +94,10 @@ describe('release workflow', () => {
 
     const fixtureRoot = mkdtempSync(join(tmpdir(), 'pluxx-release-tag-'))
     const remote = join(fixtureRoot, 'remote.git')
-    const checkout = join(fixtureRoot, 'checkout')
+    const checkout = join(fixtureRoot, 'release')
     const output = join(fixtureRoot, 'github-output')
     const git = (args: string[], cwd = checkout) => {
-      const result = spawnSync('git', args, { cwd, encoding: 'utf-8' })
+      const result = spawnSync('git', args, { cwd, encoding: 'utf-8', timeout: 15_000, killSignal: 'SIGKILL' })
       expect(result.status, result.stderr).toBe(0)
       return result.stdout.trim()
     }
@@ -94,6 +124,8 @@ describe('release workflow', () => {
       const result = spawnSync('bash', ['-c', versionScript!], {
         cwd: checkout,
         encoding: 'utf-8',
+        timeout: 15_000,
+        killSignal: 'SIGKILL',
         env: {
           ...process.env,
           GITHUB_EVENT_NAME: 'push',
@@ -109,6 +141,202 @@ describe('release workflow', () => {
     } finally {
       rmSync(fixtureRoot, { recursive: true, force: true })
     }
+  })
+
+  it('rejects a recovery dispatch whose workflow commit is no longer current main', () => {
+    const workflow = parse(releaseWorkflow) as {
+      jobs: { publish: { steps: Array<{ name?: string; run?: string }> } }
+    }
+    const versionScript = workflow.jobs.publish.steps.find((step) => step.name === 'Resolve release version')?.run
+    const authorityScripts = [
+      'Revalidate recovery authority before npm publish',
+      'Revalidate recovery authority before GitHub release',
+      'Revalidate recovery authority after GitHub release',
+    ].map((name) => workflow.jobs.publish.steps.find((step) => step.name === name)?.run)
+    expect(versionScript).toBeTruthy()
+    expect(authorityScripts.every(Boolean)).toBe(true)
+
+    const fixtureRoot = mkdtempSync(join(tmpdir(), 'pluxx-release-recovery-main-'))
+    const remote = join(fixtureRoot, 'remote.git')
+    const release = join(fixtureRoot, 'release')
+    const trustedMain = join(fixtureRoot, 'trusted-main')
+    const output = join(fixtureRoot, 'github-output')
+    const git = (args: string[], cwd = release) => {
+      const result = spawnSync('git', args, { cwd, encoding: 'utf-8', timeout: 15_000, killSignal: 'SIGKILL' })
+      expect(result.status, result.stderr).toBe(0)
+      return result.stdout.trim()
+    }
+
+    try {
+      git(['init', '--bare', remote], fixtureRoot)
+      git(['init', release], fixtureRoot)
+      git(['config', 'user.email', 'release-test@example.com'])
+      git(['config', 'user.name', 'Release Test'])
+      writeFileSync(join(release, 'package.json'), '{"version":"0.1.37"}\n')
+      git(['add', 'package.json'])
+      git(['commit', '-m', 'tagged release'])
+      git(['branch', '-M', 'main'])
+      git(['tag', 'v0.1.37'])
+      const staleWorkflowCommit = git(['rev-parse', 'HEAD'])
+      git(['remote', 'add', 'origin', remote])
+      git(['push', '-u', 'origin', 'main', '--tags'])
+
+      writeFileSync(join(release, 'recovery-workflow.txt'), 'reviewed recovery workflow\n')
+      git(['add', 'recovery-workflow.txt'])
+      git(['commit', '-m', 'add recovery workflow'])
+      git(['push', 'origin', 'main'])
+      const currentMain = git(['rev-parse', 'HEAD'])
+      expect(currentMain).not.toBe(staleWorkflowCommit)
+
+      git(['clone', remote, trustedMain], fixtureRoot)
+      git(['checkout', '--detach', staleWorkflowCommit], trustedMain)
+      git(['checkout', '--detach', 'v0.1.37'])
+
+      const result = spawnSync('bash', ['-c', versionScript!], {
+        cwd: release,
+        encoding: 'utf-8',
+        timeout: 15_000,
+        killSignal: 'SIGKILL',
+        env: {
+          ...process.env,
+          GITHUB_EVENT_NAME: 'workflow_dispatch',
+          GITHUB_REF: 'refs/heads/main',
+          GITHUB_SHA: staleWorkflowCommit,
+          GITHUB_OUTPUT: output,
+          REQUESTED_RELEASE_TAG: 'v0.1.37',
+        },
+      })
+
+      expect(result.status).toBe(1)
+      expect(result.stderr).toContain(
+        `Recovery commit ${staleWorkflowCommit} does not match current trusted main ${currentMain}.`,
+      )
+
+      for (const gateScript of authorityScripts) {
+        const unchanged = spawnSync(
+          'bash',
+          ['-c', executableAuthorityScript(gateScript!, 'v0.1.37', staleWorkflowCommit, currentMain)],
+          { cwd: release, encoding: 'utf-8', timeout: 15_000, killSignal: 'SIGKILL' },
+        )
+        expect(unchanged.status, unchanged.stderr).toBe(0)
+      }
+
+      writeFileSync(join(release, 'side-tag.txt'), 'tag outside main\n')
+      git(['add', 'side-tag.txt'])
+      git(['commit', '-m', 'side tag'])
+      const sideTagCommit = git(['rev-parse', 'HEAD'])
+      git(['tag', '--force', 'v0.1.37', sideTagCommit])
+      git(['push', '--force', 'origin', 'refs/tags/v0.1.37'])
+      for (const gateScript of authorityScripts) {
+        const outsideMain = spawnSync(
+          'bash',
+          ['-c', executableAuthorityScript(gateScript!, 'v0.1.37', sideTagCommit, currentMain)],
+          { cwd: release, encoding: 'utf-8', timeout: 15_000, killSignal: 'SIGKILL' },
+        )
+        expect(outsideMain.status).toBe(1)
+      }
+
+      git(['tag', '--force', 'v0.1.37', currentMain])
+      git(['push', '--force', 'origin', 'refs/tags/v0.1.37'])
+      for (const authorityScript of authorityScripts) {
+        const movedTag = spawnSync(
+          'bash',
+          ['-c', executableAuthorityScript(authorityScript!, 'v0.1.37', staleWorkflowCommit, currentMain)],
+          { cwd: release, encoding: 'utf-8', timeout: 15_000, killSignal: 'SIGKILL' },
+        )
+        expect(movedTag.status).toBe(1)
+      }
+
+      git(['tag', '--force', 'v0.1.37', staleWorkflowCommit])
+      git(['push', '--force', 'origin', 'refs/tags/v0.1.37'])
+      git(['checkout', 'main'])
+      writeFileSync(join(release, 'main-advanced.txt'), 'main advanced after gate\n')
+      git(['add', 'main-advanced.txt'])
+      git(['commit', '-m', 'advance main after gate'])
+      git(['push', 'origin', 'main'])
+      for (const authorityScript of authorityScripts) {
+        const advancedMain = spawnSync(
+          'bash',
+          ['-c', executableAuthorityScript(authorityScript!, 'v0.1.37', staleWorkflowCommit, currentMain)],
+          { cwd: release, encoding: 'utf-8', timeout: 15_000, killSignal: 'SIGKILL' },
+        )
+        expect(advancedMain.status).toBe(1)
+      }
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true })
+    }
+  }, 15_000)
+
+  it('keeps immutable-tag recovery fail-closed through proof and artifact identity', () => {
+    const workflow = parse(releaseWorkflow) as {
+      jobs: {
+        publish: {
+          steps: Array<{
+            name?: string
+            if?: string
+            run?: string
+            env?: Record<string, string>
+          }>
+        }
+      }
+    }
+    const steps = workflow.jobs.publish.steps
+    const names = steps.map((step) => step.name)
+    const standard = steps.find((step) => step.name === 'Run standard release checks')
+    const prepare = steps.find((step) => step.name === 'Prepare immutable-tag recovery proof')
+    const verify = steps.find((step) => step.name === 'Verify immutable-tag recovery proof')
+    const pack = steps.find((step) => step.name === 'Pack release tarball')
+    const npmAuthority = steps.find((step) => step.name === 'Revalidate recovery authority before npm publish')
+    const published = steps.find((step) => step.name === 'Verify npm publication')
+    const githubAuthority = steps.find((step) => step.name === 'Revalidate recovery authority before GitHub release')
+    const postReleaseAuthority = steps.find((step) => step.name === 'Revalidate recovery authority after GitHub release')
+    const releaseAsset = steps.find((step) => step.name === 'Verify GitHub release asset')
+
+    expect(standard?.if).toBe("github.event_name != 'workflow_dispatch'")
+    expect(standard?.run).toContain('npm run release:check')
+    expect(prepare?.run).toContain('../trusted-main/scripts/release-recovery-proof.mjs prepare')
+    expect(prepare?.run).toContain('git -C ../trusted-main status --porcelain --untracked-files=no')
+    for (const command of [
+      'npm run build',
+      'npm run typecheck',
+      'npm test',
+      'node scripts/run-npm-pack.mjs --dry-run',
+      'npm pack --pack-destination "${CANDIDATE_DIR}"',
+      'node scripts/verify-node-package-runtime.mjs --package-file "${CANDIDATE_PATH}"',
+    ]) {
+      expect(recoveryProofScript).toContain(command)
+    }
+    expect(recoveryProofScript).toContain('runPreProofValidations(args)')
+    expect(recoveryProofScript).toContain('Recovery does not support current receipt')
+    expect(prepare?.run).not.toContain('npm pack --pack-destination')
+    expect(prepare?.run?.indexOf('release-recovery-proof.mjs prepare'))
+      .toBeLessThan(prepare?.run?.indexOf('CANDIDATE_INTEGRITY=') ?? -1)
+    expect(verify?.run).toContain('../trusted-main/scripts/release-recovery-proof.mjs finalize')
+    expect(verify?.run).not.toContain('npm run proof:check')
+    expect(pack?.run).toContain('../trusted-main/scripts/release-recovery-proof.mjs verify')
+    expect(pack?.run).toContain('candidate_integrity')
+    expect(pack?.run).toContain('candidate_sha256')
+    expect(releaseAsset?.run).toContain('../trusted-main/scripts/release-recovery-proof.mjs verify')
+    expect(published?.run).toContain('EXPECTED_INTEGRITY="${{ steps.pack.outputs.package_integrity }}"')
+    for (const authority of [npmAuthority, githubAuthority, postReleaseAuthority]) {
+      expect(authority?.if).toBe("github.event_name == 'workflow_dispatch'")
+      expect(authority?.run).toContain('"main:refs/remotes/origin/main"')
+      expect(authority?.run).toContain('"refs/tags/${TAG_NAME}:refs/release-validation/${TAG_NAME}"')
+      expect(authority?.run).toContain('test "${CURRENT_MAIN}" = "${GITHUB_SHA}"')
+      expect(authority?.run).toContain('test "${CURRENT_TAG}" = "${{ steps.version.outputs.tag_commit }}"')
+    }
+
+    expect(names.indexOf('Resolve release version')).toBeLessThan(names.indexOf('Install dependencies'))
+    expect(names.indexOf('Install dependencies')).toBeLessThan(names.indexOf('Prepare immutable-tag recovery proof'))
+    expect(names.indexOf('Prepare immutable-tag recovery proof')).toBeLessThan(names.indexOf('Verify immutable-tag recovery proof'))
+    expect(names.indexOf('Verify immutable-tag recovery proof')).toBeLessThan(names.indexOf('Pack release tarball'))
+    expect(names.indexOf('Pack release tarball')).toBeLessThan(names.indexOf('Revalidate recovery authority before npm publish'))
+    expect(names.indexOf('Revalidate recovery authority before npm publish')).toBeLessThan(names.indexOf('Publish to npm'))
+    expect(names.indexOf('Stage recovery receipt asset')).toBeLessThan(names.indexOf('Revalidate recovery authority before GitHub release'))
+    expect(names.indexOf('Revalidate recovery authority before GitHub release')).toBeLessThan(names.indexOf('Create GitHub recovery release'))
+    expect(names.indexOf('Create GitHub recovery release')).toBeLessThan(names.indexOf('Verify GitHub release asset'))
+    expect(names.indexOf('Verify GitHub release asset')).toBeLessThan(names.indexOf('Revalidate recovery authority after GitHub release'))
+    expect(names.at(-1)).toBe('Revalidate recovery authority after GitHub release')
   })
 
   it('uses GitHub Actions runtime versions that avoid the Node 20 deprecation path', () => {
@@ -138,10 +366,10 @@ describe('release workflow', () => {
       jobs: { publish: { steps: Array<{ name?: string; run?: string; env?: Record<string, string> }> } }
     }
     const names = workflow.jobs.publish.steps.map((step) => step.name)
-    const releaseCheck = workflow.jobs.publish.steps.find((step) => step.name === 'Run release checks')
+    const releaseCheck = workflow.jobs.publish.steps.find((step) => step.name === 'Run standard release checks')
     expect(releaseCheck?.env?.PLUXX_RELEASE_TAG).toBe('${{ steps.version.outputs.release_tag }}')
     expect(names.indexOf('Resolve release version')).toBeLessThan(names.indexOf('Install dependencies'))
-    expect(names.indexOf('Install dependencies')).toBeLessThan(names.indexOf('Run release checks'))
+    expect(names.indexOf('Install dependencies')).toBeLessThan(names.indexOf('Run standard release checks'))
     expect(names.indexOf('Pack release tarball')).toBeLessThan(names.indexOf('Verify packaged Node runtime'))
     expect(names.indexOf('Verify packaged Node runtime')).toBeLessThan(names.indexOf('Publish to npm'))
     expect(names.indexOf('Publish to npm')).toBeLessThan(names.indexOf('Verify npm publication'))
@@ -149,7 +377,12 @@ describe('release workflow', () => {
     expect(names.indexOf('Create GitHub release')).toBeLessThan(names.indexOf('Verify GitHub release asset'))
     for (const step of workflow.jobs.publish.steps as Array<{ name?: string; run?: string }>) {
       if (!step.run) continue
-      const syntax = spawnSync('bash', ['-n'], { input: step.run, encoding: 'utf-8' })
+      const syntax = spawnSync('bash', ['-n'], {
+        input: step.run,
+        encoding: 'utf-8',
+        timeout: 15_000,
+        killSignal: 'SIGKILL',
+      })
       expect(syntax.status, `${step.name}: ${syntax.stderr}`).toBe(0)
     }
   })


### PR DESCRIPTION
## Summary
- add a fail-closed trusted-main recovery path for immutable v0.1.37
- rebuild, test, pack, and runtime-verify the exact tag tree inside one trusted helper
- bind candidate/final/npm/GitHub artifacts to exact hashes and revalidate main/tag authority at every mutation boundary
- preserve f7ee pre-squash receipts as historical and record truthful d518 exact-tag evidence

## Immutable recovery invariants
- recovery dispatch must run from exact current main
- v0.1.37 must remain at d5184752cd4898306390f20455619c34a42099dd and be contained in main
- no tag move/recreation, local publish, proof bypass, or unattended autofix
- unknown current proof tiers fail closed
- final remote authority check is the last workflow step

## Validation
- final CE correctness: CLEAN
- final CE security: CLEAN
- final CE adversarial: CLEAN
- final CE testing: CLEAN
- focused recovery/proof tests: 32 passed
- exact immutable-tag helper rehearsal: 61 files / 803 tests; production proof; package runtime; byte-identical final pack
- full branch release gate: 62 files / 815 tests; proof/build/typecheck/package runtime/dry pack all passed
- exact tag artifact SHA-256: 7c996da682887ceedecc006307c207c5a834e5dedabaab17611cd586ef85b237

## Known residuals
- npm and GitHub release writes are external and cannot be atomic with Git ref reads; a mid-write ref change produces a detected partial release, not a green workflow
- recovery receipt authenticity relies on protected GitHub Actions/release controls and durable workflow logs

## Post-deploy monitoring and validation
Owner: Brandon. Watch the Release run through helper validation, npm integrity readback, GitHub asset/receipt download, and final authority gate. Validate npm dist.integrity, tarball SHA-256, recovery receipt tag/tree/artifact fields, and the remote v0.1.37 target immediately after completion and again within 24 hours. On any mismatch or non-green step, stop; do not move the tag or publish locally.