### PR TITLE
Release Pluxx 0.1.39 with quiet OpenCode hook scope

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
       release_tag:
         description: Existing release tag to recover from the trusted main workflow
         required: true
-        default: v0.1.38
+        default: v0.1.39
         type: string
 
 permissions:

--- a/docs/orchid/plans/2026-08-05-pluxx-343-release-0.1.39.md
+++ b/docs/orchid/plans/2026-08-05-pluxx-343-release-0.1.39.md
@@ -1,0 +1,30 @@
+---
+title: PLUXX-343 Pluxx v0.1.39 Release
+date: 2026-08-05
+linear_issue: PLUXX-343
+status: in-progress
+---
+
+# PLUXX-343 Pluxx v0.1.39 Release
+
+Release and independently verify Pluxx 0.1.39 from trusted `origin/main` commit `a750c593f1fb694a71aa60365ae6f8792e51a246`, which contains merged PR #468 and its reviewed PLUXX-341/PLUXX-342 OpenCode hook-scope repair.
+
+## Scope
+
+- Synchronize package, lockfile, recovery default, proof manifest, and canonical planning truth at 0.1.39.
+- Bind fresh repository-validation and fake-home-install receipts to an exact reachable release-prep commit.
+- Require `npm run release:check`, independent review, green CI, and a true merge commit.
+- Create immutable tag `v0.1.39` only from trusted current `main`; never publish locally.
+- Verify npm, GitHub release assets, tag provenance, and an isolated registry-installed CLI.
+
+## Release contract
+
+The public release remains 0.1.38 until the trusted tag workflow succeeds. Historical 0.1.38 evidence is retained and cannot be reused as current 0.1.39 proof. If the tag-triggered workflow fails before publication, the tag must not move; recovery follows the documented trusted-main dispatch path.
+
+## Completion evidence
+
+- release-prep commit and receipt commit are ancestors of the reviewed release PR head and trusted merge;
+- `v0.1.39` resolves to the trusted merge commit;
+- the Release workflow publishes with npm provenance and creates the GitHub release asset;
+- registry and GitHub artifacts resolve to the same release identity;
+- an isolated install reports CLI version `0.1.39`.

--- a/docs/orchid/reviews/2026-08-05-pluxx-343-release-0.1.39-review.md
+++ b/docs/orchid/reviews/2026-08-05-pluxx-343-release-0.1.39-review.md
@@ -1,0 +1,30 @@
+# PLUXX-343 Pluxx 0.1.39 Release Review
+
+Date: 2026-08-05
+
+## Scope
+
+- Release: `@orchid-labs/pluxx@0.1.39` / pending `v0.1.39`
+- Source implementation: PR #468, true merge `a750c593f1fb694a71aa60365ae6f8792e51a246`
+- Release-prep proof anchor: `6ffb6337b351c5a87b985394f0c011d2c271a940`
+- Receipt commit: `13ba602`
+
+## Validation
+
+- `npm run release:check` passed against the exact release-prep anchor with 62 test files and 828 tests.
+- Isolated packed Node runtime verification passed for `@orchid-labs/pluxx@0.1.39`.
+- npm dry-run packaging passed.
+- Proof freshness passed with 22 current/historical claims and 22 receipts after receipt binding.
+- Focused release workflow, recovery, and proof suites passed with 32 tests after review remediation.
+
+## Review outcome
+
+Correctness, project-standards, testing, and adversarial release lenses reviewed the branch diff. The independent cross-model route was not used because this workspace requires Codex-only review; the adversarial lens ran in-process.
+
+The review found one P1 false-green test risk: the recovery workflow default and its test both hard-coded the same tag, so a future version bump could leave both stale while the suite passed. Commit `f9eea16` derives the expected recovery tag from `package.json`; an independent validator confirmed the finding and the focused release suites passed after the fix.
+
+No unresolved review findings remain. Tag creation, trusted-main ancestry, npm/GitHub publication, and isolated registry-install verification remain post-merge release gates.
+
+## Merge contract
+
+Use a true merge commit. Before tagging, prove `6ffb6337b351c5a87b985394f0c011d2c271a940`, `13ba602`, and the final reviewed PR head are ancestors of exact current `origin/main`. Create `v0.1.39` once at that trusted merge commit and publish only through the tag-triggered GitHub workflow.

--- a/docs/orchid/reviews/2026-08-05-pluxx-343-release-0.1.39-review.md
+++ b/docs/orchid/reviews/2026-08-05-pluxx-343-release-0.1.39-review.md
@@ -7,7 +7,7 @@ Date: 2026-08-05
 - Release: `@orchid-labs/pluxx@0.1.39` / pending `v0.1.39`
 - Source implementation: PR #468, true merge `a750c593f1fb694a71aa60365ae6f8792e51a246`
 - Release-prep proof anchor: `6ffb6337b351c5a87b985394f0c011d2c271a940`
-- Receipt commit: `13ba602`
+- Receipt commit: `13ba60274f8b6b17cd73ae1ba8d40038f25b6c76`
 
 ## Validation
 
@@ -21,10 +21,10 @@ Date: 2026-08-05
 
 Correctness, project-standards, testing, and adversarial release lenses reviewed the branch diff. The independent cross-model route was not used because this workspace requires Codex-only review; the adversarial lens ran in-process.
 
-The review found one P1 false-green test risk: the recovery workflow default and its test both hard-coded the same tag, so a future version bump could leave both stale while the suite passed. Commit `f9eea16` derives the expected recovery tag from `package.json`; an independent validator confirmed the finding and the focused release suites passed after the fix.
+The review found one P1 false-green test risk: the recovery workflow default and its test both hard-coded the same tag, so a future version bump could leave both stale while the suite passed. Commit `f9eea1673413014be2274375d374d1be0388a507` derives the expected recovery tag from `package.json`; an independent validator confirmed the finding and the focused release suites passed after the fix.
 
 No unresolved review findings remain. Tag creation, trusted-main ancestry, npm/GitHub publication, and isolated registry-install verification remain post-merge release gates.
 
 ## Merge contract
 
