### PR TITLE
fix(release): recover immutable v0.1.38 publication

### DIFF
--- a/docs/orchid/plans/2026-07-25-pluxx-340-release-0.1.38.md
+++ b/docs/orchid/plans/2026-07-25-pluxx-340-release-0.1.38.md
@@ -99,6 +99,15 @@ flowchart TB
 - **Test scenarios:** Head changes invalidate prior settledness; tag collision stops release; workflow failure stops verification; any public identity mismatch fails closeout.
 - **Verification:** PR, merge, tag, workflow run, npm package, GitHub release asset, and checksums all resolve to the same 0.1.38 release identity.
 
+### U4. Immutable-tag recovery after action-time fixture collision
+
+- **Goal:** Preserve the immutable tag and recover publication after the first tag-triggered run failed closed before pack or publish.
+- **Trigger:** Release run `30152484521` exposed a test fixture that cloned the now-tagged repository with tags and then tried to create `v0.1.38` again.
+- **Files:** `scripts/release-recovery-proof.mjs`, `tests/release-recovery-proof.test.ts`, proof/planning docs, Linear comments, and the release review record.
+- **Approach:** Keep `v0.1.38` fixed at trusted merge `e24d4db3f57fa0942376237fb212cb49368d7704`; make the fixture clone tagless; make recovery run the exact immutable test tree from a tagless clone at the same commit; merge the independently reviewed fix to exact current main; dispatch the documented recovery workflow from that trusted main commit.
+- **Test scenarios:** A release-recovery fixture must pass both before and after the real version tag exists; the tagless recovery test checkout must resolve to the exact immutable release commit; any commit drift, test failure, artifact mismatch, or tag movement fails closed.
+- **Verification:** Focused recovery tests and the full release gate pass on trusted main, recovery run succeeds, and independently downloaded npm/GitHub artifacts are byte-identical and provenance-bound to the unchanged tag.
+
 ---
 
 ## Verification Contract

--- a/docs/orchid/reviews/2026-07-25-pluxx-340-release-0.1.38-review.md
+++ b/docs/orchid/reviews/2026-07-25-pluxx-340-release-0.1.38-review.md
@@ -52,3 +52,30 @@ Correctness and adversarial re-review reported zero current findings. Maintainab
 ## Verdict
 
 Ready for the release PR with zero current review findings. Merge, tag, publication, and public artifact verification remain action-time gates.
