### PR TITLE
docs(release): close out Pluxx 0.1.39

### DIFF
--- a/docs/orchid/reviews/2026-08-05-pluxx-343-release-0.1.39-review.md
+++ b/docs/orchid/reviews/2026-08-05-pluxx-343-release-0.1.39-review.md
@@ -4,7 +4,7 @@ Date: 2026-08-05
 
 ## Scope
 
-- Release: `@orchid-labs/pluxx@0.1.39` / pending `v0.1.39`
+- Release: `@orchid-labs/pluxx@0.1.39` / `v0.1.39`
 - Source implementation: PR #468, true merge `a750c593f1fb694a71aa60365ae6f8792e51a246`
 - Release-prep proof anchor: `6ffb6337b351c5a87b985394f0c011d2c271a940`
 - Receipt commit: `13ba60274f8b6b17cd73ae1ba8d40038f25b6c76`
@@ -23,8 +23,17 @@ Correctness, project-standards, testing, and adversarial release lenses reviewed
 
 The review found one P1 false-green test risk: the recovery workflow default and its test both hard-coded the same tag, so a future version bump could leave both stale while the suite passed. Commit `f9eea1673413014be2274375d374d1be0388a507` derives the expected recovery tag from `package.json`; an independent validator confirmed the finding and the focused release suites passed after the fix.
 
-No unresolved review findings remain. Tag creation, trusted-main ancestry, npm/GitHub publication, and isolated registry-install verification remain post-merge release gates.
+No unresolved review findings remain.
 
 ## Merge contract
 
 Use a true merge commit. Before tagging, prove `6ffb6337b351c5a87b985394f0c011d2c271a940`, `13ba60274f8b6b17cd73ae1ba8d40038f25b6c76`, and the final reviewed PR head are ancestors of exact current `origin/main`. Create `v0.1.39` once at that trusted merge commit and publish only through the tag-triggered GitHub workflow.