-Use a true merge commit. Before tagging, prove `6ffb6337b351c5a87b985394f0c011d2c271a940`, `13ba602`, and the final reviewed PR head are ancestors of exact current `origin/main`. Create `v0.1.39` once at that trusted merge commit and publish only through the tag-triggered GitHub workflow.
+Use a true merge commit. Before tagging, prove `6ffb6337b351c5a87b985394f0c011d2c271a940`, `13ba60274f8b6b17cd73ae1ba8d40038f25b6c76`, and the final reviewed PR head are ancestors of exact current `origin/main`. Create `v0.1.39` once at that trusted merge commit and publish only through the tag-triggered GitHub workflow.

--- a/docs/proof-and-install.md
+++ b/docs/proof-and-install.md
@@ -32,7 +32,7 @@ For the fuller release/distribution boundary, including publish commands and def
 
 Proof labels and freshness come from [proof-freshness.md](./proof-freshness.md) and [proof-manifest.json](./proof-manifest.json). The May self-hosted run, April Firecrawl connector run, and shipped 0.1.37 and 0.1.38 evidence remain historical relative to pending repository version `0.1.39`.
 
-Historical 0.1.38 proof covers only the PLUXX-340 manifest-identity correction. Pending 0.1.39 release-prep covers only the merged PLUXX-341/PLUXX-342 quiet OpenCode hook-scope repair; fresh receipts are added only after the exact release-prep commit passes `npm run release:check`.
+Historical 0.1.38 proof covers only the PLUXX-340 manifest-identity correction. Pending 0.1.39 release-prep covers only the merged PLUXX-341/PLUXX-342 quiet OpenCode hook-scope repair. Fresh receipts `v0.1.39-repository-validation` and `v0.1.39-fake-home-install` bind to exact release-prep commit `6ffb6337b351c5a87b985394f0c011d2c271a940`, where the complete release gate passed on 2026-08-05.
 
 ## The Story In One Screen
 

--- a/docs/proof-and-install.md
+++ b/docs/proof-and-install.md
@@ -1,6 +1,6 @@
 # Proof And Install
 
-Last updated: 2026-07-25
+Last updated: 2026-08-05
 
 ## Doc Links
 
@@ -30,9 +30,9 @@ This is the shortest current repo-native path to:
 
 For the fuller release/distribution boundary, including publish commands and deferred marketplace/trust-layer work, use [docs/release-distribution-proof-map.md](./release-distribution-proof-map.md).
 
-Proof labels and freshness come from [proof-freshness.md](./proof-freshness.md) and [proof-manifest.json](./proof-manifest.json). The May self-hosted run, April Firecrawl connector run, and shipped 0.1.37 evidence remain historical relative to tagged repository version `0.1.38`.
+Proof labels and freshness come from [proof-freshness.md](./proof-freshness.md) and [proof-manifest.json](./proof-manifest.json). The May self-hosted run, April Firecrawl connector run, and shipped 0.1.37 and 0.1.38 evidence remain historical relative to pending repository version `0.1.39`.
 
-The 0.1.38 proof covers only the PLUXX-340 manifest-identity correction: one manifest archive record per host while versioned and `latest` assets remain produced and checksummed. Fresh receipts `v0.1.38-repository-validation` and `v0.1.38-fake-home-install` bind to exact release-prep commit `361958f6b16b1acc2bb901c97fc2c6d5a77ba880`, which is contained by reviewed PR head `cbc14e007626328a8d25340419a455f40701426c` and trusted merge/tag commit `e24d4db3f57fa0942376237fb212cb49368d7704`. After the first Release run failed closed before pack or publication, recovery PR #463 merged unchanged head `4024ca07fe9cc78b98e93bb0931b8d91ddc36f0f` as trusted main `a67803184890795457d095da52f4a243d61daf2a`. Recovery run [30154432818](https://github.com/orchidautomation/pluxx/actions/runs/30154432818) published and verified byte-identical npm and GitHub artifacts at SHA-256 `34af5bd24a441f13094b651658d6728509771a8cb9295f82b1bc66a985cb2c24` without moving the immutable tag.
+Historical 0.1.38 proof covers only the PLUXX-340 manifest-identity correction. Pending 0.1.39 release-prep covers only the merged PLUXX-341/PLUXX-342 quiet OpenCode hook-scope repair; fresh receipts are added only after the exact release-prep commit passes `npm run release:check`.
 
 ## The Story In One Screen
 

--- a/docs/proof-freshness.md
+++ b/docs/proof-freshness.md
@@ -1,10 +1,10 @@
 # Proof Freshness And Evidence Tiers
 
-Last updated: 2026-07-25
+Last updated: 2026-08-05
 
 This document defines how Pluxx distinguishes repeatable repository checks from installed and real-host evidence. The machine-readable source is [proof-manifest.json](./proof-manifest.json), validated by `npm run proof:check`.
 
