### PR TITLE
fix(publish): deduplicate release manifest archive identities

### DIFF
--- a/src/cli/publish.ts
+++ b/src/cli/publish.ts
@@ -3275,9 +3275,11 @@ function createReleaseArtifacts(
     repo: githubRelease.repo,
     version: plan.version,
     releaseTag: githubRelease.releaseTag,
-    builtTargets: githubRelease.assets
-      .filter((asset): asset is PublishAssetPlan & { platform: TargetPlatform } => asset.kind === 'archive' && asset.platform !== undefined)
-      .map((asset) => asset.platform),
+    builtTargets: Array.from(new Set(
+      githubRelease.assets
+        .filter((asset): asset is PublishAssetPlan & { platform: TargetPlatform } => asset.kind === 'archive' && asset.platform !== undefined)
+        .map((asset) => asset.platform),
+    )),
     installerTargets: githubRelease.assets
       .filter(
         (asset): asset is PublishAssetPlan & { platform: typeof INSTALLER_TARGETS[number] } =>

--- a/tests/publish.test.ts
+++ b/tests/publish.test.ts
@@ -1098,6 +1098,58 @@ describe('runPublish', () => {
     expect(installAllContent).toContain('bash "$TMP_DIR/install.sh" --agents "$@"')
   })
 
+  it('emits one canonical manifest archive identity for a single host while checksumming both asset names', () => {
+    const config: PluginConfig = {
+      ...makeConfig(),
+      targets: ['codex'],
+    }
+    prepareBuiltTarget('codex', GENERATED_INSTALLER_FIXTURE_FILES.codex)
+
+    let manifestContent = ''
+    let checksumsContent = ''
+    const result = runPublish(config, {
+      rootDir: ROOT,
+      requestedChannels: ['github-release'],
+      runCommand: withGithubReleaseVerification((command, args, options) => {
+        if (command === 'tar') {
+          const proc = spawnSync(command, args, {
+            cwd: options?.cwd,
+            encoding: 'utf-8',
+          })
+          return {
+            status: proc.status,
+            stdout: proc.stdout ?? '',
+            stderr: proc.stderr ?? '',
+          }
+        }
+
+        if (command === 'git') return { status: 0, stdout: '', stderr: '' }
+        if (command === 'gh' && args[0] === 'release' && args[1] === 'view') return { status: 1, stdout: '', stderr: 'missing' }
+        if (command === 'gh' && args[0] === 'release' && args[1] === 'create') {
+          const manifestPath = args.find((value) => value.endsWith('/release-manifest.json'))
+          const checksumsPath = args.find((value) => value.endsWith('/SHA256SUMS.txt'))
+          manifestContent = readFileSync(manifestPath!, 'utf-8')
+          checksumsContent = readFileSync(checksumsPath!, 'utf-8')
+          return { status: 0, stdout: 'created', stderr: '' }
+        }
+        return { status: 0, stdout: '', stderr: '' }
+      }),
+    })
+
+    expect(result.ok).toBe(true)
+    const manifest = JSON.parse(manifestContent)
+    expect(manifest.assets.archives).toEqual([
+      {
+        platform: 'codex',
+        versionedAsset: 'publish-plugin-codex-v1.2.3.tar.gz',
+        latestAsset: 'publish-plugin-codex-latest.tar.gz',
+        latestUrl: 'https://github.com/orchidautomation/publish-plugin/releases/latest/download/publish-plugin-codex-latest.tar.gz',
+      },
+    ])
+    expect(checksumsContent).toContain('  publish-plugin-codex-v1.2.3.tar.gz')
+    expect(checksumsContent).toContain('  publish-plugin-codex-latest.tar.gz')
+  })
+
   it('generates a top-level installer that routes supported agent hosts', () => {
     const config: PluginConfig = {
       ...makeConfig(),
@@ -1155,6 +1207,14 @@ describe('runPublish', () => {
     expect(installerContent).toContain('--connect-timeout 10 --max-time 120 --retry 3 --retry-all-errors')
 
     const manifest = JSON.parse(manifestContent)
+    expect(manifest.assets.archives).toHaveLength(4)
+    expect(manifest.assets.archives.map((archive: { platform: TargetPlatform }) => archive.platform)).toEqual([
+      'claude-code',
+      'cursor',
+      'codex',
+      'opencode',
+    ])
+    expect(new Set(manifest.assets.archives.map((archive: { platform: TargetPlatform }) => archive.platform)).size).toBe(4)
     expect(manifest.assets.install).toEqual({
       script: 'install.sh',
       url: 'https://github.com/orchidautomation/publish-plugin/releases/latest/download/install.sh',


### PR DESCRIPTION
Fixes #460

Linear: PLUXX-340

## Summary
- emit one release-manifest archive record per host while retaining both versioned and latest asset names
- preserve deterministic target order and manifest schema v1 compatibility
- keep both physical archives in the release asset plan and checksum both assets
- add single-host and core-four regression coverage

## Fail-first evidence
- prior behavior: 68 pass / 2 fail in tests/publish.test.ts
- one host emitted 2 manifest rows; core four emitted 8 rows

## Validation
- bun test tests/publish.test.ts --timeout 120000: 70 pass / 0 fail
- npm run release:check: 62 files / 816 tests pass; packaged-runtime verification and dry pack pass
- npm run proof:check: 18/18
- npm run typecheck: pass
- npm run build: pass
- release smoke tests: 17/17
- independent correctness, testing, and API-contract review: zero findings

No merge, tag, package publication, or release is included in this PR. The first corrected release would be 0.1.38 after this exact head is approved and merged.