+
+## Immutable-Tag Recovery Addendum
+
+Release PR [#462](https://github.com/orchidautomation/pluxx/pull/462) merged exact reviewed head `cbc14e007626328a8d25340419a455f40701426c` with true merge commit `e24d4db3f57fa0942376237fb212cb49368d7704`. Both that head and receipt-bound commit `361958f6b16b1acc2bb901c97fc2c6d5a77ba880` are trusted-main ancestors. Immutable tag `v0.1.38` points to the merge commit and has not moved.
+
+Tag-triggered Release run [30152484521](https://github.com/orchidautomation/pluxx/actions/runs/30152484521) failed closed during `npm test` before pack or publication. The production-tag proof-checker test cloned the now-tagged repository with tags, then attempted to create `v0.1.38` again. The failure was reproduced locally only after the real tag existed.
+
+The reviewed recovery change:
+
+- makes the production proof-checker fixture clone without tags;
+- runs recovery tests from a tagless clone whose exact commit must match the immutable release checkout;
+- rebuilds that exact source clone before testing so release-smoke has its required generated `dist/`;
+- strengthens the recovery fixture to fail when the version tag is inherited or build output is missing;
+- cleans an independently exposed `alias-agent.md` shared-fixture leak in `finally`; and
+- updates proof and planning truth to record that the tag exists while public 0.1.38 remains blocked pending recovery.
+
+Fail-first and gate evidence:
+
+- the production proof-checker test reproduced the tag collision as status 128 after `v0.1.38` existed;
+- adversarial review reproduced the missing-`dist/` blocker in an exact tagless `e24d4db3f57fa0942376237fb212cb49368d7704` clone;
+- the full suite exposed the shared-fixture leak as a 815/816 failure before cleanup was added;
+- focused build, recovery, workflow, and proof suites passed 83/83;
+- the complete `npm run release:check` passed with 62 files, 816 tests, isolated packed Node runtime verification, and npm dry-run package `@orchid-labs/pluxx@0.1.38`;
+- independent correctness and adversarial re-review reported zero current actionable findings; and
+- adversarial re-review independently built the exact tagless release clone and passed release-smoke 10/10.
+
+Recovery remains fail closed: merge only an unchanged green recovery PR into exact current main, dispatch only the documented `workflow_dispatch` lane from that trusted main commit, never move or recreate `v0.1.38`, and independently verify npm/GitHub identity before declaring the follow-up release public.

--- a/docs/proof-and-install.md
+++ b/docs/proof-and-install.md
@@ -30,9 +30,9 @@ This is the shortest current repo-native path to:
 
 For the fuller release/distribution boundary, including publish commands and deferred marketplace/trust-layer work, use [docs/release-distribution-proof-map.md](./release-distribution-proof-map.md).
 
-Proof labels and freshness come from [proof-freshness.md](./proof-freshness.md) and [proof-manifest.json](./proof-manifest.json). The May self-hosted run, April Firecrawl connector run, and shipped 0.1.37 evidence remain historical relative to pending repository version `0.1.38`.
+Proof labels and freshness come from [proof-freshness.md](./proof-freshness.md) and [proof-manifest.json](./proof-manifest.json). The May self-hosted run, April Firecrawl connector run, and shipped 0.1.37 evidence remain historical relative to tagged repository version `0.1.38`.
 
-The 0.1.38 release-prep proof covers only the PLUXX-340 manifest-identity correction: one manifest archive record per host while versioned and `latest` assets remain produced and checksummed. Fresh receipts `v0.1.38-repository-validation` and `v0.1.38-fake-home-install` bind to exact release-prep commit `361958f6b16b1acc2bb901c97fc2c6d5a77ba880`, where `npm run release:check` passed on 2026-07-25. The historical shipped 0.1.37 npm and GitHub artifact remains independently verified at SHA-256 `7c996da682887ceedecc006307c207c5a834e5dedabaab17611cd586ef85b237`.
+The 0.1.38 proof covers only the PLUXX-340 manifest-identity correction: one manifest archive record per host while versioned and `latest` assets remain produced and checksummed. Fresh receipts `v0.1.38-repository-validation` and `v0.1.38-fake-home-install` bind to exact release-prep commit `361958f6b16b1acc2bb901c97fc2c6d5a77ba880`, which is contained by reviewed PR head `cbc14e007626328a8d25340419a455f40701426c` and trusted merge commit `e24d4db3f57fa0942376237fb212cb49368d7704`. Immutable tag `v0.1.38` points to that merge. Its first Release run failed closed during the full test gate before pack or publication, so the historical shipped 0.1.37 npm and GitHub artifact remains the independently verified public release at SHA-256 `7c996da682887ceedecc006307c207c5a834e5dedabaab17611cd586ef85b237` until reviewed recovery succeeds.
 
 ## The Story In One Screen
 
@@ -211,7 +211,7 @@ curl -fsSL https://raw.githubusercontent.com/orchidautomation/pluxx/main/example
 Current release note:
 
 - the canonical and verified public release is `@orchid-labs/pluxx@0.1.37` / `v0.1.37` for the PLUXX-339 runtime env-sourcing security patch; npm and GitHub serve the same verified tarball and the GitHub release includes its recovery receipt
-- repository version `0.1.38` is release-prep only for the separately discovered PLUXX-340 duplicate archive-identity correction
+- repository version `0.1.38` is tagged only for the separately discovered PLUXX-340 duplicate archive-identity correction; its first Release run failed closed before pack or publication, so public verification awaits reviewed trusted-main recovery
 - the published CLI runtime is Node `>=18`; see [runtime contract](./runtime-contract.md)
 - the published package includes the Claude plugin-agent manifest fix and packaged Node runtime verification
 - the public `pluxx test --install --trust --behavioral` path now matches the repo-local Exa proof state

--- a/docs/proof-freshness.md
+++ b/docs/proof-freshness.md
@@ -4,7 +4,7 @@ Last updated: 2026-07-25
 
 This document defines how Pluxx distinguishes repeatable repository checks from installed and real-host evidence. The machine-readable source is [proof-manifest.json](./proof-manifest.json), validated by `npm run proof:check`.
 
-The repository is preparing `v0.1.38` only as the PLUXX-340 follow-up for duplicate release-manifest archive identities discovered after 0.1.37 shipped. The shipped and independently verified `v0.1.37` receipts remain historical evidence. Fresh current receipts `v0.1.38-repository-validation` and `v0.1.38-fake-home-install` bind to exact release-prep commit `361958f6b16b1acc2bb901c97fc2c6d5a77ba880`, where `npm run release:check` passed on 2026-07-25. No current receipt claims installed-runtime or real-host behavior.
+Immutable tag `v0.1.38` now records only the PLUXX-340 follow-up for duplicate release-manifest archive identities discovered after 0.1.37 shipped. The shipped and independently verified `v0.1.37` receipts remain historical evidence. Fresh current receipts `v0.1.38-repository-validation` and `v0.1.38-fake-home-install` bind to exact release-prep commit `361958f6b16b1acc2bb901c97fc2c6d5a77ba880`, where `npm run release:check` passed on 2026-07-25. The first tag-triggered release run failed closed during the full test gate before pack or publication, so public 0.1.38 artifact claims remain blocked pending reviewed trusted-main recovery. No current receipt claims installed-runtime or real-host behavior.
 
 ## Version And Freshness Policy
 

--- a/docs/proof-manifest.json
+++ b/docs/proof-manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "canonicalVersion": "0.1.38",
   "expectedTag": "v0.1.38",
-  "releaseState": "release-prep",
+  "releaseState": "released",
   "policy": {
     "environmentReceiptMaxAgeDays": 30
   },

--- a/docs/release-distribution-proof-map.md
+++ b/docs/release-distribution-proof-map.md
@@ -26,7 +26,7 @@ Last updated: 2026-07-25
 
 This is the short release/distribution map for what Pluxx can ship today, what is locally proven, and what still belongs to later marketplace or trust-layer work.
 
-Proof state is governed by [proof-freshness.md](./proof-freshness.md) and the machine-readable [proof manifest](./proof-manifest.json). The canonical repository version is pending `0.1.38` release-prep for the PLUXX-340 manifest-identity correction. The canonical and independently verified public release remains `@orchid-labs/pluxx@0.1.37`; immutable tag `v0.1.37` remains at `d5184752cd4898306390f20455619c34a42099dd`, and npm plus GitHub serve its byte-identical tarball at SHA-256 `7c996da682887ceedecc006307c207c5a834e5dedabaab17611cd586ef85b237`.
+Proof state is governed by [proof-freshness.md](./proof-freshness.md) and the machine-readable [proof manifest](./proof-manifest.json). The canonical repository version is tagged as `0.1.38` only for the PLUXX-340 manifest-identity correction. Immutable tag `v0.1.38` points to trusted merge `e24d4db3f57fa0942376237fb212cb49368d7704`, but Release run [30152484521](https://github.com/orchidautomation/pluxx/actions/runs/30152484521) failed closed during the full test gate before pack or publication. The canonical and independently verified public release therefore remains `@orchid-labs/pluxx@0.1.37`; npm plus GitHub serve its byte-identical tarball at SHA-256 `7c996da682887ceedecc006307c207c5a834e5dedabaab17611cd586ef85b237` until reviewed trusted-main recovery succeeds.
 
 ## Current Primary Fronts
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -84,7 +84,7 @@ Proof governance now distinguishes unit, bundle-contract, fake-home install, ins
 
 PLUXX-339 is shipped in the verified public `0.1.37` release after the historical `0.1.36` OpenCode workspace patch. The security patch blocks bundled runtime scripts from sourcing workspace `.env` files through direct and statically evaluable shell forms while preserving valid safe shell syntax.
 
-PLUXX-340 is the separate `0.1.38` release-prep follow-up for duplicate release-manifest archive identities discovered after the historical shipped 0.1.37 release. It preserves both versioned and `latest` physical assets while exposing one deterministic manifest identity per host.
+PLUXX-340 is the separate tagged `0.1.38` follow-up for duplicate release-manifest archive identities discovered after the historical shipped 0.1.37 release. It preserves both versioned and `latest` physical assets while exposing one deterministic manifest identity per host. The first tag-triggered Release run failed closed during the full test gate before pack or publication, so public verification remains blocked on reviewed trusted-main recovery.
 
 ### 1. Product clarity and source-of-truth coherence
 
@@ -231,7 +231,7 @@ The closure plan is now narrower than it was before:
   - `npm test` passed
   - `npm run release:check` passed
 - the canonical and verified public release is `@orchid-labs/pluxx@0.1.37` / `v0.1.37`; npm and GitHub serve the same tarball at SHA-256 `7c996da682887ceedecc006307c207c5a834e5dedabaab17611cd586ef85b237`
-- the canonical repository version is pending `0.1.38` release-prep for PLUXX-340; this does not change the shipped status of 0.1.37
+- the canonical repository version is tagged as `0.1.38` for PLUXX-340; the failed-closed first Release run did not publish artifacts and does not change the shipped status of 0.1.37
 - the release/distribution/proof boundary is now explicit:
   - [docs/release-distribution-proof-map.md](./release-distribution-proof-map.md)
   - [docs/core-four-primitive-proof-ledger.md](./core-four-primitive-proof-ledger.md)
@@ -391,11 +391,11 @@ This is for learning and proof, not for prematurely building the full trust laye
 
 ### 6. Next release
 
-The canonical repository version is pending `0.1.38` release-prep for PLUXX-340. The canonical and verified public release remains `0.1.37`; immutable tag `v0.1.37` remains at `d5184752cd4898306390f20455619c34a42099dd`, and recovery run [30144489420](https://github.com/orchidautomation/pluxx/actions/runs/30144489420) published and independently verified the exact artifact without moving its tag.
+The canonical repository version is tagged as `0.1.38` for PLUXX-340. Immutable tag `v0.1.38` points to trusted merge `e24d4db3f57fa0942376237fb212cb49368d7704`; its first Release run [30152484521](https://github.com/orchidautomation/pluxx/actions/runs/30152484521) failed closed during the full test gate before pack or publication. The canonical and verified public release remains 0.1.37 until reviewed trusted-main recovery publishes and independently verifies the exact immutable 0.1.38 artifact.
 
 The next npm cut should stay primarily an operations step rather than a code-confidence rescue step.
 
-- release and independently verify 0.1.38 as the focused PLUXX-340 manifest-identity correction
+- merge the reviewed tag-aware recovery-test fix on trusted main, dispatch immutable-tag recovery without moving `v0.1.38`, and independently verify 0.1.38 as the focused PLUXX-340 manifest-identity correction
 - preserve the completed 0.1.37 immutable-tag recovery evidence: tag commit `d5184752cd4898306390f20455619c34a42099dd`, tree `e63eea0f89995a44b7536b5403af57792e994cb9`, trusted main `044673f947115bcf6117dd7c0139918bdd248a99`, and tarball SHA-256 `7c996da682887ceedecc006307c207c5a834e5dedabaab17611cd586ef85b237`
 - refresh installed-runtime or real-host receipts separately before making broader current host claims
 - use future focused release PRs and trusted tag workflows for the next package cut

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -39,7 +39,7 @@ If you want the shortest public proof and install path after this file, use [doc
 
 If you want the current release, distribution, and proof boundary, use [docs/release-distribution-proof-map.md](./release-distribution-proof-map.md).
 
-If you need to know whether a proof claim is current, historical, repository-only, installed, or real-host evidence, use [docs/proof-freshness.md](./proof-freshness.md) and [docs/proof-manifest.json](./proof-manifest.json). Canonical repository version truth is `package.json` (`0.1.38`), currently in release-prep for the PLUXX-340 manifest-identity correction. The shipped and independently verified public release remains `@orchid-labs/pluxx@0.1.37` at immutable tag commit `d5184752cd4898306390f20455619c34a42099dd`.
+If you need to know whether a proof claim is current, historical, repository-only, installed, or real-host evidence, use [docs/proof-freshness.md](./proof-freshness.md) and [docs/proof-manifest.json](./proof-manifest.json). Canonical repository version truth is `package.json` (`0.1.38`), tagged only for the PLUXX-340 manifest-identity correction at trusted merge `e24d4db3f57fa0942376237fb212cb49368d7704`. Its first Release run failed closed during the full test gate before pack or publication. The shipped and independently verified public release therefore remains `@orchid-labs/pluxx@0.1.37` until reviewed trusted-main recovery succeeds.
 
 If you want the primitive-by-host proof ledger behind the core-four native shipping claim, use [docs/core-four-primitive-proof-ledger.md](./core-four-primitive-proof-ledger.md).
 
@@ -370,7 +370,7 @@ The repo already proves a lot.
   - `npm test` passed
   - `npm run release:check` passed
 - the canonical and verified public release is `@orchid-labs/pluxx@0.1.37` / `v0.1.37`; npm and GitHub serve the same tarball at SHA-256 `7c996da682887ceedecc006307c207c5a834e5dedabaab17611cd586ef85b237`
-- the repository is preparing `0.1.38` only as the follow-up PLUXX-340 correction for duplicate release-manifest archive identities discovered after the historical shipped 0.1.37 release
+- immutable tag `v0.1.38` records only the follow-up PLUXX-340 correction for duplicate release-manifest archive identities discovered after the historical shipped 0.1.37 release; its first Release run failed closed before pack or publication
 - marketplace submission APIs, a managed trust/distribution control plane, automatic rollback/unpublish orchestration, and real authenticated publish plus rollback proof remain explicit release gaps, not hidden shipped capabilities:
   - `docs/release-distribution-proof-map.md`
   - “automatic rollback” here means remote release rollback/unpublish; generated local installers now restore the prior bundle when staged setup fails
@@ -540,11 +540,11 @@ Run two lanes in parallel:
 
 ### 6. Release State
 
-The canonical repository version is pending `0.1.38` release-prep for the PLUXX-340 manifest-identity correction. The canonical and verified public release remains `@orchid-labs/pluxx@0.1.37`; immutable tag `v0.1.37` remains at `d5184752cd4898306390f20455619c34a42099dd` with tree `e63eea0f89995a44b7536b5403af57792e994cb9`. Reviewed recovery run [30144489420](https://github.com/orchidautomation/pluxx/actions/runs/30144489420) published and verified that exact 0.1.37 artifact without moving its tag.
+The canonical repository version is tagged as `0.1.38` only for the PLUXX-340 manifest-identity correction. Immutable tag `v0.1.38` points to trusted merge `e24d4db3f57fa0942376237fb212cb49368d7704`, which contains exact reviewed PR head `cbc14e007626328a8d25340419a455f40701426c` and receipt commit `361958f6b16b1acc2bb901c97fc2c6d5a77ba880`. Release run [30152484521](https://github.com/orchidautomation/pluxx/actions/runs/30152484521) failed closed during the full test gate before pack or publication, so the canonical and verified public release remains `@orchid-labs/pluxx@0.1.37` until reviewed trusted-main recovery succeeds.
 
 For v0.1.37, PLUXX-339 is the tagged security focus: lint, doctor, install, and packaged-runtime verification fail closed when bundled runtime scripts source workspace `.env` files through direct or statically evaluable shell forms. The patch preserves valid safe shell forms and uses a bounded explicit scanner rather than an expanding regex.
 
-For pending v0.1.38, PLUXX-340 is the only release focus: one unambiguous release-manifest archive identity per host while versioned and `latest` physical assets remain generated and checksummed.
+For tagged v0.1.38, PLUXX-340 is the only release focus: one unambiguous release-manifest archive identity per host while versioned and `latest` physical assets remain generated and checksummed.
 
 ## Working Rules
 

--- a/docs/todo/master-backlog.md
+++ b/docs/todo/master-backlog.md
@@ -126,7 +126,9 @@ Proof governance is now explicit: [proof-freshness.md](../proof-freshness.md) de
 - [x] Prepare synchronized 0.1.38 package, proof, planning, recovery-default, and release truth
 - [x] Bind fresh repository-validation and fake-home-install receipts to exact immutable release-prep commit `361958f6b16b1acc2bb901c97fc2c6d5a77ba880`
 - [x] Pass focused and full release gates plus independent review; review record: [2026-07-25-pluxx-340-release-0.1.38-review.md](../orchid/reviews/2026-07-25-pluxx-340-release-0.1.38-review.md)
-- [ ] Merge the exact green release PR with a true merge commit, prove PR-head and receipt ancestry, and push immutable tag `v0.1.38` from trusted main
+- [x] Merge PR #462 exact reviewed head `cbc14e007626328a8d25340419a455f40701426c` with true merge commit `e24d4db3f57fa0942376237fb212cb49368d7704`, prove PR-head and receipt ancestry, and push immutable tag `v0.1.38`
+- [x] Confirm tag-triggered Release run `30152484521` failed closed during the full test gate before pack or publication
+- [ ] Merge the reviewed trusted-main recovery fix and dispatch immutable-tag recovery without moving or recreating `v0.1.38`
 - [ ] Verify npm, GitHub release assets, byte-identical tarballs, immutable tag provenance, and installed CLI behavior
 
 ### 1. Product clarity and front-door coherence

--- a/docs/todo/queue.md
+++ b/docs/todo/queue.md
@@ -189,7 +189,7 @@ The public baseline is also real.
 
 - npm package is live as `@orchid-labs/pluxx`
 - the canonical and verified public release is `@orchid-labs/pluxx@0.1.37` / `v0.1.37`; npm and GitHub serve the same tarball at SHA-256 `7c996da682887ceedecc006307c207c5a834e5dedabaab17611cd586ef85b237`
-- the canonical repository version is pending `0.1.38` release-prep only for the PLUXX-340 manifest-identity correction discovered after 0.1.37 shipped
+- the canonical repository version is tagged as `0.1.38` only for the PLUXX-340 manifest-identity correction discovered after 0.1.37 shipped; its first Release run failed closed before pack or publication
 - proof claims now use [docs/proof-freshness.md](../proof-freshness.md) and [docs/proof-manifest.json](../proof-manifest.json) so historical host runs cannot masquerade as current evidence
 - published CLI runtime is Node `>=18`
 - published CLI lifecycle ergonomics are now stronger for global installs:
@@ -555,7 +555,9 @@ Current work:
 - [x] prepare synchronized 0.1.38 package, proof, planning, recovery-default, and release truth
 - [x] bind fresh repository-validation and fake-home-install receipts to exact immutable release-prep commit `361958f6b16b1acc2bb901c97fc2c6d5a77ba880`
 - [x] pass focused and full release gates plus independent review; review record: [2026-07-25-pluxx-340-release-0.1.38-review.md](../orchid/reviews/2026-07-25-pluxx-340-release-0.1.38-review.md)
-- [ ] merge the exact green release PR with a true merge commit, prove PR-head and receipt ancestry, and push immutable tag `v0.1.38` from trusted main
+- [x] merge PR #462 exact reviewed head `cbc14e007626328a8d25340419a455f40701426c` with true merge commit `e24d4db3f57fa0942376237fb212cb49368d7704`, prove PR-head and receipt ancestry, and push immutable tag `v0.1.38`
+- [x] confirm tag-triggered Release run `30152484521` failed closed during the full test gate before pack or publication
+- [ ] merge the reviewed trusted-main recovery fix and dispatch immutable-tag recovery without moving or recreating `v0.1.38`
 - [ ] verify npm, GitHub release assets, byte-identical tarballs, immutable tag provenance, and installed CLI behavior
 
 ### 7. Historical v0.1.28 release checklist

--- a/scripts/release-recovery-proof.mjs
+++ b/scripts/release-recovery-proof.mjs
@@ -2,8 +2,9 @@
 
 import { execFileSync } from 'child_process'
 import { createHash } from 'crypto'
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
-import { basename, dirname, resolve } from 'path'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { basename, dirname, join, resolve } from 'path'
 
 const MANIFEST_PATH = 'docs/proof-manifest.json'
 const PACKAGE_NAME = '@orchid-labs/pluxx'
@@ -12,7 +13,7 @@ const VALIDATION_TIMEOUT_MS = 20 * 60_000
 const PRE_PROOF_VALIDATIONS = [
   { command: 'npm run build', executable: 'npm', args: () => ['run', 'build'] },
   { command: 'npm run typecheck', executable: 'npm', args: () => ['run', 'typecheck'] },
-  { command: 'npm test', executable: 'npm', args: () => ['test'] },
+  { command: 'npm test', execute: (recovery) => runTaglessTests(recovery) },
   {
     command: 'node scripts/run-npm-pack.mjs --dry-run',
     executable: 'node',
@@ -213,6 +214,39 @@ function runPreProofValidations(args) {
     } catch {
       fail(`Recovery validation failed: ${validation.command}`)
     }
+  }
+}
+
+function runTaglessTests(args) {
+  const temporaryRoot = mkdtempSync(join(tmpdir(), 'pluxx-release-recovery-tests-'))
+  const checkout = join(temporaryRoot, 'release')
+  try {
+    execFileSync('git', ['clone', '--no-local', '--no-tags', args.releaseRoot, checkout], {
+      stdio: 'inherit',
+      timeout: GIT_TIMEOUT_MS,
+    })
+    const expectedHead = git(args.releaseRoot, 'rev-parse', 'HEAD^{commit}')
+    const actualHead = git(checkout, 'rev-parse', 'HEAD^{commit}')
+    if (actualHead !== expectedHead) {
+      fail(`Recovery test checkout ${actualHead} does not match release commit ${expectedHead}`)
+    }
+
+    const sourceNodeModules = resolve(args.releaseRoot, 'node_modules')
+    if (existsSync(sourceNodeModules)) {
+      symlinkSync(sourceNodeModules, resolve(checkout, 'node_modules'), 'dir')
+    }
+    execFileSync('npm', ['run', 'build'], {
+      cwd: checkout,
+      stdio: 'inherit',
+      timeout: VALIDATION_TIMEOUT_MS,
+    })
+    execFileSync('npm', ['test'], {
+      cwd: checkout,
+      stdio: 'inherit',
+      timeout: VALIDATION_TIMEOUT_MS,
+    })
+  } finally {
+    rmSync(temporaryRoot, { recursive: true, force: true })
   }
 }
 

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -2007,56 +2007,61 @@ describe('build', () => {
     }
 
     mkdirSync(resolve(TEST_DIR, 'agents'), { recursive: true })
-    await Bun.write(
-      resolve(TEST_DIR, 'agents/alias-agent.md'),
-      [
-        '---',
-        'name: alias-agent',
-        'description: "Alias normalization specialist."',
-        'model: "gpt-5.4"',
-        'effort: "high"',
-        'maxSteps: 7',
-        'top_p: 0.35',
-        '---',
-        '',
-        '# Alias Agent',
-        '',
-        'Validate that shared agent metadata aliases normalize cleanly.',
-        '',
-      ].join('\n'),
-    )
+    const aliasAgentPath = resolve(TEST_DIR, 'agents/alias-agent.md')
+    try {
+      await Bun.write(
+        aliasAgentPath,
+        [
+          '---',
+          'name: alias-agent',
+          'description: "Alias normalization specialist."',
+          'model: "gpt-5.4"',
+          'effort: "high"',
+          'maxSteps: 7',
+          'top_p: 0.35',
+          '---',
+          '',
+          '# Alias Agent',
+          '',
+          'Validate that shared agent metadata aliases normalize cleanly.',
+          '',
+        ].join('\n'),
+      )
 
-    await build(agentConfig, TEST_DIR)
+      await build(agentConfig, TEST_DIR)
 
-    const claudeAgent = readFileSync(
-      resolve(TEST_DIR, 'agent-metadata-aliases-dist/claude-code/agents/alias-agent.md'),
-      'utf-8',
-    )
-    const cursorAgent = readFileSync(
-      resolve(TEST_DIR, 'agent-metadata-aliases-dist/cursor/agents/alias-agent.md'),
-      'utf-8',
-    )
-    const codexAgent = readFileSync(
-      resolve(TEST_DIR, 'agent-metadata-aliases-dist/codex/.codex/agents/alias-agent.toml'),
-      'utf-8',
-    )
-    const opencodeIndex = readFileSync(
-      resolve(TEST_DIR, 'agent-metadata-aliases-dist/opencode/index.ts'),
-      'utf-8',
-    )
+      const claudeAgent = readFileSync(
+        resolve(TEST_DIR, 'agent-metadata-aliases-dist/claude-code/agents/alias-agent.md'),
+        'utf-8',
+      )
+      const cursorAgent = readFileSync(
+        resolve(TEST_DIR, 'agent-metadata-aliases-dist/cursor/agents/alias-agent.md'),
+        'utf-8',
+      )
+      const codexAgent = readFileSync(
+        resolve(TEST_DIR, 'agent-metadata-aliases-dist/codex/.codex/agents/alias-agent.toml'),
+        'utf-8',
+      )
+      const opencodeIndex = readFileSync(
+        resolve(TEST_DIR, 'agent-metadata-aliases-dist/opencode/index.ts'),
+        'utf-8',
+      )
 
-    expect(claudeAgent).toContain('effort: "high"')
-    expect(claudeAgent).toContain('maxTurns: 7')
-    expect(cursorAgent).toContain('Cursor translation note:')
-    expect(cursorAgent).toContain('"steps"')
-    expect(cursorAgent).toContain('"topP"')
-    expect(codexAgent).toContain('model_reasoning_effort = "high"')
-    expect(codexAgent).toContain('Host translation note:')
-    expect(codexAgent).toContain('"steps"')
-    expect(opencodeIndex).toContain('"alias-agent"')
-    expect(opencodeIndex).toContain('"steps": 7')
-    expect(opencodeIndex).toContain('"top_p": 0.35')
-    expect(opencodeIndex).not.toContain('"topP": 0.35')
+      expect(claudeAgent).toContain('effort: "high"')
+      expect(claudeAgent).toContain('maxTurns: 7')
+      expect(cursorAgent).toContain('Cursor translation note:')
+      expect(cursorAgent).toContain('"steps"')
+      expect(cursorAgent).toContain('"topP"')
+      expect(codexAgent).toContain('model_reasoning_effort = "high"')
+      expect(codexAgent).toContain('Host translation note:')
+      expect(codexAgent).toContain('"steps"')
+      expect(opencodeIndex).toContain('"alias-agent"')
+      expect(opencodeIndex).toContain('"steps": 7')
+      expect(opencodeIndex).toContain('"top_p": 0.35')
+      expect(opencodeIndex).not.toContain('"topP": 0.35')
+    } finally {
+      rmSync(aliasAgentPath, { force: true })
+    }
   })
 
   it('carries compiler-intent skill policies into the Codex permissions companion when present', async () => {

--- a/tests/release-recovery-proof.test.ts
+++ b/tests/release-recovery-proof.test.ts
@@ -61,9 +61,11 @@ function fixture(packageVersion = VERSION, manifestSuffix = '\n', proofPasses = 
     name: '@orchid-labs/pluxx',
     version: packageVersion,
     scripts: {
-      build: preProofPasses ? 'node -e "process.exit(0)"' : 'node -e "process.exit(1)"',
+      build: preProofPasses
+        ? 'node -e "require(\'fs\').mkdirSync(\'dist\', { recursive: true }); require(\'fs\').writeFileSync(\'dist/recovery-test-build\', \'ok\')"'
+        : 'node -e "process.exit(1)"',
       typecheck: 'node -e "process.exit(0)"',
-      test: 'node -e "process.exit(0)"',
+      test: `node -e "const { spawnSync } = require('child_process'); const { existsSync } = require('fs'); process.exit(spawnSync('git', ['show-ref', '--verify', '--quiet', 'refs/tags/${TAG}']).status === 0 || !existsSync('dist/recovery-test-build') ? 1 : 0)"`,
       'proof:check': 'node proof-check.mjs',
     },
   }
@@ -190,7 +192,7 @@ describe('immutable-tag release recovery proof', () => {
     const fixtureRoot = mkdtempSync(join(tmpdir(), 'pluxx-production-proof-'))
     const checkout = join(fixtureRoot, 'release')
     try {
-      expect(run('git', ['clone', '--no-local', ROOT, checkout], fixtureRoot).status).toBe(0)
+      expect(run('git', ['clone', '--no-local', '--no-tags', ROOT, checkout], fixtureRoot).status).toBe(0)
       expect(run('git', ['checkout', '--detach', 'HEAD'], checkout).status).toBe(0)
       expect(run('git', ['tag', TAG], checkout).status).toBe(0)
       symlinkSync(join(ROOT, 'node_modules'), join(checkout, 'node_modules'), 'dir')


### PR DESCRIPTION
## Summary

- keep immutable `v0.1.38` fixed at trusted merge `e24d4db3f57fa0942376237fb212cb49368d7704`
- make the production proof-checker fixture independent of existing repository tags
- run recovery tests from a tagless exact-commit clone, rebuilding that source before testing
- clean an order-dependent shared build-test fixture leak
- record that the first tag run failed closed before pack or publication

## Why

Release run `30152484521` failed during the full test gate because a fixture inherited the newly created `v0.1.38` tag and tried to create it again. No package was packed or published. Recovery must validate the exact immutable release tree without moving or recreating the tag.

## Recovery contract

- dispatch only from the exact trusted `main` commit after this PR merges
- use the existing `v0.1.38` tag unchanged
- fail closed on main/tag drift, test failure, proof mismatch, or artifact mismatch
- publish only through the documented GitHub recovery workflow

## Validation

- fail-first reproduced tag collision: status 128 after the real tag existed
- focused build/recovery/workflow/proof suites: 83/83 passed
- `npm run release:check`: 62 files, 816 tests, packed Node runtime, npm dry-run passed
- correctness and adversarial re-review: zero current findings
- adversarial exact-tag rehearsal: tagless `e24d4db` clone built and release-smoke passed 10/10

## Related

- PLUXX-340
- #461
- #462
- failed-closed run: https://github.com/orchidautomation/pluxx/actions/runs/30152484521

## Post-merge monitoring

After an exact-head green merge, dispatch `Release` with `release_tag=v0.1.38`, monitor it to completion, then independently compare npm and GitHub tarballs, tag provenance, and installed CLI behavior.

---

Built with [Compound Engineering](https://every.to/source-code/compound-engineering-how-every-codes-with-agents)