-Immutable tag `v0.1.38` records only the PLUXX-340 follow-up for duplicate release-manifest archive identities discovered after 0.1.37 shipped. The shipped and independently verified `v0.1.37` receipts remain historical evidence. Fresh current receipts `v0.1.38-repository-validation` and `v0.1.38-fake-home-install` bind to exact release-prep commit `361958f6b16b1acc2bb901c97fc2c6d5a77ba880`, where `npm run release:check` passed on 2026-07-25. Recovery run [30154432818](https://github.com/orchidautomation/pluxx/actions/runs/30154432818) independently revalidated the immutable tag tree and published byte-identical npm and GitHub artifacts at SHA-256 `34af5bd24a441f13094b651658d6728509771a8cb9295f82b1bc66a985cb2c24`. No current receipt claims installed-runtime or real-host behavior.
+The repository is preparing `v0.1.39` for the PLUXX-341/PLUXX-342 quiet OpenCode hook-scope repair merged through PR #468. The shipped and independently verified `v0.1.38` receipts remain historical evidence; fresh current 0.1.39 repository-validation and fake-home-install receipts are recorded only after the exact release-prep commit passes their named gates. No current receipt claims installed-runtime or real-host behavior.
 
 ## Version And Freshness Policy
 

--- a/docs/proof-freshness.md
+++ b/docs/proof-freshness.md
@@ -4,7 +4,7 @@ Last updated: 2026-08-05
 
 This document defines how Pluxx distinguishes repeatable repository checks from installed and real-host evidence. The machine-readable source is [proof-manifest.json](./proof-manifest.json), validated by `npm run proof:check`.
 
-The repository is preparing `v0.1.39` for the PLUXX-341/PLUXX-342 quiet OpenCode hook-scope repair merged through PR #468. The shipped and independently verified `v0.1.38` receipts remain historical evidence; fresh current 0.1.39 repository-validation and fake-home-install receipts are recorded only after the exact release-prep commit passes their named gates. No current receipt claims installed-runtime or real-host behavior.
+The repository is preparing `v0.1.39` for the PLUXX-341/PLUXX-342 quiet OpenCode hook-scope repair merged through PR #468. The shipped and independently verified `v0.1.38` receipts remain historical evidence. Fresh current receipts `v0.1.39-repository-validation` and `v0.1.39-fake-home-install` bind to exact release-prep commit `6ffb6337b351c5a87b985394f0c011d2c271a940`, where `npm run release:check` passed on 2026-08-05 with 62 test files and 828 tests plus isolated packed-runtime and dry-pack verification. No current receipt claims installed-runtime or real-host behavior.
 
 ## Version And Freshness Policy
 

--- a/docs/proof-manifest.json
+++ b/docs/proof-manifest.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
-  "canonicalVersion": "0.1.38",
-  "expectedTag": "v0.1.38",
-  "releaseState": "released",
+  "canonicalVersion": "0.1.39",
+  "expectedTag": "v0.1.39",
+  "releaseState": "release-prep",
   "policy": {
     "environmentReceiptMaxAgeDays": 30
   },
@@ -153,17 +153,17 @@
     },
     {
       "id": "v0.1.38-repository-validation",
-      "summary": "The exact v0.1.38 release-prep commit passes the complete repository release gate for the PLUXX-340 manifest-identity correction.",
+      "summary": "The shipped and independently verified v0.1.38 release remains historical proof for PLUXX-340.",
       "tier": "bundle-contract",
-      "freshness": "current",
+      "freshness": "historical",
       "evidencePath": "tests/proof-freshness.test.ts",
       "receiptId": "v0.1.38-repository-validation"
     },
     {
       "id": "v0.1.38-fake-home-install",
-      "summary": "The exact v0.1.38 release-prep commit passes maintained core-four isolated install coverage for the PLUXX-340 manifest-identity correction.",
+      "summary": "The shipped and independently verified v0.1.38 release remains historical maintained core-four isolated install proof.",
       "tier": "fake-home-install",
-      "freshness": "current",
+      "freshness": "historical",
       "evidencePath": "tests/release-smoke.test.ts",
       "receiptId": "v0.1.38-fake-home-install"
     }