+
+## Release closeout
+
+- PR #470 exact reviewed head `4d0465930ead185d462f3e11c47281576098bcec` was true-merged as `9e404537e8f3b007cfadf67d90487efdad160f20` after all checks passed and all review threads were resolved.
+- Release-prep commit `6ffb6337b351c5a87b985394f0c011d2c271a940`, receipt commit `13ba60274f8b6b17cd73ae1ba8d40038f25b6c76`, and the final reviewed head were verified as ancestors of exact `origin/main` before tagging.
+- Immutable tag `v0.1.39` points to `9e404537e8f3b007cfadf67d90487efdad160f20`.
+- Tag-triggered Release run [31023227838](https://github.com/orchidautomation/pluxx/actions/runs/31023227838) passed and published npm plus GitHub release artifacts.
+- npm and GitHub tarballs are byte-identical at SHA-256 `79a75caa36f636e34e03dbadc36376ca513c279cbae03fecab9c9da1235e2fe5`.
+- A fresh isolated registry install reported CLI version `0.1.39`.

--- a/docs/proof-and-install.md
+++ b/docs/proof-and-install.md
@@ -30,9 +30,9 @@ This is the shortest current repo-native path to:
 
 For the fuller release/distribution boundary, including publish commands and deferred marketplace/trust-layer work, use [docs/release-distribution-proof-map.md](./release-distribution-proof-map.md).
 
-Proof labels and freshness come from [proof-freshness.md](./proof-freshness.md) and [proof-manifest.json](./proof-manifest.json). The May self-hosted run, April Firecrawl connector run, and shipped 0.1.37 and 0.1.38 evidence remain historical relative to pending repository version `0.1.39`.
+Proof labels and freshness come from [proof-freshness.md](./proof-freshness.md) and [proof-manifest.json](./proof-manifest.json). The May self-hosted run, April Firecrawl connector run, and shipped 0.1.37 and 0.1.38 evidence remain historical relative to the canonical public `0.1.39` release.
 
-Historical 0.1.38 proof covers only the PLUXX-340 manifest-identity correction. Pending 0.1.39 release-prep covers only the merged PLUXX-341/PLUXX-342 quiet OpenCode hook-scope repair. Fresh receipts `v0.1.39-repository-validation` and `v0.1.39-fake-home-install` bind to exact release-prep commit `6ffb6337b351c5a87b985394f0c011d2c271a940`, where the complete release gate passed on 2026-08-05.
+Historical 0.1.38 proof covers only the PLUXX-340 manifest-identity correction. Canonical 0.1.39 covers only the merged PLUXX-341/PLUXX-342 quiet OpenCode hook-scope repair. Fresh receipts `v0.1.39-repository-validation` and `v0.1.39-fake-home-install` bind to exact release-prep commit `6ffb6337b351c5a87b985394f0c011d2c271a940`, where the complete release gate passed on 2026-08-05; immutable tag `v0.1.39` points to trusted merge `9e404537e8f3b007cfadf67d90487efdad160f20` and its npm and GitHub tarballs are byte-identical at SHA-256 `79a75caa36f636e34e03dbadc36376ca513c279cbae03fecab9c9da1235e2fe5`.
 
 ## The Story In One Screen
 
@@ -210,7 +210,8 @@ curl -fsSL https://raw.githubusercontent.com/orchidautomation/pluxx/main/example
 
 Current release note:
 
-- the canonical and verified public release is `@orchid-labs/pluxx@0.1.38` / `v0.1.38`, only for the separately discovered PLUXX-340 duplicate archive-identity correction; npm and GitHub serve the same verified tarball at SHA-256 `34af5bd24a441f13094b651658d6728509771a8cb9295f82b1bc66a985cb2c24`
+- the canonical and verified public release is `@orchid-labs/pluxx@0.1.39` / `v0.1.39`, only for the PLUXX-341/PLUXX-342 quiet OpenCode hook-scope repair; npm and GitHub serve the same verified tarball at SHA-256 `79a75caa36f636e34e03dbadc36376ca513c279cbae03fecab9c9da1235e2fe5`
+- 0.1.38 remains the shipped and independently verified historical PLUXX-340 duplicate archive-identity correction
 - 0.1.37 remains the shipped and independently verified historical PLUXX-339 runtime env-sourcing security release
 - the published CLI runtime is Node `>=18`; see [runtime contract](./runtime-contract.md)
 - the published package includes the Claude plugin-agent manifest fix and packaged Node runtime verification

--- a/docs/proof-freshness.md
+++ b/docs/proof-freshness.md
@@ -4,7 +4,7 @@ Last updated: 2026-08-05
 
 This document defines how Pluxx distinguishes repeatable repository checks from installed and real-host evidence. The machine-readable source is [proof-manifest.json](./proof-manifest.json), validated by `npm run proof:check`.
 
-The repository is preparing `v0.1.39` for the PLUXX-341/PLUXX-342 quiet OpenCode hook-scope repair merged through PR #468. The shipped and independently verified `v0.1.38` receipts remain historical evidence. Fresh current receipts `v0.1.39-repository-validation` and `v0.1.39-fake-home-install` bind to exact release-prep commit `6ffb6337b351c5a87b985394f0c011d2c271a940`, where `npm run release:check` passed on 2026-08-05 with 62 test files and 828 tests plus isolated packed-runtime and dry-pack verification. No current receipt claims installed-runtime or real-host behavior.
+The canonical and independently verified public release is `@orchid-labs/pluxx@0.1.39` for the PLUXX-341/PLUXX-342 quiet OpenCode hook-scope repair merged through PR #468. Immutable tag `v0.1.39` points to trusted merge `9e404537e8f3b007cfadf67d90487efdad160f20`; tag-triggered Release run [31023227838](https://github.com/orchidautomation/pluxx/actions/runs/31023227838) published byte-identical npm and GitHub artifacts at SHA-256 `79a75caa36f636e34e03dbadc36376ca513c279cbae03fecab9c9da1235e2fe5`. Fresh current receipts `v0.1.39-repository-validation` and `v0.1.39-fake-home-install` bind to exact release-prep commit `6ffb6337b351c5a87b985394f0c011d2c271a940`, where `npm run release:check` passed on 2026-08-05 with 62 test files and 828 tests plus isolated packed-runtime and dry-pack verification. No current receipt claims installed-runtime or real-host behavior.
 
 ## Version And Freshness Policy
 

--- a/docs/proof-manifest.json
+++ b/docs/proof-manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "canonicalVersion": "0.1.39",
   "expectedTag": "v0.1.39",
-  "releaseState": "release-prep",
+  "releaseState": "released",
   "policy": {
     "environmentReceiptMaxAgeDays": 30
   },

--- a/docs/release-distribution-proof-map.md
+++ b/docs/release-distribution-proof-map.md
@@ -1,6 +1,6 @@
 # Release Distribution Proof Map
 
-Last updated: 2026-07-25
+Last updated: 2026-08-05
 
 ## Doc Links
 
@@ -26,7 +26,7 @@ Last updated: 2026-07-25
 
 This is the short release/distribution map for what Pluxx can ship today, what is locally proven, and what still belongs to later marketplace or trust-layer work.
 
-Proof state is governed by [proof-freshness.md](./proof-freshness.md) and the machine-readable [proof manifest](./proof-manifest.json). The canonical and independently verified public release is `@orchid-labs/pluxx@0.1.38`, only for the PLUXX-340 manifest-identity correction discovered after shipped 0.1.37. Immutable tag `v0.1.38` remains fixed at trusted merge `e24d4db3f57fa0942376237fb212cb49368d7704`; recovery run [30154432818](https://github.com/orchidautomation/pluxx/actions/runs/30154432818) published byte-identical npm and GitHub artifacts at SHA-256 `34af5bd24a441f13094b651658d6728509771a8cb9295f82b1bc66a985cb2c24`.
+Proof state is governed by [proof-freshness.md](./proof-freshness.md) and the machine-readable [proof manifest](./proof-manifest.json). The canonical and independently verified public release is `@orchid-labs/pluxx@0.1.39`, focused on the PLUXX-341/PLUXX-342 quiet OpenCode hook-scope repair. Immutable tag `v0.1.39` is fixed at trusted merge `9e404537e8f3b007cfadf67d90487efdad160f20`; tag-triggered Release run [31023227838](https://github.com/orchidautomation/pluxx/actions/runs/31023227838) published byte-identical npm and GitHub artifacts at SHA-256 `79a75caa36f636e34e03dbadc36376ca513c279cbae03fecab9c9da1235e2fe5`.
 
 ## Current Primary Fronts
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -86,7 +86,7 @@ PLUXX-339 is shipped in the verified public `0.1.37` release after the historica
 
 PLUXX-340 is the separately shipped and independently verified `0.1.38` follow-up for duplicate release-manifest archive identities discovered after the historical shipped 0.1.37 release. It preserves both versioned and `latest` physical assets while exposing one deterministic manifest identity per host. Recovery run [30154432818](https://github.com/orchidautomation/pluxx/actions/runs/30154432818) published byte-identical npm and GitHub artifacts without moving the immutable tag.
 
-PLUXX-341/PLUXX-342 is merged through PR #468 and pending `0.1.39` release. It keeps generated OpenCode hook matchers scoped, normalizes supported tool alternatives consistently, and makes doctor fail closed on malformed or unscoped plans while preserving quiet health behavior.
+PLUXX-341/PLUXX-342 shipped in the independently verified public `0.1.39` release through PR #468. It keeps generated OpenCode hook matchers scoped, normalizes supported tool alternatives consistently, and makes doctor fail closed on malformed or unscoped plans while preserving quiet health behavior.
 
 ### 1. Product clarity and source-of-truth coherence
 
@@ -232,7 +232,8 @@ The closure plan is now narrower than it was before:
 - historical release-gate evidence from 2026-05-19 remains available but is not current proof:
   - `npm test` passed
   - `npm run release:check` passed
-- the canonical and verified public release is `@orchid-labs/pluxx@0.1.38` / `v0.1.38`; npm and GitHub serve the same tarball at SHA-256 `34af5bd24a441f13094b651658d6728509771a8cb9295f82b1bc66a985cb2c24`
+- the canonical and verified public release is `@orchid-labs/pluxx@0.1.39` / `v0.1.39`; npm and GitHub serve the same tarball at SHA-256 `79a75caa36f636e34e03dbadc36376ca513c279cbae03fecab9c9da1235e2fe5`
+- 0.1.39 is only the PLUXX-341/PLUXX-342 quiet OpenCode hook-scope repair
 - 0.1.38 is only the PLUXX-340 manifest-identity follow-up discovered after shipped and independently verified 0.1.37
 - the release/distribution/proof boundary is now explicit:
   - [docs/release-distribution-proof-map.md](./release-distribution-proof-map.md)
@@ -393,12 +394,12 @@ This is for learning and proof, not for prematurely building the full trust laye
 
 ### 6. Next release
 
-The canonical repository version is pending `0.1.39` release-prep for PLUXX-341/PLUXX-342. The canonical and verified public release remains `@orchid-labs/pluxx@0.1.38` for PLUXX-340 at immutable trusted merge `e24d4db3f57fa0942376237fb212cb49368d7704`.
+The canonical repository and verified public release is `@orchid-labs/pluxx@0.1.39` for PLUXX-341/PLUXX-342 at immutable trusted merge `9e404537e8f3b007cfadf67d90487efdad160f20`.
 
 The next npm cut should stay primarily an operations step rather than a code-confidence rescue step.
 
 - preserve completed 0.1.38 recovery evidence: tag commit `e24d4db3f57fa0942376237fb212cb49368d7704`, tree `8d876bac5753d0dab019f573b4f3bf806bddaa04`, trusted recovery main `a67803184890795457d095da52f4a243d61daf2a`, and tarball SHA-256 `34af5bd24a441f13094b651658d6728509771a8cb9295f82b1bc66a985cb2c24`
-- release and independently verify 0.1.39 as the focused PLUXX-341/PLUXX-342 quiet OpenCode hook-scope repair
+- preserve completed 0.1.39 evidence: tag and trusted merge `9e404537e8f3b007cfadf67d90487efdad160f20`, Release run `31023227838`, and byte-identical npm/GitHub tarball SHA-256 `79a75caa36f636e34e03dbadc36376ca513c279cbae03fecab9c9da1235e2fe5`
 - preserve the completed 0.1.37 immutable-tag recovery evidence: tag commit `d5184752cd4898306390f20455619c34a42099dd`, tree `e63eea0f89995a44b7536b5403af57792e994cb9`, trusted main `044673f947115bcf6117dd7c0139918bdd248a99`, and tarball SHA-256 `7c996da682887ceedecc006307c207c5a834e5dedabaab17611cd586ef85b237`
 - refresh installed-runtime or real-host receipts separately before making broader current host claims
 - use future focused release PRs and trusted tag workflows for the next package cut

--- a/docs/start-here.md
+++ b/docs/start-here.md
@@ -39,7 +39,7 @@ If you want the shortest public proof and install path after this file, use [doc
 
 If you want the current release, distribution, and proof boundary, use [docs/release-distribution-proof-map.md](./release-distribution-proof-map.md).
 
-If you need to know whether a proof claim is current, historical, repository-only, installed, or real-host evidence, use [docs/proof-freshness.md](./proof-freshness.md) and [docs/proof-manifest.json](./proof-manifest.json). Canonical repository version truth is `package.json` (`0.1.39`), currently in release-prep for the PLUXX-341/PLUXX-342 quiet OpenCode hook-scope repair. The independently verified public release remains `@orchid-labs/pluxx@0.1.38`.
+If you need to know whether a proof claim is current, historical, repository-only, installed, or real-host evidence, use [docs/proof-freshness.md](./proof-freshness.md) and [docs/proof-manifest.json](./proof-manifest.json). Canonical repository and independently verified public release truth is `@orchid-labs/pluxx@0.1.39` for the PLUXX-341/PLUXX-342 quiet OpenCode hook-scope repair.
 
 If you want the primitive-by-host proof ledger behind the core-four native shipping claim, use [docs/core-four-primitive-proof-ledger.md](./core-four-primitive-proof-ledger.md).
 
@@ -369,8 +369,8 @@ The repo already proves a lot.
 - historical release-gate evidence from 2026-05-19 remains available but is not current proof:
   - `npm test` passed
   - `npm run release:check` passed
-- the canonical and verified public release is `@orchid-labs/pluxx@0.1.38` / `v0.1.38`; npm and GitHub serve the same tarball at SHA-256 `34af5bd24a441f13094b651658d6728509771a8cb9295f82b1bc66a985cb2c24`
-- the repository is preparing `0.1.39` only for the merged PLUXX-341/PLUXX-342 OpenCode hook matcher-scope and quiet-health repair
+- the canonical and verified public release is `@orchid-labs/pluxx@0.1.39` / `v0.1.39`; npm and GitHub serve the same tarball at SHA-256 `79a75caa36f636e34e03dbadc36376ca513c279cbae03fecab9c9da1235e2fe5`
+- `0.1.39` contains only the merged PLUXX-341/PLUXX-342 OpenCode hook matcher-scope and quiet-health repair
 - immutable tag `v0.1.38` records only the follow-up PLUXX-340 correction for duplicate release-manifest archive identities discovered after the historical shipped 0.1.37 release
 - marketplace submission APIs, a managed trust/distribution control plane, automatic rollback/unpublish orchestration, and real authenticated publish plus rollback proof remain explicit release gaps, not hidden shipped capabilities:
   - `docs/release-distribution-proof-map.md`
@@ -541,13 +541,13 @@ Run two lanes in parallel:
 
 ### 6. Release State
 
-The canonical repository version is pending `0.1.39` release-prep for the PLUXX-341/PLUXX-342 quiet OpenCode hook-scope repair. The canonical and verified public release remains `@orchid-labs/pluxx@0.1.38`; immutable tag `v0.1.38` remains at trusted merge `e24d4db3f57fa0942376237fb212cb49368d7704`.
+The canonical repository and verified public release is `@orchid-labs/pluxx@0.1.39`; immutable tag `v0.1.39` remains at trusted merge `9e404537e8f3b007cfadf67d90487efdad160f20`.
 
 For v0.1.37, PLUXX-339 is the tagged security focus: lint, doctor, install, and packaged-runtime verification fail closed when bundled runtime scripts source workspace `.env` files through direct or statically evaluable shell forms. The patch preserves valid safe shell forms and uses a bounded explicit scanner rather than an expanding regex.
 
 For historical tagged v0.1.38, PLUXX-340 is the only release focus: one unambiguous release-manifest archive identity per host while versioned and `latest` physical assets remain generated and checksummed.
 
-For pending v0.1.39, PLUXX-341/PLUXX-342 is the only release focus: OpenCode hooks keep matcher scope, normalize supported tool alternatives consistently, and doctor fails closed on malformed or unscoped plans without emitting noisy health output.
+For v0.1.39, PLUXX-341/PLUXX-342 is the only release focus: OpenCode hooks keep matcher scope, normalize supported tool alternatives consistently, and doctor fails closed on malformed or unscoped plans without emitting noisy health output.
 
 ## Working Rules
 

--- a/docs/todo/master-backlog.md
+++ b/docs/todo/master-backlog.md
@@ -131,14 +131,14 @@ Proof governance is now explicit: [proof-freshness.md](../proof-freshness.md) de
 - [x] Merge recovery PR #463 exact head `4024ca07fe9cc78b98e93bb0931b8d91ddc36f0f` as trusted main `a67803184890795457d095da52f4a243d61daf2a`, then dispatch run `30154432818` without moving or recreating `v0.1.38`
 - [x] Verify npm, GitHub release assets and recovery receipt, byte-identical tarballs at SHA-256 `34af5bd24a441f13094b651658d6728509771a8cb9295f82b1bc66a985cb2c24`, immutable tag provenance, and isolated installed CLI `0.1.38`
 
-### 0. v0.1.39 quiet OpenCode hook scope
+### 0. Historical v0.1.39 quiet OpenCode hook scope
 
 - [x] Merge PR #468 exact reviewed head `e4c11db` as true merge commit `a750c593f1fb694a71aa60365ae6f8792e51a246`
 - [x] Prepare synchronized 0.1.39 package, proof, planning, recovery-default, and release truth
 - [x] Bind fresh repository-validation and fake-home-install receipts to exact release-prep commit `6ffb6337b351c5a87b985394f0c011d2c271a940`
 - [x] Pass focused and full release gates plus independent review; review record: [2026-08-05-pluxx-343-release-0.1.39-review.md](../orchid/reviews/2026-08-05-pluxx-343-release-0.1.39-review.md)
-- [ ] Merge the exact green release PR with a true merge commit and push immutable tag `v0.1.39`
-- [ ] Verify npm, GitHub release assets, immutable tag provenance, and isolated installed CLI `0.1.39`
+- [x] Merge PR #470 exact reviewed head `4d0465930ead185d462f3e11c47281576098bcec` with true merge commit `9e404537e8f3b007cfadf67d90487efdad160f20` and push immutable tag `v0.1.39`
+- [x] Verify tag-triggered Release run `31023227838`, npm, GitHub release asset, byte-identical tarballs at SHA-256 `79a75caa36f636e34e03dbadc36376ca513c279cbae03fecab9c9da1235e2fe5`, immutable tag provenance, and isolated installed CLI `0.1.39`
 
 ### 1. Product clarity and front-door coherence
 

--- a/docs/todo/queue.md
+++ b/docs/todo/queue.md
@@ -188,8 +188,8 @@ The initial author-once hardening tranche is also materially done.
 The public baseline is also real.
 
 - npm package is live as `@orchid-labs/pluxx`
-- the canonical and verified public release is `@orchid-labs/pluxx@0.1.38` / `v0.1.38`; npm and GitHub serve the same tarball at SHA-256 `34af5bd24a441f13094b651658d6728509771a8cb9295f82b1bc66a985cb2c24`
-- the canonical repository version is pending `0.1.39` release-prep for the PLUXX-341/PLUXX-342 quiet OpenCode hook-scope repair merged through PR #468
+- the canonical and verified public release is `@orchid-labs/pluxx@0.1.39` / `v0.1.39`; npm and GitHub serve the same tarball at SHA-256 `79a75caa36f636e34e03dbadc36376ca513c279cbae03fecab9c9da1235e2fe5`
+- 0.1.39 is the focused PLUXX-341/PLUXX-342 quiet OpenCode hook-scope repair merged through PR #468 and released through trusted merge `9e404537e8f3b007cfadf67d90487efdad160f20`
 - 0.1.38 is only the PLUXX-340 manifest-identity correction discovered after the shipped and independently verified 0.1.37 release
 - proof claims now use [docs/proof-freshness.md](../proof-freshness.md) and [docs/proof-manifest.json](../proof-manifest.json) so historical host runs cannot masquerade as current evidence
 - published CLI runtime is Node `>=18`
@@ -561,14 +561,14 @@ Current work:
 - [x] merge recovery PR #463 exact head `4024ca07fe9cc78b98e93bb0931b8d91ddc36f0f` as trusted main `a67803184890795457d095da52f4a243d61daf2a`, then dispatch run `30154432818` without moving or recreating `v0.1.38`
 - [x] verify npm, GitHub release assets and recovery receipt, byte-identical tarballs at SHA-256 `34af5bd24a441f13094b651658d6728509771a8cb9295f82b1bc66a985cb2c24`, immutable tag provenance, and isolated installed CLI `0.1.38`
 
-### 11. v0.1.39 quiet OpenCode hook scope
+### 11. Historical v0.1.39 quiet OpenCode hook scope
 
 - [x] merge PR #468 exact reviewed head `e4c11db` as true merge commit `a750c593f1fb694a71aa60365ae6f8792e51a246`
 - [x] prepare synchronized 0.1.39 package, proof, planning, recovery-default, and release truth
 - [x] bind fresh repository-validation and fake-home-install receipts to exact release-prep commit `6ffb6337b351c5a87b985394f0c011d2c271a940`
 - [x] pass focused and full release gates plus independent review; review record: [2026-08-05-pluxx-343-release-0.1.39-review.md](../orchid/reviews/2026-08-05-pluxx-343-release-0.1.39-review.md)
-- [ ] merge the exact green release PR with a true merge commit and push immutable tag `v0.1.39`
-- [ ] verify npm, GitHub release assets, immutable tag provenance, and isolated installed CLI `0.1.39`
+- [x] merge PR #470 exact reviewed head `4d0465930ead185d462f3e11c47281576098bcec` with true merge commit `9e404537e8f3b007cfadf67d90487efdad160f20` and push immutable tag `v0.1.39`
+- [x] verify tag-triggered Release run `31023227838`, npm, GitHub release asset, byte-identical tarballs at SHA-256 `79a75caa36f636e34e03dbadc36376ca513c279cbae03fecab9c9da1235e2fe5`, immutable tag provenance, and isolated installed CLI `0.1.39`
 
 ### 7. Historical v0.1.28 release checklist
 


### PR DESCRIPTION
## Summary
- mark 0.1.39 released across canonical proof and planning docs
- record trusted merge, immutable tag, and successful Release workflow
- record byte-identical npm/GitHub artifacts and isolated registry-install verification

## Verification
- npm run proof:check
- npm test -- tests/proof-freshness.test.ts
- git diff --check

Closes PLUXX-343

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes out the `@orchid-labs/pluxx@0.1.39` release in the docs: marks it as the canonical public version, flips the proof state to released, and records the tag-triggered publish evidence (immutable `v0.1.39`, byte-identical npm/GitHub artifacts, and isolated install receipts).
Confirms the quiet OpenCode matcher-scope fix is shipped as required by PLUXX-343.

<sup>Written for commit f246d34f02687b96c45447ae51e8ff30f1a7ecf8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/orchidautomation/pluxx/pull/471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