@@ -624,7 +624,7 @@
     {
       "id": "v0.1.38-repository-validation",
       "tier": "bundle-contract",
-      "freshness": "current",
+      "freshness": "historical",
       "commitSha": "361958f6b16b1acc2bb901c97fc2c6d5a77ba880",
       "packageVersion": "0.1.38",
       "timestamp": "2026-07-25T08:28:31.000Z",
@@ -647,7 +647,7 @@
     {
       "id": "v0.1.38-fake-home-install",
       "tier": "fake-home-install",
-      "freshness": "current",
+      "freshness": "historical",
       "commitSha": "361958f6b16b1acc2bb901c97fc2c6d5a77ba880",
       "packageVersion": "0.1.38",
       "timestamp": "2026-07-25T08:28:31.000Z",

--- a/docs/proof-manifest.json
+++ b/docs/proof-manifest.json
@@ -166,6 +166,22 @@
       "freshness": "historical",
       "evidencePath": "tests/release-smoke.test.ts",
       "receiptId": "v0.1.38-fake-home-install"
+    },
+    {
+      "id": "v0.1.39-repository-validation",
+      "summary": "The exact v0.1.39 release-prep commit passes the complete repository release gate for the PLUXX-341/PLUXX-342 quiet OpenCode hook-scope repair.",
+      "tier": "bundle-contract",
+      "freshness": "current",
+      "evidencePath": "tests/proof-freshness.test.ts",
+      "receiptId": "v0.1.39-repository-validation"
+    },
+    {
+      "id": "v0.1.39-fake-home-install",
+      "summary": "The exact v0.1.39 release-prep commit passes maintained core-four isolated install coverage for the PLUXX-341/PLUXX-342 quiet OpenCode hook-scope repair.",
+      "tier": "fake-home-install",
+      "freshness": "current",
+      "evidencePath": "tests/release-smoke.test.ts",
+      "receiptId": "v0.1.39-fake-home-install"
     }
   ],
   "receipts": [
@@ -651,6 +667,52 @@
       "commitSha": "361958f6b16b1acc2bb901c97fc2c6d5a77ba880",
       "packageVersion": "0.1.38",
       "timestamp": "2026-07-25T08:28:31.000Z",
+      "commands": [
+        {
+          "command": "npm run release:check",
+          "outcome": "passed"
+        }
+      ],
+      "targets": [
+        {
+          "target": "claude-code,cursor,codex,opencode",
+          "hostVersion": null,
+          "installedPath": null,
+          "sha256": null,
+          "outcome": "passed"
+        }
+      ]
+    },
+    {
+      "id": "v0.1.39-repository-validation",
+      "tier": "bundle-contract",
+      "freshness": "current",
+      "commitSha": "6ffb6337b351c5a87b985394f0c011d2c271a940",
+      "packageVersion": "0.1.39",
+      "timestamp": "2026-08-05T15:23:51.000Z",
+      "commands": [
+        {
+          "command": "npm run release:check",
+          "outcome": "passed"
+        }
+      ],
+      "targets": [
+        {
+          "target": "repository",
+          "hostVersion": null,
+          "installedPath": null,
+          "sha256": null,
+          "outcome": "passed"
+        }
+      ]
+    },
+    {
+      "id": "v0.1.39-fake-home-install",
+      "tier": "fake-home-install",
+      "freshness": "current",
+      "commitSha": "6ffb6337b351c5a87b985394f0c011d2c271a940",
+      "packageVersion": "0.1.39",
+      "timestamp": "2026-08-05T15:23:51.000Z",
       "commands": [
         {
           "command": "npm run release:check",

--- a/docs/proof-receipts/v0.1.39-fake-home-install.json
+++ b/docs/proof-receipts/v0.1.39-fake-home-install.json
@@ -1,0 +1,23 @@
+{
+  "id": "v0.1.39-fake-home-install",
+  "tier": "fake-home-install",
+  "freshness": "current",
+  "commitSha": "6ffb6337b351c5a87b985394f0c011d2c271a940",
+  "packageVersion": "0.1.39",
+  "timestamp": "2026-08-05T15:23:51.000Z",
+  "commands": [
+    {
+      "command": "npm run release:check",
+      "outcome": "passed"
+    }
+  ],
+  "targets": [
+    {
+      "target": "claude-code,cursor,codex,opencode",
+      "hostVersion": null,
+      "installedPath": null,
+      "sha256": null,
+      "outcome": "passed"
+    }
+  ]
+}

--- a/docs/proof-receipts/v0.1.39-repository-validation.json
+++ b/docs/proof-receipts/v0.1.39-repository-validation.json
@@ -1,0 +1,23 @@
+{
+  "id": "v0.1.39-repository-validation",
+  "tier": "bundle-contract",
+  "freshness": "current",
+  "commitSha": "6ffb6337b351c5a87b985394f0c011d2c271a940",
+  "packageVersion": "0.1.39",
+  "timestamp": "2026-08-05T15:23:51.000Z",
+  "commands": [
+    {
+      "command": "npm run release:check",
+      "outcome": "passed"
+    }
+  ],
+  "targets": [
+    {
+      "target": "repository",
+      "hostVersion": null,
+      "installedPath": null,
+      "sha256": null,
+      "outcome": "passed"
+    }
+  ]
+}

--- a/docs/releasing-pluxx.md
+++ b/docs/releasing-pluxx.md
@@ -80,7 +80,7 @@ git merge-base --is-ancestor <exact-pr-head> <trusted-main-commit>
 git merge-base --is-ancestor <current-receipt-commit> <trusted-main-commit>
 ```
 
-If the trusted release workflow fails before publication for a recoverable infrastructure or proof-topology reason, do not move or recreate the tag and do not publish locally. Merge a reviewed workflow fix to `main`, then dispatch `Release` from exact current `main` with the existing tag. The default recovery input is currently `v0.1.38`.
+If the trusted release workflow fails before publication for a recoverable infrastructure or proof-topology reason, do not move or recreate the tag and do not publish locally. Merge a reviewed workflow fix to `main`, then dispatch `Release` from exact current `main` with the existing tag. The default recovery input is currently `v0.1.39`.
 
 You can use `patch`, `minor`, or `major` depending on the release.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Last updated: 2026-07-25
+Last updated: 2026-08-05
 
 ## Doc Links
 
@@ -85,6 +85,8 @@ Proof governance now distinguishes unit, bundle-contract, fake-home install, ins
 PLUXX-339 is shipped in the verified public `0.1.37` release after the historical `0.1.36` OpenCode workspace patch. The security patch blocks bundled runtime scripts from sourcing workspace `.env` files through direct and statically evaluable shell forms while preserving valid safe shell syntax.
 
 PLUXX-340 is the separately shipped and independently verified `0.1.38` follow-up for duplicate release-manifest archive identities discovered after the historical shipped 0.1.37 release. It preserves both versioned and `latest` physical assets while exposing one deterministic manifest identity per host. Recovery run [30154432818](https://github.com/orchidautomation/pluxx/actions/runs/30154432818) published byte-identical npm and GitHub artifacts without moving the immutable tag.
+
+PLUXX-341/PLUXX-342 is merged through PR #468 and pending `0.1.39` release. It keeps generated OpenCode hook matchers scoped, normalizes supported tool alternatives consistently, and makes doctor fail closed on malformed or unscoped plans while preserving quiet health behavior.
 
 ### 1. Product clarity and source-of-truth coherence
 
@@ -391,11 +393,12 @@ This is for learning and proof, not for prematurely building the full trust laye
 
 ### 6. Next release
 
-The canonical and verified public release is `@orchid-labs/pluxx@0.1.38` for PLUXX-340. Immutable tag `v0.1.38` points to trusted merge `e24d4db3f57fa0942376237fb212cb49368d7704`; reviewed recovery run [30154432818](https://github.com/orchidautomation/pluxx/actions/runs/30154432818) published byte-identical npm and GitHub artifacts at SHA-256 `34af5bd24a441f13094b651658d6728509771a8cb9295f82b1bc66a985cb2c24`.
+The canonical repository version is pending `0.1.39` release-prep for PLUXX-341/PLUXX-342. The canonical and verified public release remains `@orchid-labs/pluxx@0.1.38` for PLUXX-340 at immutable trusted merge `e24d4db3f57fa0942376237fb212cb49368d7704`.
 
 The next npm cut should stay primarily an operations step rather than a code-confidence rescue step.
 
 - preserve completed 0.1.38 recovery evidence: tag commit `e24d4db3f57fa0942376237fb212cb49368d7704`, tree `8d876bac5753d0dab019f573b4f3bf806bddaa04`, trusted recovery main `a67803184890795457d095da52f4a243d61daf2a`, and tarball SHA-256 `34af5bd24a441f13094b651658d6728509771a8cb9295f82b1bc66a985cb2c24`
+- release and independently verify 0.1.39 as the focused PLUXX-341/PLUXX-342 quiet OpenCode hook-scope repair
 - preserve the completed 0.1.37 immutable-tag recovery evidence: tag commit `d5184752cd4898306390f20455619c34a42099dd`, tree `e63eea0f89995a44b7536b5403af57792e994cb9`, trusted main `044673f947115bcf6117dd7c0139918bdd248a99`, and tarball SHA-256 `7c996da682887ceedecc006307c207c5a834e5dedabaab17611cd586ef85b237`
 - refresh installed-runtime or real-host receipts separately before making broader current host claims
 - use future focused release PRs and trusted tag workflows for the next package cut

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -1,6 +1,6 @@
 # Start Here
 
-Last updated: 2026-07-25
+Last updated: 2026-08-05
 
 ## Doc Links
 
@@ -39,7 +39,7 @@ If you want the shortest public proof and install path after this file, use [doc
 
 If you want the current release, distribution, and proof boundary, use [docs/release-distribution-proof-map.md](./release-distribution-proof-map.md).
 
-If you need to know whether a proof claim is current, historical, repository-only, installed, or real-host evidence, use [docs/proof-freshness.md](./proof-freshness.md) and [docs/proof-manifest.json](./proof-manifest.json). Canonical repository and independently verified public release truth is `@orchid-labs/pluxx@0.1.38`, tagged only for the PLUXX-340 manifest-identity correction at trusted merge `e24d4db3f57fa0942376237fb212cb49368d7704`. Recovery run [30154432818](https://github.com/orchidautomation/pluxx/actions/runs/30154432818) published byte-identical npm and GitHub artifacts at SHA-256 `34af5bd24a441f13094b651658d6728509771a8cb9295f82b1bc66a985cb2c24`.
+If you need to know whether a proof claim is current, historical, repository-only, installed, or real-host evidence, use [docs/proof-freshness.md](./proof-freshness.md) and [docs/proof-manifest.json](./proof-manifest.json). Canonical repository version truth is `package.json` (`0.1.39`), currently in release-prep for the PLUXX-341/PLUXX-342 quiet OpenCode hook-scope repair. The independently verified public release remains `@orchid-labs/pluxx@0.1.38`.
 
 If you want the primitive-by-host proof ledger behind the core-four native shipping claim, use [docs/core-four-primitive-proof-ledger.md](./core-four-primitive-proof-ledger.md).
 
@@ -370,6 +370,7 @@ The repo already proves a lot.
   - `npm test` passed
   - `npm run release:check` passed
 - the canonical and verified public release is `@orchid-labs/pluxx@0.1.38` / `v0.1.38`; npm and GitHub serve the same tarball at SHA-256 `34af5bd24a441f13094b651658d6728509771a8cb9295f82b1bc66a985cb2c24`
+- the repository is preparing `0.1.39` only for the merged PLUXX-341/PLUXX-342 OpenCode hook matcher-scope and quiet-health repair
 - immutable tag `v0.1.38` records only the follow-up PLUXX-340 correction for duplicate release-manifest archive identities discovered after the historical shipped 0.1.37 release
 - marketplace submission APIs, a managed trust/distribution control plane, automatic rollback/unpublish orchestration, and real authenticated publish plus rollback proof remain explicit release gaps, not hidden shipped capabilities:
   - `docs/release-distribution-proof-map.md`
@@ -540,11 +541,13 @@ Run two lanes in parallel:
 
 ### 6. Release State
 
-The canonical and verified public release is `@orchid-labs/pluxx@0.1.38`, only for the PLUXX-340 manifest-identity correction. Immutable tag `v0.1.38` points to trusted merge `e24d4db3f57fa0942376237fb212cb49368d7704`, which contains exact reviewed PR head `cbc14e007626328a8d25340419a455f40701426c` and receipt commit `361958f6b16b1acc2bb901c97fc2c6d5a77ba880`. Recovery PR #463 merged exact head `4024ca07fe9cc78b98e93bb0931b8d91ddc36f0f` as trusted main `a67803184890795457d095da52f4a243d61daf2a`; run [30154432818](https://github.com/orchidautomation/pluxx/actions/runs/30154432818) then published and verified the byte-identical npm/GitHub artifact at SHA-256 `34af5bd24a441f13094b651658d6728509771a8cb9295f82b1bc66a985cb2c24` without moving the tag.
+The canonical repository version is pending `0.1.39` release-prep for the PLUXX-341/PLUXX-342 quiet OpenCode hook-scope repair. The canonical and verified public release remains `@orchid-labs/pluxx@0.1.38`; immutable tag `v0.1.38` remains at trusted merge `e24d4db3f57fa0942376237fb212cb49368d7704`.
 
 For v0.1.37, PLUXX-339 is the tagged security focus: lint, doctor, install, and packaged-runtime verification fail closed when bundled runtime scripts source workspace `.env` files through direct or statically evaluable shell forms. The patch preserves valid safe shell forms and uses a bounded explicit scanner rather than an expanding regex.
 
-For tagged v0.1.38, PLUXX-340 is the only release focus: one unambiguous release-manifest archive identity per host while versioned and `latest` physical assets remain generated and checksummed.
+For historical tagged v0.1.38, PLUXX-340 is the only release focus: one unambiguous release-manifest archive identity per host while versioned and `latest` physical assets remain generated and checksummed.
+
+For pending v0.1.39, PLUXX-341/PLUXX-342 is the only release focus: OpenCode hooks keep matcher scope, normalize supported tool alternatives consistently, and doctor fails closed on malformed or unscoped plans without emitting noisy health output.
 
 ## Working Rules
 

--- a/docs/todo/master-backlog.md
+++ b/docs/todo/master-backlog.md
@@ -134,9 +134,9 @@ Proof governance is now explicit: [proof-freshness.md](../proof-freshness.md) de
 ### 0. v0.1.39 quiet OpenCode hook scope
 
 - [x] Merge PR #468 exact reviewed head `e4c11db` as true merge commit `a750c593f1fb694a71aa60365ae6f8792e51a246`
-- [~] Prepare synchronized 0.1.39 package, proof, planning, recovery-default, and release truth
-- [ ] Bind fresh repository-validation and fake-home-install receipts to the exact release-prep commit
-- [ ] Pass focused and full release gates plus independent review
+- [x] Prepare synchronized 0.1.39 package, proof, planning, recovery-default, and release truth
+- [x] Bind fresh repository-validation and fake-home-install receipts to exact release-prep commit `6ffb6337b351c5a87b985394f0c011d2c271a940`
+- [~] Pass focused and full release gates plus independent review; full local gate passed with 62 files and 828 tests
 - [ ] Merge the exact green release PR with a true merge commit and push immutable tag `v0.1.39`
 - [ ] Verify npm, GitHub release assets, immutable tag provenance, and isolated installed CLI `0.1.39`
 

--- a/docs/todo/master-backlog.md
+++ b/docs/todo/master-backlog.md
@@ -109,7 +109,7 @@ Proof governance is now explicit: [proof-freshness.md](../proof-freshness.md) de
 - [x] Push immutable tag `v0.1.36` from main
 - [x] Verify `@orchid-labs/pluxx@0.1.36`, GitHub release assets, tarball contents, and CLI behavior
 
-### 0. v0.1.37 runtime env-sourcing security patch release
+### 0. Historical v0.1.37 runtime env-sourcing security patch release
 
 - [x] Merge PLUXX-339 through PR #456 at exact reviewed head `b888c62dc7905fd66c9fdf50c4e752984fee5b48`
 - [x] Historical: prepare synchronized 0.1.37 package, proof, planning, and release truth

--- a/docs/todo/master-backlog.md
+++ b/docs/todo/master-backlog.md
@@ -136,7 +136,7 @@ Proof governance is now explicit: [proof-freshness.md](../proof-freshness.md) de
 - [x] Merge PR #468 exact reviewed head `e4c11db` as true merge commit `a750c593f1fb694a71aa60365ae6f8792e51a246`
 - [x] Prepare synchronized 0.1.39 package, proof, planning, recovery-default, and release truth
 - [x] Bind fresh repository-validation and fake-home-install receipts to exact release-prep commit `6ffb6337b351c5a87b985394f0c011d2c271a940`
-- [~] Pass focused and full release gates plus independent review; full local gate passed with 62 files and 828 tests
+- [x] Pass focused and full release gates plus independent review; review record: [2026-08-05-pluxx-343-release-0.1.39-review.md](../orchid/reviews/2026-08-05-pluxx-343-release-0.1.39-review.md)
 - [ ] Merge the exact green release PR with a true merge commit and push immutable tag `v0.1.39`
 - [ ] Verify npm, GitHub release assets, immutable tag provenance, and isolated installed CLI `0.1.39`
 

--- a/docs/todo/master-backlog.md
+++ b/docs/todo/master-backlog.md
@@ -1,6 +1,6 @@
 # Master Backlog
 
-Last updated: 2026-07-25
+Last updated: 2026-08-05
 
 This is the most complete repo-native backlog for Pluxx.
 
@@ -120,16 +120,25 @@ Proof governance is now explicit: [proof-freshness.md](../proof-freshness.md) de
 - [x] Merge recovery PR #458 at exact reviewed head `5f8a0d58786a7aae4e495bf7dbc484cbc12b348f` and dispatch the fail-closed immutable-tag recovery from trusted-main commit `044673f947115bcf6117dd7c0139918bdd248a99`
 - [x] Verify `@orchid-labs/pluxx@0.1.37`, GitHub release assets and recovery receipt, byte-identical npm/GitHub tarballs, immutable tag/tree identity, and installed CLI behavior
 
-### 0. v0.1.38 PLUXX-340 manifest-identity correction
+### 0. Historical v0.1.38 PLUXX-340 manifest-identity correction
 
 - [x] Merge PR #461 exact reviewed head `b839f6d93ec1174c4da5dcfb1554c7c6f8f294d5` as trusted main commit `b979bc6e02bb9801fa623f80302000553a0693c7`
-- [x] Prepare synchronized 0.1.38 package, proof, planning, recovery-default, and release truth
+- [x] Historical: prepare synchronized 0.1.38 package, proof, planning, recovery-default, and release truth
 - [x] Bind fresh repository-validation and fake-home-install receipts to exact immutable release-prep commit `361958f6b16b1acc2bb901c97fc2c6d5a77ba880`
 - [x] Pass focused and full release gates plus independent review; review record: [2026-07-25-pluxx-340-release-0.1.38-review.md](../orchid/reviews/2026-07-25-pluxx-340-release-0.1.38-review.md)
 - [x] Merge PR #462 exact reviewed head `cbc14e007626328a8d25340419a455f40701426c` with true merge commit `e24d4db3f57fa0942376237fb212cb49368d7704`, prove PR-head and receipt ancestry, and push immutable tag `v0.1.38`
 - [x] Confirm tag-triggered Release run `30152484521` failed closed during the full test gate before pack or publication
 - [x] Merge recovery PR #463 exact head `4024ca07fe9cc78b98e93bb0931b8d91ddc36f0f` as trusted main `a67803184890795457d095da52f4a243d61daf2a`, then dispatch run `30154432818` without moving or recreating `v0.1.38`
 - [x] Verify npm, GitHub release assets and recovery receipt, byte-identical tarballs at SHA-256 `34af5bd24a441f13094b651658d6728509771a8cb9295f82b1bc66a985cb2c24`, immutable tag provenance, and isolated installed CLI `0.1.38`
+
+### 0. v0.1.39 quiet OpenCode hook scope
+
+- [x] Merge PR #468 exact reviewed head `e4c11db` as true merge commit `a750c593f1fb694a71aa60365ae6f8792e51a246`
+- [~] Prepare synchronized 0.1.39 package, proof, planning, recovery-default, and release truth
+- [ ] Bind fresh repository-validation and fake-home-install receipts to the exact release-prep commit
+- [ ] Pass focused and full release gates plus independent review
+- [ ] Merge the exact green release PR with a true merge commit and push immutable tag `v0.1.39`
+- [ ] Verify npm, GitHub release assets, immutable tag provenance, and isolated installed CLI `0.1.39`
 
 ### 1. Product clarity and front-door coherence
 

--- a/docs/todo/queue.md
+++ b/docs/todo/queue.md
@@ -1,6 +1,6 @@
 # Pluxx Queue
 
-Last updated: 2026-07-25
+Last updated: 2026-08-05
 
 ## Doc Links
 
@@ -189,6 +189,7 @@ The public baseline is also real.
 
 - npm package is live as `@orchid-labs/pluxx`
 - the canonical and verified public release is `@orchid-labs/pluxx@0.1.38` / `v0.1.38`; npm and GitHub serve the same tarball at SHA-256 `34af5bd24a441f13094b651658d6728509771a8cb9295f82b1bc66a985cb2c24`
+- the canonical repository version is pending `0.1.39` release-prep for the PLUXX-341/PLUXX-342 quiet OpenCode hook-scope repair merged through PR #468
 - 0.1.38 is only the PLUXX-340 manifest-identity correction discovered after the shipped and independently verified 0.1.37 release
 - proof claims now use [docs/proof-freshness.md](../proof-freshness.md) and [docs/proof-manifest.json](../proof-manifest.json) so historical host runs cannot masquerade as current evidence
 - published CLI runtime is Node `>=18`
@@ -549,16 +550,25 @@ Current work:
 - [x] merge recovery PR #458 at exact reviewed head `5f8a0d58786a7aae4e495bf7dbc484cbc12b348f`, then dispatch run `30144489420` from trusted-main commit `044673f947115bcf6117dd7c0139918bdd248a99` without moving the tag
 - [x] verify npm, GitHub release assets and receipt, byte-identical tarballs, immutable tag/tree identity, and installed CLI behavior
 
-### 10. v0.1.38 PLUXX-340 manifest-identity correction
+### 10. Historical v0.1.38 PLUXX-340 manifest-identity correction
 
 - [x] merge PR #461 exact reviewed head `b839f6d93ec1174c4da5dcfb1554c7c6f8f294d5` as trusted main commit `b979bc6e02bb9801fa623f80302000553a0693c7`
-- [x] prepare synchronized 0.1.38 package, proof, planning, recovery-default, and release truth
+- [x] Historical: prepare synchronized 0.1.38 package, proof, planning, recovery-default, and release truth
 - [x] bind fresh repository-validation and fake-home-install receipts to exact immutable release-prep commit `361958f6b16b1acc2bb901c97fc2c6d5a77ba880`
 - [x] pass focused and full release gates plus independent review; review record: [2026-07-25-pluxx-340-release-0.1.38-review.md](../orchid/reviews/2026-07-25-pluxx-340-release-0.1.38-review.md)
 - [x] merge PR #462 exact reviewed head `cbc14e007626328a8d25340419a455f40701426c` with true merge commit `e24d4db3f57fa0942376237fb212cb49368d7704`, prove PR-head and receipt ancestry, and push immutable tag `v0.1.38`
 - [x] confirm tag-triggered Release run `30152484521` failed closed during the full test gate before pack or publication
 - [x] merge recovery PR #463 exact head `4024ca07fe9cc78b98e93bb0931b8d91ddc36f0f` as trusted main `a67803184890795457d095da52f4a243d61daf2a`, then dispatch run `30154432818` without moving or recreating `v0.1.38`
 - [x] verify npm, GitHub release assets and recovery receipt, byte-identical tarballs at SHA-256 `34af5bd24a441f13094b651658d6728509771a8cb9295f82b1bc66a985cb2c24`, immutable tag provenance, and isolated installed CLI `0.1.38`
+
+### 11. v0.1.39 quiet OpenCode hook scope
+
+- [x] merge PR #468 exact reviewed head `e4c11db` as true merge commit `a750c593f1fb694a71aa60365ae6f8792e51a246`
+- [~] prepare synchronized 0.1.39 package, proof, planning, recovery-default, and release truth
+- [ ] bind fresh repository-validation and fake-home-install receipts to the exact release-prep commit
+- [ ] pass focused and full release gates plus independent review
+- [ ] merge the exact green release PR with a true merge commit and push immutable tag `v0.1.39`
+- [ ] verify npm, GitHub release assets, immutable tag provenance, and isolated installed CLI `0.1.39`
 
 ### 7. Historical v0.1.28 release checklist
 

--- a/docs/todo/queue.md
+++ b/docs/todo/queue.md
@@ -539,10 +539,10 @@ Current work:
 - [x] pushed immutable tag `v0.1.36` from main
 - [x] verified npm, GitHub release assets, tarball contents, and CLI behavior
 
-### 9. v0.1.37 runtime env-sourcing security patch release
+### 9. Historical v0.1.37 runtime env-sourcing security patch release
 
 - [x] merge PLUXX-339 through exact reviewed PR #456 head `b888c62dc7905fd66c9fdf50c4e752984fee5b48`
-- [x] bump package and canonical release truth to 0.1.37
+- [x] Historical: bump package and canonical release truth to 0.1.37
 - [x] bind repository-validation and fake-home-install receipts to commands observed directly against immutable tag commit `d5184752cd4898306390f20455619c34a42099dd`; preserve the distinct pre-squash `f7ee0bd5d6cf5f8b75dec7df6dcda85dcf5a7af8` receipts as historical
 - [x] pass `npm run release:check`
 - [x] merge the focused release PR and push immutable tag `v0.1.37` from main

--- a/docs/todo/queue.md
+++ b/docs/todo/queue.md
@@ -564,9 +564,9 @@ Current work:
 ### 11. v0.1.39 quiet OpenCode hook scope
 
 - [x] merge PR #468 exact reviewed head `e4c11db` as true merge commit `a750c593f1fb694a71aa60365ae6f8792e51a246`
-- [~] prepare synchronized 0.1.39 package, proof, planning, recovery-default, and release truth
-- [ ] bind fresh repository-validation and fake-home-install receipts to the exact release-prep commit
-- [ ] pass focused and full release gates plus independent review
+- [x] prepare synchronized 0.1.39 package, proof, planning, recovery-default, and release truth
+- [x] bind fresh repository-validation and fake-home-install receipts to exact release-prep commit `6ffb6337b351c5a87b985394f0c011d2c271a940`
+- [~] pass focused and full release gates plus independent review; full local gate passed with 62 files and 828 tests
 - [ ] merge the exact green release PR with a true merge commit and push immutable tag `v0.1.39`
 - [ ] verify npm, GitHub release assets, immutable tag provenance, and isolated installed CLI `0.1.39`
 

--- a/docs/todo/queue.md
+++ b/docs/todo/queue.md
@@ -566,7 +566,7 @@ Current work:
 - [x] merge PR #468 exact reviewed head `e4c11db` as true merge commit `a750c593f1fb694a71aa60365ae6f8792e51a246`
 - [x] prepare synchronized 0.1.39 package, proof, planning, recovery-default, and release truth
 - [x] bind fresh repository-validation and fake-home-install receipts to exact release-prep commit `6ffb6337b351c5a87b985394f0c011d2c271a940`
-- [~] pass focused and full release gates plus independent review; full local gate passed with 62 files and 828 tests
+- [x] pass focused and full release gates plus independent review; review record: [2026-08-05-pluxx-343-release-0.1.39-review.md](../orchid/reviews/2026-08-05-pluxx-343-release-0.1.39-review.md)
 - [ ] merge the exact green release PR with a true merge commit and push immutable tag `v0.1.39`
 - [ ] verify npm, GitHub release assets, immutable tag provenance, and isolated installed CLI `0.1.39`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orchid-labs/pluxx",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchid-labs/pluxx",
-      "version": "0.1.38",
+      "version": "0.1.39",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orchid-labs/pluxx",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "description": "Build AI agent plugins once. Prime-time on Claude Code, Cursor, Codex, and OpenCode, with beta generators for additional hosts.",
   "type": "module",
   "main": "dist/index.js",

--- a/tests/release-recovery-proof.test.ts
+++ b/tests/release-recovery-proof.test.ts
@@ -8,6 +8,7 @@ const ROOT = resolve(import.meta.dir, '..')
 const SCRIPT = resolve(ROOT, 'scripts/release-recovery-proof.mjs')
 const VERSION = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf-8')).version
 const TAG = `v${VERSION}`
+const MISMATCHED_VERSION = VERSION === '0.0.0' ? '0.0.1' : '0.0.0'
 const TEST_NPM_CACHE = join(tmpdir(), 'pluxx-release-recovery-npm-cache')
 const PRE_PROOF_COMMANDS = [
   'npm run build',
@@ -338,7 +339,7 @@ describe('immutable-tag release recovery proof', () => {
   }, 15_000)
 
   it('rejects a tag whose version differs from the package identity', () => {
-    const runFixture = fixture('0.1.39')
+    const runFixture = fixture(MISMATCHED_VERSION)
     try {
       const result = run('node', [
         SCRIPT,
@@ -350,7 +351,7 @@ describe('immutable-tag release recovery proof', () => {
         '--receipt', runFixture.receipt,
       ], runFixture.root)
       expect(result.status).toBe(1)
-      expect(result.stderr).toContain(`Release tag ${TAG} does not match package version 0.1.39`)
+      expect(result.stderr).toContain(`Release tag ${TAG} does not match package version ${MISMATCHED_VERSION}`)
     } finally {
       rmSync(runFixture.root, { recursive: true, force: true })
     }

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -6,6 +6,8 @@ import { parse } from 'yaml'
 import { spawnSync } from 'child_process'
 
 const ROOT = resolve(import.meta.dir, '..')
+const packageVersion = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf-8')).version as string
+const expectedReleaseTag = `v${packageVersion}`
 const releaseWorkflow = readFileSync(resolve(ROOT, '.github/workflows/release.yml'), 'utf-8')
 const ciWorkflow = readFileSync(resolve(ROOT, '.github/workflows/ci.yml'), 'utf-8')
 const recoveryProofScript = readFileSync(resolve(ROOT, 'scripts/release-recovery-proof.mjs'), 'utf-8')
@@ -56,7 +58,7 @@ describe('release workflow', () => {
     expect(workflow.on.workflow_dispatch.inputs.release_tag).toEqual({
       description: 'Existing release tag to recover from the trusted main workflow',
       required: true,
-      default: 'v0.1.39',
+      default: expectedReleaseTag,
       type: 'string',
     })
     expect(workflow.jobs.publish.defaults.run['working-directory']).toBe('release')

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -56,7 +56,7 @@ describe('release workflow', () => {
     expect(workflow.on.workflow_dispatch.inputs.release_tag).toEqual({
       description: 'Existing release tag to recover from the trusted main workflow',
       required: true,
-      default: 'v0.1.38',
+      default: 'v0.1.39',
       type: 'string',
     })
     expect(workflow.jobs.publish.defaults.run['working-directory']).toBe('release')


### PR DESCRIPTION
## Summary

- prepare `@orchid-labs/pluxx@0.1.39` for the merged PLUXX-341/PLUXX-342 quiet OpenCode hook-scope repair
- bind current repository-validation and fake-home-install receipts to exact prep commit `6ffb6337b351c5a87b985394f0c011d2c271a940`
- keep shipped `0.1.38` evidence historical and synchronize release/planning truth
- make the recovery-default test derive its expected tag from `package.json` so matching stale literals cannot pass together

## Validation

- `npm run release:check` on exact prep commit: 62 files, 828 tests, packed Node runtime verification, npm dry-run package
- `npm run proof:check`: 22 claims, 22 receipts
- focused workflow/recovery/proof suites after review fix: 32 tests passed
- correctness, project-standards, testing, adversarial review; one P1 fixed and independently validated

## Merge and release contract

- merge with a true merge commit; do not squash or rebase
- prove prep commit `6ffb633`, receipt commit `13ba602`, and final reviewed PR head are ancestors of exact current `origin/main`
- create immutable tag `v0.1.39` once at that trusted merge commit
- publish only through the tag-triggered GitHub workflow; never publish locally
- verify npm, GitHub release asset, tag provenance, and isolated registry install before closing PLUXX-343

Linear: PLUXX-343
GitHub issue: #469

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares `@orchid-labs/pluxx@0.1.39` for release to ship the quiet OpenCode hook matcher-scope repair (PLUXX-341/342). Bumps the version, sets the Release workflow recovery default to `v0.1.39`, refreshes the proof manifest with bound `v0.1.39` receipts, and updates docs to mark 0.1.39 as release-prep with tighter release audit identity, satisfying PLUXX-343.

- **Bug Fixes**
  - Tests now derive the expected recovery tag from `package.json` and assert mismatched versions, preventing stale hard-coded tags from passing.

<sup>Written for commit 4d0465930ead185d462f3e11c47281576098bcec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/orchidautomation/pluxx/pull/470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

